### PR TITLE
Enable safe PR feedback continuation and checkpoint recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,6 +8,9 @@ Implementation PRs can use [durable feedback subscriptions](docs/guide/flows/dur
 
 The [account kill switch](docs/guide/account-kill-switch.md) serializes halt transitions and runtime admission on the account row. Audit records and durable execution stop intent share the transition transaction. Monitors and recovery workers distinguish a stop request from confirmed runtime termination; approval deadlines recover once by their actual frozen interval.
 
+Database worker ownership, row-lock compatibility, and cancellation rules are
+documented in [Transactions and asynchronous request handling](docs/architecture/data-model.md#transactions-and-asynchronous-request-handling).
+
 ## High-Level Architecture
 
 ```mermaid

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Preloop is an open-source, responsible AI automation platform. It can proxy tool
 
 ARCHITECTURE.md is the map. Read one chapter under `docs/architecture/` for the subsystem you are changing. Do not load every chapter for context.
 
-Implementation PRs can use [durable feedback subscriptions](docs/guide/flows/durable-implementation-feedback.md): PostgreSQL threads and inbox leases coordinate new execution turns, while native conversation artifacts remain isolated from workspace checkpoints. Repository events and bounded reconciliation advance CI/review gates without idle agent containers.
+Implementation PRs can use [durable feedback subscriptions](docs/guide/flows/durable-implementation-feedback.md): PostgreSQL threads and inbox leases coordinate new execution turns, while native conversation artifacts remain isolated from workspace checkpoints. Repository events and bounded reconciliation advance CI/review gates without idle agent containers. Feedback opt-in applies to future executions; a preview-and-adopt API binds one older publication explicitly. Live policy changes are checked again at atomic repair reservation. Missing native checkpoints fail closed unless the operator explicitly selected a source-only published-branch handoff. Unreadable repository requirements prevent readiness while fully verified feedback can still authorize bounded repairs.
 
 The [account kill switch](docs/guide/account-kill-switch.md) serializes halt transitions and runtime admission on the account row. Audit records and durable execution stop intent share the transition transaction. Monitors and recovery workers distinguish a stop request from confirmed runtime termination; approval deadlines recover once by their actual frozen interval.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent database waits in authentication and approval summaries from blocking
+  the API event loop; cancellation now waits for shared-session workers to finish.
+  Native permission checks release authentication connections before human waits.
+  Artifact quota locks permit independent account foreign-key inserts, OAuth
+  refresh reloads current credentials and releases unnecessary locks, and agent
+  heartbeats use the same row-lock order as operator lifecycle changes.
+
 - **OpenCode log-filter tests no longer crash without Node**:
   `TestOpenCodeLogFilterJs` spawned `node` and raised `FileNotFoundError`
   in the GitLab agents job (Python slim image) and any local env without

--- a/backend/preloop/agents/session_runtime.py
+++ b/backend/preloop/agents/session_runtime.py
@@ -27,6 +27,8 @@ if __name__ == "__main__":
     url = os.environ.get("PRELOOP_CHECKPOINT_URL")
     token = os.environ.get("PRELOOP_NATIVE_SESSION_GET_TOKEN" if action == "restore" else "PRELOOP_NATIVE_SESSION_PUT_TOKEN")
     try:
+        if action == "restore" and (not token or not url):
+            raise SessionRestoreError("native checkpoint transport missing")
         if not token or not url:
             print("PRELOOP_NATIVE_RESUME " + json.dumps({"mode": "cold_handoff", "reason": "artifact_unavailable_or_runner_unsupported"}))
             sys.exit(0)
@@ -39,13 +41,11 @@ if __name__ == "__main__":
                     archive = response.read(MAX_BYTES + 1)
             except urllib.error.HTTPError as exc:
                 if exc.code in (404, 410):
-                    print("PRELOOP_NATIVE_RESUME " + json.dumps({"mode": "cold_handoff", "reason": "missing_or_expired"}))
-                    sys.exit(0)
+                    raise SessionRestoreError("native checkpoint missing or expired") from exc
                 raise
             files = unpack_session(archive, harness=harness, harness_version=version, session_id=sid, thread_id=thread)
             if files is None:
-                print("PRELOOP_NATIVE_RESUME " + json.dumps({"mode": "cold_handoff", "reason": "expired"}))
-                sys.exit(0)
+                raise SessionRestoreError("native checkpoint expired")
             restore_session(files, Path(root))
             print("PRELOOP_NATIVE_RESUME " + json.dumps({"mode": "native_resume", "session_id": sid}))
             sys.exit(10)
@@ -101,6 +101,14 @@ if [ -n "$PRELOOP_CLI_SESSION_ID" ]; then
 fi
 """
     )
+    if context.get("published_branch_handoff_authorized") is True:
+        restore += (
+            "echo 'PRELOOP_NATIVE_RESUME "
+            + json.dumps(
+                {"mode": "cold_handoff", "reason": "explicit_published_branch_adoption"}
+            )
+            + "'\n"
+        )
     pack = f"""
 if [ -n {captured_sid_expr} ]; then
     python3 {script} pack {common} {captured_sid_expr} {shlex.quote(str(thread))}

--- a/backend/preloop/api/auth/jwt.py
+++ b/backend/preloop/api/auth/jwt.py
@@ -13,6 +13,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt import PyJWTError
 from passlib.context import CryptContext
+from sqlalchemy.exc import TimeoutError as SQLAlchemyPoolTimeout
 from sqlalchemy.orm import Session
 
 # Configuration
@@ -670,7 +671,17 @@ async def get_user_from_token_if_valid(token: str, db_session: Any) -> Optional[
     Returns None if the token is invalid, expired, or the user doesn't exist.
     This function does not raise HTTPException.
     """
-    return get_user_from_token_if_valid_sync(token, db_session)
+    from preloop.api.loop_safety import run_db_off_loop
+
+    def authenticate() -> Optional[User]:
+        user = get_user_from_token_if_valid_sync(token, db_session)
+        if user is not None:
+            # API-key last-used commits expire the user. Hydrate its scalar
+            # fields here so async callers do not issue a lazy SELECT.
+            _ = user.id, user.account_id, user.username, user.email, user.is_active
+        return user
+
+    return await run_db_off_loop(authenticate)
 
 
 def get_user_from_token_if_valid_sync(token: str, db_session: Any) -> Optional[User]:
@@ -705,6 +716,9 @@ def get_user_from_token_if_valid_sync(token: str, db_session: Any) -> Optional[U
         if user and user.is_active:
             return user
 
+    except SQLAlchemyPoolTimeout:
+        # Capacity failures are retryable service overload, not bad credentials.
+        raise
     except HTTPException as e:
         # Raised by _authenticate_with_api_key with the concrete rejection
         # reason (inactive key, expired key, deleted/suspended managed agent).

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -1617,6 +1617,17 @@ async def authenticate_user(
     Returns:
         The user if authentication is successful, None otherwise.
     """
+    from preloop.api.loop_safety import run_db_off_loop
+
+    return await run_db_off_loop(
+        lambda: _authenticate_user_sync(username, password, db, source_ip)
+    )
+
+
+def _authenticate_user_sync(
+    username: str, password: str, db: Session, source_ip: Optional[str] = None
+) -> Optional[UserModel]:
+    """Verify credentials and record login using one sequential worker owner."""
     from datetime import datetime, timezone
     import threading
 
@@ -1686,6 +1697,9 @@ async def authenticate_user(
         thread.daemon = True
         thread.start()
 
+    # The audit insert commits and expires user fields. Token construction
+    # reads them immediately after this worker returns to the event loop.
+    _ = user.id, user.account_id, user.username, user.email, user.is_active
     return user
 
 

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -408,14 +408,8 @@ def _touch_presence(
     session_mode: Optional[str] = None,
     commit: bool = True,
 ) -> None:
-    crud_runtime_session.touch_activity(
-        db,
-        account_id=context.runtime_session.account_id,
-        runtime_session_id=context.runtime_session.id,
-        observed_at=observed_at,
-        min_update_interval=HEARTBEAT_TOUCH_INTERVAL,
-        commit=False,
-    )
+    # Match operator lifecycle transactions: managed agent before runtime.
+    # Reversing this order lets heartbeat and decommission wait on each other.
     crud_managed_agent.touch_last_seen_for_principal(
         db,
         account_id=context.runtime_session.account_id,
@@ -428,6 +422,14 @@ def _touch_presence(
         # every call here is proof the plugin is connected right now. It is the
         # only presence signal the other api replicas can read.
         control_heartbeat_at=observed_at,
+        commit=False,
+    )
+    crud_runtime_session.touch_activity(
+        db,
+        account_id=context.runtime_session.account_id,
+        runtime_session_id=context.runtime_session.id,
+        observed_at=observed_at,
+        min_update_interval=HEARTBEAT_TOUCH_INTERVAL,
         commit=False,
     )
     if commit:

--- a/backend/preloop/api/endpoints/agent_permission.py
+++ b/backend/preloop/api/endpoints/agent_permission.py
@@ -8,25 +8,73 @@ decision (or timeout) and returns a simple allow/deny.
 """
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import (
     _authenticate_with_api_key,
     _managed_agent_for_api_key,
     _runtime_session_id_from_api_key,
 )
+from preloop.api.loop_safety import run_db_off_loop
 from preloop.config import settings
 from preloop.models.crud import crud_api_key, crud_runtime_session
-from preloop.models.db.session import get_db_session
+from preloop.models.db.session import get_session_factory
 from preloop.services.agent_permission_service import request_agent_permission
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@dataclass(frozen=True)
+class PermissionIdentity:
+    """Authenticated scalars safe to retain while awaiting a human decision."""
+
+    account_id: str
+    user_id: UUID
+    managed_agent_id: UUID
+    runtime_session_id: Optional[UUID]
+    managed_agent_name: str
+
+
+def _resolve_permission_identity(token: str) -> PermissionIdentity:
+    """Authenticate in one worker-owned session, closed before approval waits."""
+    with get_session_factory()() as db:
+        api_key = crud_api_key.get_by_key(db, key=token)
+        user = _authenticate_with_api_key(db, api_key)
+        managed_agent = _managed_agent_for_api_key(db, api_key)
+        if managed_agent is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token is not bound to a managed agent",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        runtime_session = None
+        runtime_session_id = _runtime_session_id_from_api_key(api_key)
+        if runtime_session_id is not None:
+            runtime_session = crud_runtime_session.get_account_session(
+                db,
+                account_id=api_key.account_id,
+                runtime_session_id=runtime_session_id,
+            )
+        return PermissionIdentity(
+            account_id=str(api_key.account_id),
+            user_id=user.id,
+            managed_agent_id=managed_agent.id,
+            runtime_session_id=runtime_session.id
+            if runtime_session
+            else runtime_session_id,
+            managed_agent_name=(
+                getattr(managed_agent, "display_name", None)
+                or getattr(managed_agent, "name", None)
+                or "Agent"
+            ),
+        )
 
 
 def _permission_check_base_url() -> str:
@@ -94,7 +142,6 @@ class AgentPermissionCheckResponse(BaseModel):
 async def agent_permission_check(
     payload: AgentPermissionCheckRequest,
     authorization: Optional[str] = Header(None),
-    db: Session = Depends(get_db_session),
 ) -> AgentPermissionCheckResponse:
     """Decide whether an onboarded agent's native tool call may proceed."""
     if not authorization or not authorization.lower().startswith("bearer "):
@@ -105,33 +152,9 @@ async def agent_permission_check(
         )
     token = authorization.split(" ", 1)[1].strip()
 
-    # The agent calls this with its durable managed credential (the same token
-    # used for MCP). That credential is bound to a managed agent but is NOT
-    # necessarily tied to a live runtime session, so we resolve loosely:
-    # managed agent is required (for identity); runtime session is optional.
-    api_key = crud_api_key.get_by_key(db, key=token)
-    user = _authenticate_with_api_key(db, api_key)  # validates active/expired
-    managed_agent = _managed_agent_for_api_key(db, api_key)
-    if managed_agent is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token is not bound to a managed agent",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    runtime_session = None
-    runtime_session_id = _runtime_session_id_from_api_key(api_key)
-    if runtime_session_id is not None:
-        runtime_session = crud_runtime_session.get_account_session(
-            db,
-            account_id=api_key.account_id,
-            runtime_session_id=runtime_session_id,
-        )
-
-    agent_name = (
-        getattr(managed_agent, "display_name", None)
-        or getattr(managed_agent, "name", None)
-        or "Agent"
-    )
+    # Preserve the existing credential/binding checks, but keep all ORM access
+    # and pool waits off the event loop. No session survives this await.
+    identity = await run_db_off_loop(lambda: _resolve_permission_identity(token))
 
     tool_input = dict(payload.tool_input or {})
     if payload.cwd:
@@ -144,13 +167,11 @@ async def agent_permission_check(
 
     decision, reason, request_id, timed_out = await request_agent_permission(
         base_url=_permission_check_base_url(),
-        account_id=str(api_key.account_id),
-        user_id=user.id,
-        managed_agent_id=managed_agent.id,
-        runtime_session_id=runtime_session.id
-        if runtime_session
-        else runtime_session_id,
-        managed_agent_name=agent_name,
+        account_id=identity.account_id,
+        user_id=identity.user_id,
+        managed_agent_id=identity.managed_agent_id,
+        runtime_session_id=identity.runtime_session_id,
+        managed_agent_name=identity.managed_agent_name,
         source=payload.source,
         tool_name=payload.tool_name,
         tool_input=tool_input,

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -13,6 +13,7 @@ from preloop.models.crud import (
     crud_ai_model,
     crud_api_usage,
     crud_flow_runner,
+    crud_flow_feedback,
     crud_runtime_session_activity,
 )
 from preloop.models.crud.flow import CRUDFlow
@@ -43,6 +44,17 @@ from preloop.services.host_exec import (
     host_exec_flow_error,
     host_exec_profile_name,
     host_exec_unavailable_reason,
+)
+
+from preloop.schemas.flow_continuation import (
+    ContinuationPreview,
+    ContinuationAdoptRequest,
+    ContinuationAdoptResponse,
+)
+from preloop.services.flow_continuation_adoption import (
+    ContinuationAdoptionError,
+    preview_continuation,
+    adopt_continuation,
 )
 
 
@@ -719,6 +731,46 @@ def read_flow_execution(
     project_execution_totals(db, [execution])
 
     return execution
+
+
+@router.get(
+    "/flows/executions/{execution_id}/continuation", response_model=ContinuationPreview
+)
+@require_permission("view_flows")
+def preview_execution_continuation(
+    *,
+    db: Session = Depends(get_db),
+    execution_id: uuid.UUID,
+    current_user: User = Depends(get_current_active_user),
+) -> ContinuationPreview:
+    """Inspect one publication without enabling repairs or holding DB during I/O."""
+    account_id = current_user.account_id
+    crud_flow_feedback.release_read(db)
+    try:
+        return preview_continuation(account_id, execution_id)
+    except ContinuationAdoptionError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+@router.post(
+    "/flows/executions/{execution_id}/continuation",
+    response_model=ContinuationAdoptResponse,
+)
+@require_permission("execute_flows")
+def adopt_execution_continuation(
+    *,
+    db: Session = Depends(get_db),
+    execution_id: uuid.UUID,
+    request: ContinuationAdoptRequest,
+    current_user: User = Depends(get_current_active_user),
+) -> ContinuationAdoptResponse:
+    """Explicitly subscribe one previously published PR to bounded repairs."""
+    account_id = current_user.account_id
+    crud_flow_feedback.release_read(db)
+    try:
+        return adopt_continuation(account_id, execution_id, request)
+    except ContinuationAdoptionError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.get("/flows/executions/{execution_id}/result")

--- a/backend/preloop/api/loop_safety.py
+++ b/backend/preloop/api/loop_safety.py
@@ -20,8 +20,10 @@ or wrap their synchronous body in :func:`run_db_off_loop`.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Callable, TypeVar
 
+from anyio import CancelScope
 from fastapi.concurrency import run_in_threadpool
 
 T = TypeVar("T")
@@ -45,4 +47,24 @@ async def run_db_off_loop(operation: Callable[[], T]) -> T:
     Returns:
         Whatever ``operation`` returns.
     """
-    return await run_in_threadpool(operation)
+    # Shield the worker future from raw asyncio cancellation as well as AnyIO
+    # cancellation scopes. Dependency cleanup may rollback/close the same
+    # request Session as soon as this coroutine exits.
+    worker = asyncio.create_task(run_in_threadpool(operation))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        # AnyIO cancellation is level-triggered. Shield its enclosing scope
+        # while draining; still handle repeated raw Task.cancel separately.
+        with CancelScope(shield=True):
+            while not worker.done():
+                try:
+                    await asyncio.shield(worker)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+        # Retrieve a worker exception even when cancellation takes precedence.
+        if not worker.cancelled():
+            worker.exception()
+        raise

--- a/backend/preloop/models/crud/flow_artifact.py
+++ b/backend/preloop/models/crud/flow_artifact.py
@@ -14,9 +14,11 @@ def store(
     db: Session, *, values: dict[str, Any], quota_bytes: int
 ) -> models.FlowArtifact:
     """Serialize account writes and enforce retained ciphertext quota."""
+    # Serialize quota checks without blocking child audit/usage foreign keys.
+    # Account identity does not change, so NO KEY UPDATE is sufficient.
     db.query(models.Account).filter(
         models.Account.id == values["account_id"]
-    ).with_for_update().one()
+    ).with_for_update(key_share=True).one()
     size = (
         db.query(
             func.coalesce(

--- a/backend/preloop/models/crud/flow_feedback.py
+++ b/backend/preloop/models/crud/flow_feedback.py
@@ -18,6 +18,10 @@ TERMINAL = {"SUCCEEDED", "FAILED", "CANCELLED", "TIMED_OUT", "ABORTED", "STOPPED
 class CRUDFlowFeedback:
     """Transaction boundaries for subscriptions, inbox receipts and dispatch."""
 
+    def release_read(self, db: Session) -> None:
+        """End a materialized read before asynchronous provider I/O."""
+        db.commit()
+
     def rollback(self, db: Session) -> None:
         db.rollback()
 
@@ -36,6 +40,9 @@ class CRUDFlowFeedback:
                     .as_boolean()
                     .is_(True),
                     execution.result["pr_url"].astext.isnot(None),
+                    execution.trigger_event_details["_session_thread_id"].astext.isnot(
+                        None
+                    ),
                     ~bound,
                 )
                 .order_by(execution.created_at.desc())
@@ -257,6 +264,18 @@ class CRUDFlowFeedback:
         db.commit()
         return True
 
+    def sync_policy(
+        self, db: Session, thread: models.FlowThread, policy: dict[str, Any]
+    ) -> None:
+        """Apply live policy without replenishing spent budgets or extending TTL."""
+        thread.policy = dict(policy)
+        original = thread.created_at.replace(tzinfo=None)
+        thread.expires_at = min(
+            thread.expires_at,
+            original + timedelta(hours=int(policy.get("max_age_hours", 168))),
+        )
+        db.commit()
+
     def reserve(
         self,
         db: Session,
@@ -267,7 +286,19 @@ class CRUDFlowFeedback:
         receipt_ids: list[uuid.UUID],
         head_sha: str,
         now: datetime,
+        expected_policy: dict[str, Any] | None = None,
     ) -> models.FlowExecution | None:
+        candidate = self.leased(db, thread_id, token)
+        if candidate is None:
+            db.rollback()
+            return None
+        # Parent before child matches flow deletion's FK cascade lock order.
+        flow = db.execute(
+            select(models.Flow)
+            .where(models.Flow.id == candidate.flow_id)
+            .execution_options(populate_existing=True)
+            .with_for_update(read=True)
+        ).scalar_one_or_none()
         thread = self.leased(db, thread_id, token, lock=True)
         if (
             thread is None
@@ -276,6 +307,26 @@ class CRUDFlowFeedback:
             or thread.active_execution_id
         ):
             db.rollback()
+            return None
+        # Re-read under a shared row lock so a concurrent policy edit cannot
+        # commit between this authorization check and execution reservation.
+        policy = (flow.agent_config or {}).get("feedback") if flow else None
+        if (
+            flow is None
+            or flow.account_id != thread.account_id
+            or not flow.is_enabled
+            or not isinstance(policy, dict)
+            or policy.get("enabled") is not True
+            or (expected_policy is not None and policy != expected_policy)
+            or now >= thread.expires_at
+            or thread.turns >= int(policy.get("max_turns", 5))
+            or thread.cost >= float(policy.get("max_cost", 100))
+            or thread.no_progress >= int(policy.get("max_no_progress", 2))
+        ):
+            thread.lease_until = None
+            thread.lease_token = None
+            thread.due_at = now
+            db.commit()
             return None
         execution = models.FlowExecution(
             id=uuid.uuid4(),

--- a/backend/preloop/models/crud/secret_reference.py
+++ b/backend/preloop/models/crud/secret_reference.py
@@ -1,19 +1,49 @@
 """CRUD operations for SecretReference."""
 
-from typing import Optional
+from typing import Any, Callable, Optional
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from ..models.secret_reference import SecretReference
+from preloop.models import models
 from .base import CRUDBase
 
 
-class CRUDSecretReference(CRUDBase[SecretReference]):
+class CRUDSecretReference(CRUDBase[models.SecretReference]):
     """CRUD class for SecretReference operations."""
+
+    def inspect_for_refresh(
+        self,
+        db: Session,
+        *,
+        secret_id: UUID,
+        inspect: Callable[
+            [Optional[models.SecretReference]], tuple[dict[str, Any], bool]
+        ],
+    ) -> dict[str, Any]:
+        """Read current secret state under an owned, releasable row lock.
+
+        The inspector returns a payload and whether refresh still needs the
+        lock. Rolling back only this savepoint releases an unnecessary lock
+        without committing or discarding the caller's surrounding transaction.
+        A required refresh retains exclusion until the caller persists rotation.
+        """
+        with db.begin_nested() as savepoint:
+            secret = (
+                db.query(self.model)
+                .filter(self.model.id == secret_id)
+                .populate_existing()
+                .with_for_update()
+                .one_or_none()
+            )
+            payload, needs_refresh = inspect(secret)
+            if not needs_refresh:
+                savepoint.rollback()
+            return payload
 
     def get_for_account(
         self, db: Session, *, secret_id: str, account_id: str
-    ) -> Optional[SecretReference]:
+    ) -> Optional[models.SecretReference]:
         """Get a secret reference scoped to an account."""
         return (
             db.query(self.model)
@@ -22,4 +52,4 @@ class CRUDSecretReference(CRUDBase[SecretReference]):
         )
 
 
-crud_secret_reference = CRUDSecretReference(SecretReference)
+crud_secret_reference = CRUDSecretReference(models.SecretReference)

--- a/backend/preloop/schemas/flow_continuation.py
+++ b/backend/preloop/schemas/flow_continuation.py
@@ -1,0 +1,38 @@
+"""Explicit adoption contract for one previously published implementation."""
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+RecoveryMode = Literal["native_resume", "published_branch_handoff"]
+
+
+class ContinuationPreview(BaseModel):
+    execution_id: UUID
+    flow_id: UUID
+    pr_url: str
+    branch: str
+    head_sha: str
+    feedback_enabled: bool
+    artifact_upload_enabled: bool
+    feedback_readable: bool = False
+    feedback_blocked_reason: str | None = None
+    native_resume_available: bool
+    existing_thread_id: UUID | None = None
+    existing_thread_state: str | None = None
+    allowed_recovery_modes: list[RecoveryMode]
+    warnings: list[str]
+
+
+class ContinuationAdoptRequest(BaseModel):
+    recovery_mode: RecoveryMode
+    expected_head_sha: str = Field(pattern=r"^[0-9a-fA-F]{40,64}$")
+    acknowledge_fresh_conversation: bool = False
+
+
+class ContinuationAdoptResponse(BaseModel):
+    thread_id: UUID
+    state: str
+    pr_url: str
+    recovery_mode: RecoveryMode

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -1888,10 +1888,11 @@ class ApprovalService:
 
         # Generate user-facing summary before any notifications fire.
         try:
-            from preloop.models.db.session import get_db_session
+            from preloop.api.loop_safety import run_db_off_loop
+            from preloop.models.db.session import get_session_factory
             from preloop.services.approval_summary import generate_approval_summary
 
-            sync_db = next(get_db_session())
+            sync_db = await run_db_off_loop(lambda: get_session_factory()())
             try:
                 summary = await generate_approval_summary(
                     sync_db,
@@ -1902,7 +1903,9 @@ class ApprovalService:
                     managed_agent_name=managed_agent_name,
                 )
             finally:
-                sync_db.close()
+                # Rollback during close is database I/O too. The summary's
+                # worker has drained before returning, including cancellation.
+                await run_db_off_loop(sync_db.close)
             if summary:
                 approval_request = await self.update_approval_request(
                     approval_request.id,

--- a/backend/preloop/services/approval_summary.py
+++ b/backend/preloop/services/approval_summary.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 
 from sqlalchemy.orm import Session
 
+from preloop.api.loop_safety import run_db_off_loop
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.models.ai_model import AIModel
 from preloop.services.litellm_routing import to_litellm_model
@@ -119,6 +120,10 @@ def _call_summary_model(
     }
     kwargs = build_aux_kwargs(model, creds_kwargs, call_site_kwargs=call_site_kwargs)
 
+    # Cancellation drains a worker that still owns the caller's Session.
+    # Bound provider I/O as well as the coroutine deadline.
+    kwargs["timeout"] = SUMMARY_ATTEMPT_TIMEOUT_SECONDS
+    kwargs["num_retries"] = 0
     response = litellm.completion(**kwargs)
     check_reasoning_model_empty_content(response)
     text = (response.choices[0].message.content or "").strip()
@@ -154,8 +159,10 @@ async def generate_approval_summary(
         return question[:SUMMARY_MAX_CHARS]
 
     try:
-        model = crud_ai_model.get_default_active_model(
-            db, account_id=str(account_id), model_kind="llm"
+        model = await run_db_off_loop(
+            lambda: crud_ai_model.get_default_active_model(
+                db, account_id=str(account_id), model_kind="llm"
+            )
         )
     except Exception as exc:
         logger.warning("Could not resolve default model for approval summary: %s", exc)

--- a/backend/preloop/services/checkpoint_runtime.py
+++ b/backend/preloop/services/checkpoint_runtime.py
@@ -60,7 +60,9 @@ def checkpoint_context(db: Session, context: dict[str, Any]) -> dict[str, str]:
             operation="get",
             reference=ArtifactReference.model_validate(native_ref),
         )
-    if resume.get("execution_id"):
+    if resume.get("execution_id") and not context.get(
+        "published_branch_handoff_authorized"
+    ):
         prior = crud.latest(
             db,
             account_id=identifiers["account_id"],

--- a/backend/preloop/services/flow_continuation_adoption.py
+++ b/backend/preloop/services/flow_continuation_adoption.py
@@ -1,0 +1,399 @@
+"""Operator-selected PR adoption with short, worker-owned database transactions."""
+
+import asyncio
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+from types import SimpleNamespace
+from urllib.parse import quote, urlparse
+from uuid import UUID
+
+from preloop.config import settings
+from preloop.agents.cli_session import valid_session_id
+from preloop.models.crud import (
+    crud_flow,
+    crud_flow_execution,
+    crud_flow_feedback,
+    crud_tracker,
+)
+from preloop.models.crud import flow_artifact
+from preloop.models.db.session import get_session_factory
+from preloop.schemas.flow_continuation import (
+    ContinuationAdoptRequest,
+    ContinuationAdoptResponse,
+    ContinuationPreview,
+)
+from preloop.services.flow_artifacts import artifact_thread_id, artifact_reference
+from preloop.services.flow_feedback import feedback_policy, register_thread
+from preloop.services.flow_feedback_provider import (
+    FeedbackProvider,
+    feedback_tracker_options,
+)
+from preloop.sync.trackers.factory import create_tracker_client
+
+
+class ContinuationAdoptionError(ValueError):
+    """A safe, operator-readable adoption precondition failure."""
+
+    def __init__(self, message: str, status_code: int = 409) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _load_source(account_id: UUID, execution_id: UUID) -> dict[str, Any]:
+    """Materialize only the selected source, then release DB before provider I/O."""
+    with get_session_factory()() as db:
+        execution = crud_flow_execution.get(db, id=execution_id, account_id=account_id)
+        if execution is None:
+            raise ContinuationAdoptionError("Flow execution not found", 404)
+        flow = crud_flow.get(db, id=execution.flow_id)
+        if flow is None or flow.account_id != account_id:
+            raise ContinuationAdoptionError("Flow execution not found", 404)
+        if execution.status != "SUCCEEDED":
+            raise ContinuationAdoptionError(
+                "Only a successful publishing execution can be adopted"
+            )
+        details = execution.trigger_event_details or {}
+        if details.get("_thread_id"):
+            raise ContinuationAdoptionError("Select the original publishing execution")
+        result = execution.result or {}
+        pr_url, branch = result.get("pr_url"), result.get("pr_source_branch")
+        if not isinstance(pr_url, str) or not isinstance(branch, str) or not branch:
+            raise ContinuationAdoptionError(
+                "Execution has no recorded PR and source branch"
+            )
+        payload = details.get("payload") or {}
+        repository = payload.get("repository") or payload.get("project") or {}
+        repository_id = repository.get("id")
+        provider = details.get("source")
+        number = urlparse(pr_url).path.rstrip("/").split("/")[-1]
+        try:
+            tracker_id = UUID(
+                str(details.get("tracker_id") or flow.trigger_event_source)
+            )
+        except (ValueError, TypeError, AttributeError) as exc:
+            raise ContinuationAdoptionError(
+                "Execution has no valid tracker binding"
+            ) from exc
+        if (
+            provider not in {"github", "gitlab"}
+            or not repository_id
+            or not number.isdigit()
+        ):
+            raise ContinuationAdoptionError(
+                "Execution has no valid provider PR binding"
+            )
+        tracker = crud_tracker.get(db, id=tracker_id)
+        if (
+            tracker is None
+            or tracker.account_id != account_id
+            or tracker.tracker_type != provider
+        ):
+            raise ContinuationAdoptionError("Execution tracker is unavailable", 404)
+        thread_id = artifact_thread_id(details, execution_id)
+        workspace = flow_artifact.latest(
+            db,
+            account_id=account_id,
+            flow_id=flow.id,
+            thread_id=thread_id,
+            execution_id=execution_id,
+            kind="workspace",
+        )
+        cli = execution.cli_session or {}
+        reference = cli.get("artifact_reference") or {}
+        native = None
+        if reference.get("artifact_id"):
+            try:
+                native = flow_artifact.get(
+                    db,
+                    artifact_id=UUID(str(reference["artifact_id"])),
+                    account_id=account_id,
+                    flow_id=flow.id,
+                    thread_id=thread_id,
+                )
+            except (ValueError, TypeError):
+                native = None
+        now = datetime.now(UTC)
+
+        def available(artifact: Any) -> bool:
+            return bool(
+                artifact is not None
+                and artifact.execution_id == execution_id
+                and artifact.ciphertext is not None
+                and artifact.expires_at.replace(tzinfo=UTC) > now
+            )
+
+        bindings = crud_flow_feedback.find(
+            db,
+            account_id=account_id,
+            tracker_id=tracker_id,
+            repository_id=str(repository_id),
+            pr_number=number,
+        )
+        existing = next((row for row in bindings if row.flow_id == flow.id), None)
+        return {
+            "execution_id": execution_id,
+            "flow_id": flow.id,
+            "pr_url": pr_url,
+            "branch": branch,
+            "provider": provider,
+            "repository_id": str(repository_id),
+            "number": number,
+            "feedback_enabled": bool(flow.is_enabled and feedback_policy(flow)),
+            "policy": deepcopy(feedback_policy(flow) or {}),
+            "native_resume_available": bool(
+                valid_session_id(cli.get("agent_type", ""), cli.get("session_id", ""))
+                and available(workspace)
+                and available(native)
+                and native.kind == "native_session"
+                and str(reference.get("execution_id")) == str(execution_id)
+                and reference.get("manifest_sha256")
+                == artifact_reference(native).manifest_sha256
+            ),
+            "existing_thread_id": existing.id if existing else None,
+            "existing_thread_state": existing.state if existing else None,
+            # Never project tracker credentials into the API response.
+            "tracker_id": tracker_id,
+            "tracker_key": tracker.resolved_api_key,
+            "tracker_options": feedback_tracker_options(db, tracker),
+        }
+
+
+class _BoundedReadClient:
+    """A single-publication preflight has at most twelve provider requests."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self.remaining = 12
+        self.gl = getattr(client, "gl", None)
+
+    def _take(self) -> None:
+        self.remaining -= 1
+        if self.remaining < 0:
+            raise ContinuationAdoptionError("Provider preflight request limit reached")
+
+    async def _request(self, method: str, path: str, *args: Any, **kwargs: Any) -> Any:
+        self._take()
+        if method != "GET" and not (method == "POST" and path == "/graphql"):
+            raise ContinuationAdoptionError("Provider preflight permits reads only")
+        return await self.client._request(method, path, *args, **kwargs)
+
+    async def _make_request(self, method: Any, path: str) -> Any:
+        self._take()
+        return await self.client._make_request(method, path)
+
+
+async def _feedback_preflight(
+    client: _BoundedReadClient, source: dict[str, Any], publication: dict[str, Any]
+) -> dict[str, Any]:
+    """Exercise the same review/check/protection reads used by reconciliation."""
+    thread = SimpleNamespace(
+        provider=source["provider"],
+        repository_id=source["repository_id"],
+        pr_number=source["number"],
+        policy=source["policy"],
+    )
+    try:
+        state = await FeedbackProvider(client, thread).read()
+        publication["open"] = publication["open"] and not state.closed
+        publication["feedback_readable"] = state.blocked_reason != "provider_page_limit"
+        publication["feedback_blocked_reason"] = state.blocked_reason
+        if state.head_sha != publication["head_sha"]:
+            raise ContinuationAdoptionError("PR head changed during preflight")
+    except ContinuationAdoptionError:
+        raise
+    except Exception:
+        publication["feedback_readable"] = False
+        publication["feedback_blocked_reason"] = "provider_reconciliation_unavailable"
+    return publication
+
+
+async def _bounded_publication(source: dict[str, Any]) -> dict[str, Any]:
+    async with asyncio.timeout(25):
+        return await _read_publication(source)
+
+
+async def _read_publication(source: dict[str, Any]) -> dict[str, Any]:
+    """Read exactly one current PR without holding a database session."""
+    client = await create_tracker_client(
+        source["provider"],
+        str(source["tracker_id"]),
+        source["tracker_key"],
+        source["tracker_options"],
+    )
+    if client is None:
+        raise ContinuationAdoptionError("Tracker cannot read the published PR")
+    client = _BoundedReadClient(client)
+    repository = quote(source["repository_id"], safe="")
+    number = quote(source["number"], safe="")
+    if source["provider"] == "github":
+        pr = await client._request("GET", f"/repositories/{repository}/pulls/{number}")
+        same_repository = all(
+            str((pr.get(side, {}).get("repo") or {}).get("id"))
+            == source["repository_id"]
+            for side in ("base", "head")
+        )
+        publication = {
+            "open": pr.get("state") == "open",
+            "same_repository": same_repository,
+            "branch": pr.get("head", {}).get("ref"),
+            "head_sha": pr.get("head", {}).get("sha"),
+            "pr_url": pr.get("html_url"),
+        }
+        return await _feedback_preflight(client, source, publication)
+    path = f"/projects/{repository}/merge_requests/{number}"
+    pr = await client._make_request(client.gl.http_get, path)
+    publication = {
+        "open": pr.get("state") == "opened",
+        "same_repository": all(
+            str(pr.get(key)) == source["repository_id"]
+            for key in ("source_project_id", "target_project_id")
+        ),
+        "branch": pr.get("source_branch"),
+        "head_sha": pr.get("sha"),
+        "pr_url": pr.get("web_url"),
+    }
+
+    return await _feedback_preflight(client, source, publication)
+
+
+def preview_continuation(account_id: UUID, execution_id: UUID) -> ContinuationPreview:
+    """Preview one source in a FastAPI worker; no activation or provider writes."""
+    try:
+        source = _load_source(account_id, execution_id)
+    except ContinuationAdoptionError:
+        raise
+    except ValueError as exc:
+        raise ContinuationAdoptionError(
+            "Execution tracker configuration is unavailable"
+        ) from exc
+    try:
+        publication = asyncio.run(_bounded_publication(source))
+    except ContinuationAdoptionError:
+        raise
+    except Exception as exc:
+        raise ContinuationAdoptionError(
+            "Unable to verify the current published PR"
+        ) from exc
+    if (
+        not publication["open"]
+        or not publication["same_repository"]
+        or publication["branch"] != source["branch"]
+        or str(publication["pr_url"]).rstrip("/") != source["pr_url"].rstrip("/")
+        or not publication["head_sha"]
+    ):
+        raise ContinuationAdoptionError(
+            "Published PR is closed or its repository/branch binding changed"
+        )
+    warnings = []
+    if not publication.get("feedback_readable"):
+        warnings.append(
+            "Tracker cannot verify the PR review, CI and repository gates. Check its read permissions."
+        )
+    elif (
+        publication.get("feedback_blocked_reason")
+        == "repository_requirements_unavailable"
+    ):
+        warnings.append(
+            "Repository requirements are unavailable. Known review and CI feedback can be repaired, but readiness cannot be verified."
+        )
+    elif publication.get("feedback_blocked_reason"):
+        warnings.append(
+            "Feedback reconciliation is blocked: "
+            + publication["feedback_blocked_reason"]
+        )
+    if not source["feedback_enabled"]:
+        warnings.append("Enable PR follow-up on this flow before adopting the PR.")
+    if not settings.flow_artifact_direct_upload:
+        warnings.append("Direct checkpoint uploads must be enabled before adoption.")
+    if not source["native_resume_available"]:
+        warnings.append(
+            "Recovery files are unavailable. Continuing requires a fresh conversation on the published PR branch."
+        )
+    return ContinuationPreview(
+        **{
+            key: source[key]
+            for key in (
+                "execution_id",
+                "flow_id",
+                "pr_url",
+                "branch",
+                "feedback_enabled",
+                "native_resume_available",
+                "existing_thread_id",
+                "existing_thread_state",
+            )
+        },
+        head_sha=publication["head_sha"],
+        feedback_readable=publication.get("feedback_readable", False),
+        feedback_blocked_reason=publication.get("feedback_blocked_reason"),
+        artifact_upload_enabled=settings.flow_artifact_direct_upload,
+        allowed_recovery_modes=["native_resume"]
+        if source["native_resume_available"]
+        else ["published_branch_handoff"],
+        warnings=warnings,
+    )
+
+
+def adopt_continuation(
+    account_id: UUID, execution_id: UUID, request: ContinuationAdoptRequest
+) -> ContinuationAdoptResponse:
+    """Revalidate the selected PR and atomically register one bounded thread."""
+    preview = preview_continuation(account_id, execution_id)
+    if not preview.feedback_readable:
+        raise ContinuationAdoptionError(
+            "Tracker cannot read the required feedback and repository gates"
+        )
+    if preview.head_sha != request.expected_head_sha:
+        raise ContinuationAdoptionError("PR head changed; preview the PR again")
+    if not preview.feedback_enabled or not preview.artifact_upload_enabled:
+        raise ContinuationAdoptionError(
+            "Flow feedback and direct checkpoint uploads must be enabled"
+        )
+    if request.recovery_mode not in preview.allowed_recovery_modes:
+        raise ContinuationAdoptionError("Requested recovery mode is unavailable")
+    if (
+        request.recovery_mode == "published_branch_handoff"
+        and not request.acknowledge_fresh_conversation
+    ):
+        raise ContinuationAdoptionError(
+            "Acknowledge starting a fresh conversation from the published branch"
+        )
+    with get_session_factory()() as db:
+        execution = crud_flow_execution.get(db, id=execution_id, account_id=account_id)
+        if execution is None or execution.status != "SUCCEEDED":
+            raise ContinuationAdoptionError(
+                "Publishing execution is no longer available"
+            )
+        result = execution.result or {}
+        if (
+            result.get("pr_url") != preview.pr_url
+            or result.get("pr_source_branch") != preview.branch
+        ):
+            raise ContinuationAdoptionError("Publishing execution binding changed")
+        flow = crud_flow.get(db, id=execution.flow_id)
+        if flow is None or not flow.is_enabled or not feedback_policy(flow):
+            raise ContinuationAdoptionError("Flow feedback is no longer enabled")
+        thread = register_thread(
+            db,
+            execution,
+            preview.pr_url,
+            preview.branch,
+            adoption={
+                "source_execution_id": str(execution_id),
+                "recovery_mode": request.recovery_mode,
+                "acknowledged_head_sha": preview.head_sha,
+                "acknowledged_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        if thread is None:
+            raise ContinuationAdoptionError(
+                "Execution cannot be registered for continuation"
+            )
+        recorded = (thread.context or {}).get("adoption") or {}
+        return ContinuationAdoptResponse(
+            thread_id=thread.id,
+            state=thread.state,
+            pr_url=thread.pr_url,
+            recovery_mode=recorded.get("recovery_mode", "native_resume"),
+        )

--- a/backend/preloop/services/flow_continuation_adoption.py
+++ b/backend/preloop/services/flow_continuation_adoption.py
@@ -180,6 +180,8 @@ class _BoundedReadClient:
 
     async def _make_request(self, method: Any, path: str) -> Any:
         self._take()
+        if self.gl is None or method != self.gl.http_get:
+            raise ContinuationAdoptionError("Provider preflight permits reads only")
         return await self.client._make_request(method, path)
 
 
@@ -391,9 +393,20 @@ def adopt_continuation(
                 "Execution cannot be registered for continuation"
             )
         recorded = (thread.context or {}).get("adoption") or {}
+        # Registration can lose an insert race or find a previously subscribed
+        # publication. Only an exact adoption replay is idempotent; changing an
+        # existing thread's recovery authority requires a separate operation.
+        if (
+            recorded.get("source_execution_id") != str(execution_id)
+            or recorded.get("recovery_mode") != request.recovery_mode
+        ):
+            raise ContinuationAdoptionError(
+                "PR already has a continuation thread; adoption cannot change "
+                "its source or recovery mode"
+            )
         return ContinuationAdoptResponse(
             thread_id=thread.id,
             state=thread.state,
             pr_url=thread.pr_url,
-            recovery_mode=recorded.get("recovery_mode", "native_resume"),
+            recovery_mode=recorded["recovery_mode"],
         )

--- a/backend/preloop/services/flow_feedback.py
+++ b/backend/preloop/services/flow_feedback.py
@@ -6,12 +6,14 @@ import hashlib
 import json
 import logging
 import uuid
+from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 
+from preloop.config import settings
 from preloop.models import models
 from preloop.models.crud import crud_flow, crud_flow_execution, crud_flow_feedback
 from preloop.services.flow_feedback_provider import (
@@ -53,8 +55,13 @@ def feedback_policy(flow: Any) -> dict[str, Any] | None:
 
 
 def register_thread(
-    db: Session, execution: models.FlowExecution, pr_url: str, branch: str
-) -> None:
+    db: Session,
+    execution: models.FlowExecution,
+    pr_url: str,
+    branch: str,
+    *,
+    adoption: dict[str, Any] | None = None,
+) -> models.FlowThread | None:
     """Register after trusted publication; initial reconciliation recovers races."""
     flow = crud_flow.get(db, id=execution.flow_id)
     policy = feedback_policy(flow)
@@ -62,7 +69,11 @@ def register_thread(
         return
     details = execution.trigger_event_details or {}
     if details.get("_thread_id"):
-        return
+        return None
+    if not details.get("_session_thread_id") and adoption is None:
+        # Enabling an old flow is permission for future implementations, not
+        # permission to spend repair budgets on its historical PR backlog.
+        return None
     payload = details.get("payload") or {}
     repository = payload.get("repository") or payload.get("project") or {}
     repository_id = repository.get("id")
@@ -75,7 +86,7 @@ def register_thread(
         session_thread_id = (
             uuid.UUID(str(details["_session_thread_id"]))
             if details.get("_session_thread_id")
-            else uuid.uuid4()
+            else uuid.UUID(str(execution.id))
         )
     except (ValueError, TypeError, AttributeError):
         logger.warning("Cannot bind feedback: tracker or session id is not a UUID")
@@ -101,6 +112,7 @@ def register_thread(
             ).encode()
         ).hexdigest(),
         "repository": repository,
+        **({"adoption": adoption} if adoption is not None else {}),
         "trigger": {
             **{
                 key: details[key]
@@ -112,7 +124,7 @@ def register_thread(
             "account_id": str(flow.account_id),
         },
     }
-    crud_flow_feedback.register(
+    return crud_flow_feedback.register(
         db,
         values={
             "id": session_thread_id,
@@ -166,12 +178,61 @@ def resolve_native_checkpoint(
     )
     if prior is None or prior.flow_id != flow_id:
         raise ValueError("resume_failed: checkpoint execution mismatch")
+    if not settings.flow_artifact_direct_upload:
+        raise ValueError("resume_failed: checkpoint uploads disabled")
+    if source_cold_handoff(thread, prior.id):
+        if (
+            resume.get("pr_url") != thread.pr_url
+            or resume.get("source_branch") != thread.branch
+        ):
+            raise ValueError("resume_failed: published branch binding mismatch")
+        return {"cold_handoff_authorized": True}
     session = prior.cli_session
     if not isinstance(session, dict):
-        return None
+        raise ValueError("resume_failed: native checkpoint missing")
+    from preloop.agents.cli_session import valid_session_id
+
+    if not valid_session_id(
+        session.get("agent_type", ""), session.get("session_id", "")
+    ):
+        raise ValueError("resume_failed: invalid native session identity")
+    if settings.flow_artifact_direct_upload:
+        from preloop.models.crud import flow_artifact
+        from preloop.services.flow_artifacts import artifact_reference
+
+        reference = session.get("artifact_reference") or {}
+        try:
+            artifact = flow_artifact.get(
+                db,
+                artifact_id=uuid.UUID(str(reference.get("artifact_id"))),
+                account_id=account_id,
+                flow_id=flow_id,
+                thread_id=str(thread.id),
+            )
+        except (ValueError, TypeError):
+            artifact = None
+        if (
+            artifact is None
+            or artifact.kind != "native_session"
+            or artifact.execution_id != prior.id
+            or artifact.ciphertext is None
+            or artifact.expires_at.replace(tzinfo=UTC) <= datetime.now(UTC)
+            or str(reference.get("execution_id")) != str(prior.id)
+            or reference.get("manifest_sha256")
+            != artifact_reference(artifact).manifest_sha256
+        ):
+            raise ValueError("resume_failed: native checkpoint unavailable")
     if session.get("thread_id") and session["thread_id"] != str(thread.id):
         raise ValueError("resume_failed: native session thread mismatch")
     return dict(session)
+
+
+def source_cold_handoff(thread: models.FlowThread, source_id: uuid.UUID) -> bool:
+    """The explicit exception belongs only to the adopted source checkpoint."""
+    adoption = (thread.context or {}).get("adoption") or {}
+    return adoption.get("recovery_mode") == "published_branch_handoff" and adoption.get(
+        "source_execution_id"
+    ) == str(source_id)
 
 
 def ingest_feedback(db: Session, event: dict[str, Any]) -> bool:
@@ -235,7 +296,8 @@ def decide(
         return "closed", "pr_closed_or_merged"
     if now >= thread.expires_at:
         return "expired", "subscription_expired"
-    if state.blocked_reason and not state.checks_pending:
+    requirements_unknown = state.blocked_reason == "repository_requirements_unavailable"
+    if state.blocked_reason and not state.checks_pending and not requirements_unknown:
         return "blocked", state.blocked_reason
     if state.checks_pending:
         started = (thread.cursor or {}).get("ci_wait_started")
@@ -268,6 +330,8 @@ def decide(
         return "stopped", "no_progress"
     if actionable:
         return "repair", None
+    if requirements_unknown:
+        return "blocked", state.blocked_reason
     if state.checks_passed and state.reviews_passed and not state.blocked_reason:
         return "ready", None
     return "waiting", "review_or_ci_pending"
@@ -325,6 +389,18 @@ async def _reconcile(
             now=now,
         )
         return
+    if feedback_policy(flow) is None:
+        # Keep budget/deadline history so an explicit re-enable can continue.
+        crud_flow_feedback.update(
+            db,
+            thread_id,
+            token,
+            changes={"state": "paused", "stop_reason": "feedback_disabled"},
+            now=now,
+        )
+        return
+    policy = deepcopy(feedback_policy(flow))
+    crud_flow_feedback.sync_policy(db, thread, policy)
     provider = await FeedbackProvider.for_thread(db, thread)
     state = await provider.read()
     if state.closed or now >= thread.expires_at:
@@ -443,7 +519,11 @@ async def _reconcile(
         "pr_url": thread.pr_url,
         "source_branch": thread.branch,
     }
-    if isinstance(prior.cli_session, dict) and prior.cli_session.get("session_id"):
+    if (
+        not source_cold_handoff(thread, prior.id)
+        and isinstance(prior.cli_session, dict)
+        and prior.cli_session.get("session_id")
+    ):
         resume["cli_session"] = prior.cli_session
     actionable = [
         item
@@ -512,6 +592,7 @@ async def _reconcile(
         receipt_ids=[item.id for item in pending],
         head_sha=state.head_sha,
         now=now,
+        expected_policy=policy,
     )
     if execution is not None:
         from preloop.services.flow_trigger_service import FlowTriggerService

--- a/backend/preloop/services/flow_feedback_provider.py
+++ b/backend/preloop/services/flow_feedback_provider.py
@@ -7,11 +7,15 @@ import json
 import re
 from dataclasses import dataclass, field
 from typing import Any
+from types import SimpleNamespace
+from copy import deepcopy
 from urllib.parse import quote
 
 from preloop.models import models
-from preloop.models.crud import crud_tracker
+from preloop.models.crud import crud_tracker, crud_flow_feedback
+from preloop.models.crud.oauth_app_installation import crud_oauth_app_installation
 from preloop.sync.trackers import create_tracker_client
+from preloop.sync.exceptions import TrackerPermissionError
 from sqlalchemy.orm import Session
 
 
@@ -135,10 +139,32 @@ def classify_checks(
     return pending, not pending and not failures and not blocked, blocked, failures
 
 
+def feedback_tracker_options(db: Session, tracker: Any) -> dict[str, Any]:
+    """Materialize authoritative tracker authentication before network I/O."""
+    options = deepcopy({"url": tracker.url, **(tracker.connection_details or {})})
+    auth_type = getattr(tracker, "auth_type", None) or "api_token"
+    if tracker.tracker_type == "github":
+        options["auth_type"] = auth_type
+        options.pop("github_installation_id", None)
+        if auth_type in {"github_app", "oauth_app"}:
+            installation = crud_oauth_app_installation.get_by_id_provider_and_account(
+                db,
+                id=tracker.oauth_installation_id,
+                provider="github",
+                account_id=tracker.account_id,
+            )
+            if installation is None or not installation.external_id:
+                raise ValueError("feedback tracker installation unavailable")
+            options["github_installation_id"] = installation.external_id
+    return options
+
+
 class FeedbackProvider:
     """Read-only APIs, scoped by the trusted tracker and bound repository ID."""
 
-    def __init__(self, client: Any, thread: models.FlowThread) -> None:
+    def __init__(
+        self, client: Any, thread: models.FlowThread | SimpleNamespace
+    ) -> None:
         self.client = client
         self.thread = thread
 
@@ -149,15 +175,23 @@ class FeedbackProvider:
         tracker = crud_tracker.get(db, id=thread.tracker_id)
         if tracker is None or tracker.account_id != thread.account_id:
             raise ValueError("feedback tracker account mismatch")
-        client = await create_tracker_client(
+        tracker_args = (
             tracker.tracker_type,
             str(tracker.id),
             tracker.resolved_api_key,
-            {"url": tracker.url, **(tracker.connection_details or {})},
+            feedback_tracker_options(db, tracker),
         )
+        snapshot = SimpleNamespace(
+            provider=thread.provider,
+            repository_id=thread.repository_id,
+            pr_number=thread.pr_number,
+            policy=deepcopy(thread.policy),
+        )
+        crud_flow_feedback.release_read(db)
+        client = await create_tracker_client(*tracker_args)
         if client is None:
             raise ValueError("feedback provider unavailable")
-        return cls(client, thread)
+        return cls(client, snapshot)
 
     async def read(self) -> FeedbackState:
         if self.thread.provider == "github":
@@ -242,10 +276,16 @@ class FeedbackProvider:
         count = int(self.thread.policy.get("required_approvals", 1))
         # Repository policy is authoritative; absent explicit config is not proof
         # that required checks are empty. Branch protection errors fail closed.
+        requirements_unknown = False
         if "required_checks" not in self.thread.policy:
-            protection = await request(
-                "GET", f"{repo}/branches/{quote(pr['base']['ref'], safe='')}/protection"
-            )
+            try:
+                protection = await request(
+                    "GET",
+                    f"{repo}/branches/{quote(pr['base']['ref'], safe='')}/protection",
+                )
+            except TrackerPermissionError:
+                protection = {}
+                requirements_unknown = True
             required = (protection.get("required_status_checks") or {}).get(
                 "contexts", []
             )
@@ -254,9 +294,13 @@ class FeedbackProvider:
                     "required_approving_review_count", count
                 )
             )
-        rules = await request(
-            "GET", f"{repo}/rules/branches/{quote(pr['base']['ref'], safe='')}"
-        )
+        try:
+            rules = await request(
+                "GET", f"{repo}/rules/branches/{quote(pr['base']['ref'], safe='')}"
+            )
+        except TrackerPermissionError:
+            rules = []
+            requirements_unknown = True
         unsupported_gate = False
         for rule in rules:
             parameters = rule.get("parameters") or {}
@@ -306,7 +350,13 @@ class FeedbackProvider:
             sha,
         )
         state.feedback += [receipt("ci", item, head_sha=sha) for item in failed]
+        if requirements_unknown:
+            state.checks_passed = False
+            state.reviews_passed = False
+            if state.blocked_reason is None:
+                state.blocked_reason = "repository_requirements_unavailable"
         current = await request("GET", base)
+        state.closed = current.get("state") == "closed"
         if current["head"]["sha"] != sha:
             return FeedbackState(
                 current["head"]["sha"],

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2178,6 +2178,11 @@ class FlowExecutionOrchestrator:
         if resume.get("thread_id"):
             execution_context["checkpoint_resume_authorized"] = True
             execution_context["thread_id"] = resume["thread_id"]
+        cold_handoff = bool(native and native.get("cold_handoff_authorized"))
+        if cold_handoff:
+            execution_context["published_branch_handoff_authorized"] = True
+            resume.pop("cli_session", None)
+            native = None
         if native or resume.get("cli_session"):
             validate_native_resume_identity(
                 self.db, self.flow, self.trigger_event_data, resume
@@ -2193,7 +2198,7 @@ class FlowExecutionOrchestrator:
         # so unpushed commits (and scratch state) survive into this run.
         restore_archive = (
             None
-            if settings.flow_artifact_direct_upload
+            if settings.flow_artifact_direct_upload or cold_handoff
             else self._resolve_workspace_restore_archive()
         )
         if restore_archive is not None:
@@ -2202,7 +2207,9 @@ class FlowExecutionOrchestrator:
         # Correlated resume: extract the prior execution's packed CLI session
         # from its workspace snapshot so the agent script can restore it into
         # runners that cannot seed the filesystem pre-start (Kubernetes).
-        cli_session_archive = self._resolve_cli_session_restore_archive()
+        cli_session_archive = (
+            None if cold_handoff else self._resolve_cli_session_restore_archive()
+        )
         if cli_session_archive is not None:
             execution_context["cli_session_restore_archive"] = cli_session_archive
 

--- a/backend/preloop/services/flow_trigger_service.py
+++ b/backend/preloop/services/flow_trigger_service.py
@@ -706,6 +706,8 @@ class FlowTriggerService:
                 trigger_details["test_mode"] = True
             from preloop.services.flow_feedback import feedback_policy
 
+            trigger_details.pop("_session_thread_id", None)
+            trigger_details.pop("_thread_id", None)
             if feedback_policy(flow):
                 trigger_details["_session_thread_id"] = str(uuid.uuid4())
             event_data = trigger_details
@@ -1448,6 +1450,12 @@ class FlowTriggerService:
         from preloop.services.flow_orchestrator import _make_json_serializable
 
         trigger_details = _make_json_serializable(trigger_details)
+        from preloop.services.flow_feedback import feedback_policy
+
+        trigger_details.pop("_session_thread_id", None)
+        trigger_details.pop("_thread_id", None)
+        if feedback_policy(flow):
+            trigger_details["_session_thread_id"] = str(uuid.uuid4())
         pin_source_id = retry_of_execution_id or source_execution_id
         source_execution = None
         pin_kind = None
@@ -1578,6 +1586,8 @@ class FlowTriggerService:
             trigger_details = _make_json_serializable(trigger_details)
             from preloop.services.flow_feedback import feedback_policy
 
+            trigger_details.pop("_session_thread_id", None)
+            trigger_details.pop("_thread_id", None)
             if feedback_policy(flow):
                 trigger_details["_session_thread_id"] = str(uuid.uuid4())
             attach_trigger_subject(trigger_details)

--- a/backend/preloop/services/model_credentials.py
+++ b/backend/preloop/services/model_credentials.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Optional
 
 from sqlalchemy.orm import Session
 
+from preloop.api.loop_safety import run_db_off_loop
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.models.ai_model import AIModel
 from preloop.services.aux_model_retry import call_with_aux_retry
@@ -409,6 +410,9 @@ async def call_with_default_model_fallback(
         attempt_timeout: Optional per-attempt timeout in seconds. Each attempt gets its
                 own budget, so a slow primary still leaves room for the fallback. Callers
                 that wrap this in an overall deadline should pass roughly half of it.
+                Cancellation waits for the worker to finish using the shared
+                Session, so wall time can exceed this budget. Provider calls
+                must configure their own I/O timeout.
 
     Returns:
         The result of the caller, or None if both primary and fallback fail.
@@ -425,7 +429,9 @@ async def call_with_default_model_fallback(
         )
 
     async def _attempt(model: AIModel) -> Any:
-        coro = asyncio.to_thread(_resolve_and_call, model)
+        # Credential resolution and the caller share db. A timeout may not
+        # start fallback or close that Session before the worker relinquishes it.
+        coro = run_db_off_loop(lambda: _resolve_and_call(model))
         if attempt_timeout is None:
             return await coro
         return await asyncio.wait_for(coro, timeout=attempt_timeout)
@@ -461,8 +467,10 @@ async def call_with_default_model_fallback(
                 return None
 
         # Get the system-wide default model.
-        system_default = crud_ai_model.get_default_active_model(
-            db, account_id=None, model_kind="llm"
+        system_default = await run_db_off_loop(
+            lambda: crud_ai_model.get_default_active_model(
+                db, account_id=None, model_kind="llm"
+            )
         )
 
         if not system_default:

--- a/backend/preloop/services/model_gateway_auth.py
+++ b/backend/preloop/services/model_gateway_auth.py
@@ -52,7 +52,16 @@ async def authenticate_bearer_token(
     if not token:
         return None
 
+    from preloop.api.loop_safety import run_db_off_loop
+
     user = await get_user_from_token_if_valid(token, db)
+    return await run_db_off_loop(lambda: _resolve_bearer_context(token, db, user))
+
+
+def _resolve_bearer_context(
+    token: str, db: Session, user: Optional[User]
+) -> Optional[ModelGatewayAuthContext]:
+    """Resolve remaining gateway credentials on the session's worker thread."""
     if user:
         api_key = crud_api_key.get_by_key(db, key=token)
         if api_key is not None:

--- a/backend/preloop/services/secret_service.py
+++ b/backend/preloop/services/secret_service.py
@@ -568,6 +568,8 @@ class SecretService:
                     if isinstance(decoded, dict):
                         payload = decoded
                 except (TypeError, ValueError, json.JSONDecodeError):
+                    # Keep the caller's fallback when the locked row is not
+                    # valid JSON (corrupt ciphertext or a non-object payload).
                     pass
             needs_refresh = refresh_required(payload) and bool(
                 str(payload.get("refresh") or "").strip()

--- a/backend/preloop/services/secret_service.py
+++ b/backend/preloop/services/secret_service.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 import logging
-from typing import Any, Dict, Optional, Protocol
+from typing import Any, Callable, Dict, Optional, Protocol
 from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
@@ -17,9 +17,12 @@ from sqlalchemy.orm import Session
 
 from preloop.config import settings
 from preloop.models.crud.secret_reference import crud_secret_reference
-from preloop.models.models.ai_model import AIModel
-from preloop.models.models.secret_reference import SecretReference
+from preloop.models import models
+
 from preloop.utils.encryption import decrypt_value, encrypt_value
+
+AIModel = models.AIModel
+SecretReference = models.SecretReference
 
 logger = logging.getLogger(__name__)
 
@@ -544,6 +547,8 @@ class SecretService:
         db: Session,
         secret_ref: SecretReference,
         fallback: Dict[str, Any],
+        *,
+        refresh_required: Callable[[Dict[str, Any]], bool],
     ) -> Dict[str, Any]:
         """Serialize OAuth refreshes on the secret row across workers.
 
@@ -554,19 +559,24 @@ class SecretService:
         already rotated the bundle while we waited, callers must use its
         result instead of refreshing again.
         """
-        locked = (
-            db.query(SecretReference)
-            .filter(SecretReference.id == secret_ref.id)
-            .with_for_update()
-            .one_or_none()
+
+        def inspect(locked: Optional[SecretReference]) -> tuple[Dict[str, Any], bool]:
+            payload = fallback
+            if locked is not None and locked.encrypted_value:
+                try:
+                    decoded = json.loads(decrypt_value(locked.encrypted_value))
+                    if isinstance(decoded, dict):
+                        payload = decoded
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    pass
+            needs_refresh = refresh_required(payload) and bool(
+                str(payload.get("refresh") or "").strip()
+            )
+            return payload, needs_refresh
+
+        return crud_secret_reference.inspect_for_refresh(
+            db, secret_id=secret_ref.id, inspect=inspect
         )
-        if locked is None or not locked.encrypted_value:
-            return fallback
-        try:
-            payload = json.loads(decrypt_value(locked.encrypted_value))
-        except (TypeError, ValueError, json.JSONDecodeError):
-            return fallback
-        return payload if isinstance(payload, dict) else fallback
 
     def _refresh_openai_codex_ai_model_credentials(
         self,
@@ -581,7 +591,10 @@ class SecretService:
             and ai_model.credentials_secret.backend_type == LOCAL_ENCRYPTED_BACKEND
         ):
             payload = self._lock_and_reload_oauth_payload(
-                db, ai_model.credentials_secret, payload
+                db,
+                ai_model.credentials_secret,
+                payload,
+                refresh_required=self._openai_codex_refresh_required,
             )
             if not self._openai_codex_refresh_required(payload):
                 return payload
@@ -661,7 +674,10 @@ class SecretService:
             and ai_model.credentials_secret.backend_type == LOCAL_ENCRYPTED_BACKEND
         ):
             payload = self._lock_and_reload_oauth_payload(
-                db, ai_model.credentials_secret, payload
+                db,
+                ai_model.credentials_secret,
+                payload,
+                refresh_required=self._anthropic_claude_code_refresh_required,
             )
             if not self._anthropic_claude_code_refresh_required(payload):
                 return payload

--- a/backend/preloop/sync/exceptions.py
+++ b/backend/preloop/sync/exceptions.py
@@ -51,6 +51,10 @@ class TrackerResponseError(TrackerError):
     pass
 
 
+class TrackerPermissionError(TrackerResponseError):
+    """Provider explicitly denied permission, excluding throttling/auth failures."""
+
+
 class EmbeddingError(PreloopSyncError):
     """Raised when there's an issue with generating embeddings."""
 

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -31,6 +31,7 @@ from ..exceptions import (
     TrackerAuthenticationError,
     TrackerConnectionError,
     TrackerResponseError,
+    TrackerPermissionError,
 )
 from .base import BaseTracker
 from .utils import (
@@ -255,7 +256,27 @@ class GitHubTracker(BaseTracker):
                 if response.status_code == HTTP_STATUS_UNAUTHORIZED:
                     raise TrackerAuthenticationError("GitHub authentication failed")
                 elif response.status_code >= 400:
-                    raise TrackerResponseError(
+                    denied = False
+                    if (
+                        response.status_code == 403
+                        and response.headers.get("x-ratelimit-remaining") != "0"
+                        and not response.headers.get("retry-after")
+                    ):
+                        try:
+                            message = (
+                                response.json().get("message", "").rstrip(".").lower()
+                            )
+                            denied = message in {
+                                "resource not accessible by integration",
+                                "resource not accessible by personal access token",
+                                "must have admin rights to repository",
+                            }
+                        except (ValueError, AttributeError):
+                            pass
+                    error_type = (
+                        TrackerPermissionError if denied else TrackerResponseError
+                    )
+                    raise error_type(
                         f"GitHub API error: {response.status_code} - {response.text}"
                     )
                 return response.json(), dict(response.headers)
@@ -481,6 +502,7 @@ class GitHubTracker(BaseTracker):
             TrackerAuthenticationError,
             TrackerConnectionError,
             TrackerResponseError,
+            TrackerPermissionError,
         ) as e:
             return TrackerConnection(connected=False, message=str(e))
 

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -272,6 +272,8 @@ class GitHubTracker(BaseTracker):
                                 "must have admin rights to repository",
                             }
                         except (ValueError, AttributeError):
+                            # Malformed responses do not establish permission
+                            # denial; retain the generic tracker response error.
                             pass
                     error_type = (
                         TrackerPermissionError if denied else TrackerResponseError

--- a/backend/tests/endpoints/test_agent_control_lock_order.py
+++ b/backend/tests/endpoints/test_agent_control_lock_order.py
@@ -1,0 +1,139 @@
+"""Presence updates and operator lifecycle changes use the same row-lock order."""
+
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from threading import Event
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import Engine, event, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from preloop.api.auth.jwt import RuntimeBearerAuthContext
+from preloop.api.endpoints.agent_control import _touch_presence
+from preloop.models import models
+from preloop.models.crud import crud_managed_agent, crud_runtime_session
+
+
+@pytest.fixture
+def presence_scope(db_engine: Engine) -> Iterator[tuple[UUID, UUID, UUID]]:
+    """Commit one synthetic active agent and its runtime session."""
+    old = datetime.now(UTC) - timedelta(minutes=5)
+    with Session(db_engine) as db:
+        account = models.Account(organization_name="Presence lock test")
+        db.add(account)
+        db.flush()
+        runtime = models.RuntimeSession(
+            account_id=account.id,
+            session_source_type="test",
+            session_source_id=str(uuid4()),
+            started_at=old,
+            last_activity_at=old,
+        )
+        db.add(runtime)
+        db.flush()
+        agent = models.ManagedAgent(
+            account_id=account.id,
+            runtime_session_id=runtime.id,
+            agent_kind="test",
+            session_source_type=runtime.session_source_type,
+            session_source_id=runtime.session_source_id,
+            display_name="Synthetic agent",
+            lifecycle_state="active",
+            lifecycle_updated_at=old,
+            last_seen_at=old,
+        )
+        db.add(agent)
+        db.flush()
+        scope = (account.id, runtime.id, agent.id)
+        db.commit()
+    try:
+        yield scope
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.ManagedAgent).filter_by(id=scope[2]).delete()
+            db.query(models.RuntimeSession).filter_by(id=scope[1]).delete()
+            db.query(models.Account).filter_by(id=scope[0]).delete()
+            db.commit()
+
+
+def test_heartbeat_does_not_hold_runtime_while_waiting_for_operator_agent_lock(
+    db_engine: Engine, presence_scope: tuple[UUID, UUID, UUID]
+) -> None:
+    """Run actual heartbeat CRUD against the operator's agent-then-runtime path."""
+    account_id, runtime_id, agent_id = presence_scope
+    heartbeat_requests_agent = Event()
+    observed_at = datetime.now(UTC)
+
+    def heartbeat() -> None:
+        with Session(db_engine) as db:
+            db.execute(text("SET LOCAL lock_timeout = '3s'"))
+            runtime = db.get(models.RuntimeSession, runtime_id)
+            agent = db.get(models.ManagedAgent, agent_id)
+            assert runtime is not None and agent is not None
+            context = RuntimeBearerAuthContext(
+                user=models.User(),
+                api_key=None,
+                runtime_session=runtime,
+                managed_agent=agent,
+            )
+
+            def before_update(
+                connection: Any,
+                cursor: Any,
+                statement: str,
+                parameters: Any,
+                context: Any,
+                executemany: bool,
+            ) -> None:
+                if statement.lower().startswith("update managed_agent "):
+                    heartbeat_requests_agent.set()
+
+            event.listen(db.connection(), "before_cursor_execute", before_update)
+            _touch_presence(db, context, observed_at=observed_at, session_mode="remote")
+
+    conflict = None
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        with Session(db_engine) as operator:
+            # Same order as update_account_managed_agent: agent first, then
+            # the bound runtime when decommissioning. Roll back the probe so
+            # heartbeat assertions remain independent of lifecycle transitions.
+            crud_managed_agent.get_for_account(
+                operator,
+                account_id=str(account_id),
+                agent_id=str(agent_id),
+                for_update=True,
+            )
+            pending = executor.submit(heartbeat)
+            try:
+                assert heartbeat_requests_agent.wait(timeout=2), (
+                    "Heartbeat never requested the agent lock"
+                )
+                operator.execute(text("SET LOCAL lock_timeout = '250ms'"))
+                try:
+                    crud_runtime_session.update_operator_state(
+                        operator,
+                        account_id=str(account_id),
+                        runtime_session_id=str(runtime_id),
+                        ended_at=observed_at,
+                        commit=False,
+                    )
+                except OperationalError as exc:
+                    conflict = exc
+            finally:
+                operator.rollback()
+            pending.result(timeout=4)
+    assert conflict is None, (
+        "Heartbeat held the runtime lock while waiting for the operator's agent lock"
+    )
+    with Session(db_engine) as db:
+        runtime = db.get(models.RuntimeSession, runtime_id)
+        agent = db.get(models.ManagedAgent, agent_id)
+        assert runtime is not None and agent is not None
+        assert runtime.last_activity_at.replace(tzinfo=UTC) == observed_at
+        assert agent.control_last_heartbeat_at.replace(tzinfo=UTC) == observed_at
+        assert agent.control_session_mode == "remote"
+        assert agent.lifecycle_state == "active"

--- a/backend/tests/endpoints/test_agent_permission_check.py
+++ b/backend/tests/endpoints/test_agent_permission_check.py
@@ -9,8 +9,24 @@ permission service unchanged, and stamps it into ``tool_input`` as the
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
 PERMISSION_CHECK_URL = "/api/v1/agents/permission-check"
 TOKEN_URL = "/api/v1/auth/runtime-sessions/token"
+
+
+@pytest.fixture(autouse=True)
+def permission_identity_session(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Worker owns its Session while sharing the test's rollback transaction."""
+    factory = sessionmaker(
+        bind=db_session.connection(), join_transaction_mode="create_savepoint"
+    )
+    monkeypatch.setattr(
+        "preloop.api.endpoints.agent_permission.get_session_factory", lambda: factory
+    )
 
 
 def _issue_opencode_runtime_token(client) -> str:

--- a/backend/tests/endpoints/test_agent_permission_session.py
+++ b/backend/tests/endpoints/test_agent_permission_session.py
@@ -1,0 +1,218 @@
+"""Native permission authentication must release DB resources before human waits."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from typing import Any, Iterator
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import Engine, delete
+from sqlalchemy.orm import Session, sessionmaker
+
+from preloop.api.endpoints import agent_permission as endpoint
+from preloop.models import models
+from preloop.models.crud import (
+    crud_account,
+    crud_api_key,
+    crud_managed_agent,
+    crud_user,
+)
+
+
+@pytest.fixture
+def permission_credential(
+    db_engine: Engine, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[dict]:
+    """Commit an isolated identity so worker-owned connections can authenticate it."""
+    factory = sessionmaker(bind=db_engine)
+    unique = uuid4().hex
+    with factory() as db:
+        account = crud_account.create(db, obj_in={"organization_name": unique})
+        account_id = account.id
+        user = crud_user.create(
+            db,
+            obj_in={
+                "account_id": account_id,
+                "email": f"{unique}@example.com",
+                "username": unique,
+                "hashed_password": "unused-test-password",
+                "is_active": True,
+                "email_verified": True,
+            },
+        )
+        now = datetime.now(timezone.utc)
+        agent = crud_managed_agent.create(
+            db,
+            obj_in={
+                "account_id": account_id,
+                "owner_user_id": user.id,
+                "agent_kind": "opencode",
+                "session_source_type": "opencode",
+                "session_source_id": unique,
+                "display_name": "Permission test agent",
+                "lifecycle_updated_at": now,
+                "last_seen_at": now,
+            },
+        )
+        key, token = crud_api_key.create_runtime_key(
+            db,
+            name=unique,
+            account_id=account_id,
+            user_id=user.id,
+            context_data={"managed_agent_id": str(agent.id)},
+        )
+        identity = {
+            "account_id": account_id,
+            "user_id": user.id,
+            "agent_id": agent.id,
+            "key_id": key.id,
+            "token": token,
+        }
+    monkeypatch.setattr(endpoint, "get_session_factory", lambda: factory)
+    monkeypatch.setattr(endpoint.settings, "preloop_url", "https://example.invalid")
+    try:
+        yield identity
+    finally:
+        with factory() as db:
+            db.execute(delete(models.Account).where(models.Account.id == account_id))
+            db.commit()
+
+
+@pytest.mark.asyncio
+async def test_permission_wait_releases_connection_and_keeps_scalar_identity(
+    db_engine: Engine, permission_credential: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    baseline = db_engine.pool.checkedout()
+    waiting, release = asyncio.Event(), asyncio.Event()
+    captured = {}
+
+    async def decide(**kwargs: Any) -> tuple[str, str, str, bool]:
+        captured.update(kwargs)
+        waiting.set()
+        await release.wait()
+        return "allow", "Approved", "request", False
+
+    monkeypatch.setattr(endpoint, "request_agent_permission", decide)
+    task = asyncio.create_task(
+        endpoint.agent_permission_check(
+            endpoint.AgentPermissionCheckRequest(tool_name="Bash"),
+            authorization="Bearer " + permission_credential["token"],
+        )
+    )
+    try:
+        await asyncio.wait_for(waiting.wait(), timeout=3)
+        assert not task.done()
+        assert db_engine.pool.checkedout() == baseline
+        assert captured["account_id"] == str(permission_credential["account_id"])
+        assert captured["user_id"] == permission_credential["user_id"]
+        assert captured["managed_agent_id"] == permission_credential["agent_id"]
+        assert captured["runtime_session_id"] is None
+        assert captured["managed_agent_name"] == "Permission test agent"
+        with Session(db_engine) as db:
+            key = crud_api_key.get(db, id=permission_credential["key_id"])
+            assert key.last_used_at is not None
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=3)
+
+
+@pytest.mark.asyncio
+async def test_blocked_credential_query_keeps_event_loop_responsive(
+    permission_credential: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    entered, release = asyncio.Event(), threading.Event()
+    real_get = crud_api_key.get_by_key
+    worker_threads = []
+
+    def blocked_get(db: Session, *, key: str) -> models.ApiKey | None:
+        worker_threads.append(threading.get_ident())
+        loop.call_soon_threadsafe(entered.set)
+        # Bounded even if the regression accidentally executes on the event loop.
+        release.wait(timeout=2)
+        return real_get(db, key=key)
+
+    monkeypatch.setattr(crud_api_key, "get_by_key", blocked_get)
+    monkeypatch.setattr(
+        endpoint,
+        "request_agent_permission",
+        AsyncMock(return_value=("deny", "No", None, False)),
+    )
+    task = asyncio.create_task(
+        endpoint.agent_permission_check(
+            endpoint.AgentPermissionCheckRequest(tool_name="Bash"),
+            authorization="Bearer " + permission_credential["token"],
+        )
+    )
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        assert len(worker_threads) == 1
+        assert worker_threads[0] != loop_thread
+        assert not task.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=3)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "revoked",
+        "expired",
+        "inactive_user",
+        "suspended_agent",
+        "foreign_agent",
+        "unbound",
+        "missing_runtime",
+    ],
+)
+def test_identity_auth_rejects_invalid_bindings_and_returns_connection(
+    invalid: str, db_engine: Engine, permission_credential: dict
+) -> None:
+    with Session(db_engine) as db:
+        key = crud_api_key.get(db, id=permission_credential["key_id"])
+        if invalid == "revoked":
+            key.is_active = False
+        elif invalid == "expired":
+            key.expires_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        elif invalid == "inactive_user":
+            crud_user.get(db, id=permission_credential["user_id"]).is_active = False
+        elif invalid == "suspended_agent":
+            crud_managed_agent.get(
+                db, id=permission_credential["agent_id"]
+            ).lifecycle_state = "suspended"
+        elif invalid == "foreign_agent":
+            # An existing agent in another account cannot satisfy this key's binding.
+            other = crud_account.create(db, obj_in={"organization_name": uuid4().hex})
+            key.account_id = other.id
+            other_id = other.id
+        elif invalid == "unbound":
+            key.context_data = {}
+        else:
+            key.context_data = {**key.context_data, "runtime_session_id": str(uuid4())}
+        db.commit()
+    baseline = db_engine.pool.checkedout()
+    try:
+        with pytest.raises(HTTPException) as error:
+            endpoint._resolve_permission_identity(permission_credential["token"])
+        assert error.value.status_code == 401
+        assert error.value.headers == {"WWW-Authenticate": "Bearer"}
+        assert db_engine.pool.checkedout() == baseline
+    finally:
+        if invalid == "foreign_agent":
+            with Session(db_engine) as db:
+                db.execute(delete(models.Account).where(models.Account.id == other_id))
+                db.commit()
+
+
+def test_identity_snapshot_is_immutable(permission_credential: dict) -> None:
+    identity = endpoint._resolve_permission_identity(permission_credential["token"])
+    with pytest.raises(FrozenInstanceError):
+        identity.account_id = "different-account"

--- a/backend/tests/helm/test_native_checkpoint_overlay.py
+++ b/backend/tests/helm/test_native_checkpoint_overlay.py
@@ -1,0 +1,57 @@
+"""Native checkpoint deployment uses existing shared env without changing defaults."""
+
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.helm.chart_helpers import CHART_DIR, helm_template, load_values
+
+OVERLAY = "values-native-checkpoints.yaml"
+
+
+def test_checkpoint_defaults_remain_disabled() -> None:
+    assert not any(
+        item["name"] == "FLOW_ARTIFACT_DIRECT_UPLOAD"
+        for item in load_values()["extraEnv"]
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "templates/api-deployment.yaml",
+        "templates/gateway-deployment.yaml",
+        "templates/spacesync-worker-deployment.yaml",
+        "templates/spacesync-scheduler-deployment.yaml",
+    ],
+)
+def test_checkpoint_overlay_reaches_api_and_execution_workers(template: str) -> None:
+    documents = list(
+        yaml.safe_load_all(helm_template(template, values_files=[OVERLAY]))
+    )
+    assert documents
+    signing_refs: list[dict[str, Any]] = []
+    for document in documents:
+        for container in document["spec"]["template"]["spec"]["containers"]:
+            env_items = container["env"]
+            env = {item["name"]: item for item in env_items}
+            assert len(env) == len(env_items)
+            assert env["FLOW_ARTIFACT_DIRECT_UPLOAD"]["value"] == "true"
+            assert env["WORKSPACE_SNAPSHOT_MAX_BYTES"]["value"] == "16777216"
+            assert env["FLOW_NATIVE_SESSION_RETENTION_HOURS"]["value"] == "168"
+            assert env["WORKSPACE_SNAPSHOT_TTL_HOURS"]["value"] == "168"
+            signing_refs.append(env["SECRET_KEY"]["valueFrom"])
+    assert all(
+        ref == {"secretKeyRef": {"name": "preloop", "key": "jwt-secret"}}
+        for ref in signing_refs
+    )
+
+
+def test_checkpoint_overlay_preserves_keys_and_proxy_limits() -> None:
+    overlay = yaml.safe_load((CHART_DIR / OVERLAY).read_text())
+    assert set(overlay) == {"extraEnv"}
+    env = {item["name"]: item for item in overlay["extraEnv"]}
+    assert "SECRET_KEY" not in env and "SECURITY__ENCRYPTION_KEY" not in env
+    assert load_values()["gateway"]["proxy"]["bodySize"] == "32m"
+    assert int(env["WORKSPACE_SNAPSHOT_MAX_BYTES"]["value"]) < 32 * 1024**2

--- a/backend/tests/models/test_flow_artifact_lock_compatibility.py
+++ b/backend/tests/models/test_flow_artifact_lock_compatibility.py
@@ -1,0 +1,112 @@
+"""Artifact quota locks must exclude writers without blocking audit foreign keys."""
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import Engine, event, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+from preloop.models.crud import crud_account_halt, crud_audit_log
+from preloop.models.crud import flow_artifact
+
+
+@pytest.fixture
+def artifact_values(db_engine: Engine) -> Iterator[dict[str, Any]]:
+    """Commit synthetic parents for independent transaction visibility."""
+    with Session(db_engine) as db:
+        account = models.Account(organization_name="Artifact lock test")
+        db.add(account)
+        db.flush()
+        flow = models.Flow(
+            account_id=account.id,
+            name="Artifact lock test",
+            prompt_template="test",
+            agent_type="codex",
+            agent_config={},
+        )
+        db.add(flow)
+        db.flush()
+        execution = models.FlowExecution(flow_id=flow.id, status="RUNNING")
+        db.add(execution)
+        db.flush()
+        values = {
+            "account_id": account.id,
+            "flow_id": flow.id,
+            "execution_id": execution.id,
+            "thread_id": str(uuid4()),
+            "kind": "workspace",
+            "manifest": {},
+            "manifest_sha256": "0" * 64,
+            "ciphertext": b"synthetic",
+            "expires_at": datetime.now(UTC) + timedelta(hours=1),
+        }
+        db.commit()
+    try:
+        yield values
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.FlowArtifact).filter_by(
+                account_id=values["account_id"]
+            ).delete()
+            db.query(models.FlowExecution).filter_by(id=values["execution_id"]).delete()
+            db.query(models.Flow).filter_by(id=values["flow_id"]).delete()
+            db.query(models.Account).filter_by(id=values["account_id"]).delete()
+            db.commit()
+
+
+def test_artifact_store_allows_concurrent_audit_insert(
+    db_engine: Engine, artifact_values: dict[str, Any]
+) -> None:
+    """Exercise actual store CRUD while a child insert uses another connection."""
+    audit_ids = []
+    with Session(db_engine) as storage, Session(db_engine) as audit:
+
+        def insert_audit_after_lock(
+            connection: Any,
+            cursor: Any,
+            statement: str,
+            parameters: Any,
+            context: Any,
+            executemany: bool,
+        ) -> None:
+            # The quota aggregate runs after store acquires the account lock.
+            if "sum(octet_length(" not in statement.lower():
+                return
+            audit.execute(text("SET LOCAL lock_timeout = '250ms'"))
+            entry = crud_audit_log.log_action(
+                audit,
+                account_id=artifact_values["account_id"],
+                action="artifact_checkpoint",
+                resource_type="flow_execution",
+                status="success",
+            )
+            audit_ids.append(entry.id)
+
+        event.listen(
+            storage.connection(), "before_cursor_execute", insert_audit_after_lock
+        )
+        artifact = flow_artifact.store(storage, values=artifact_values, quota_bytes=100)
+        assert artifact.id is not None
+        assert len(audit_ids) == 1
+
+
+def test_artifact_store_serializes_writers_and_rechecks_quota(
+    db_engine: Engine, artifact_values: dict[str, Any]
+) -> None:
+    """A contender cannot bypass admission or reuse an out-of-date quota total."""
+    with Session(db_engine) as owner, Session(db_engine) as contender:
+        crud_account_halt.lock_account(owner, account_id=artifact_values["account_id"])
+        contender.execute(text("SET LOCAL lock_timeout = '250ms'"))
+        with pytest.raises(OperationalError, match="lock timeout"):
+            flow_artifact.store(contender, values=artifact_values, quota_bytes=10)
+        contender.rollback()
+        owner.rollback()
+        flow_artifact.store(contender, values=artifact_values, quota_bytes=10)
+        with pytest.raises(ValueError, match="artifact_quota_exceeded"):
+            flow_artifact.store(contender, values=artifact_values, quota_bytes=10)
+        contender.rollback()

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -3839,8 +3839,10 @@ async def test_create_and_notify_owns_summary_session_until_finished(
         )
         if outcome == "cancelled":
             with pytest.raises(asyncio.CancelledError):
-                await operation
+                cancelled = await operation
+                raise AssertionError(f"canceled notify returned {cancelled!r}")
         else:
-            await operation
+            created = await operation
+            assert created is sample_approval_request
     assert phases == ["created", "summary", "closed"]
     assert all(thread != loop_thread for thread in worker_threads)

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -5,6 +5,8 @@ import uuid
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from sqlalchemy import Engine
 
 import pytest
 from preloop.models.models import ApprovalWorkflow, ApprovalRequest
@@ -1706,8 +1708,8 @@ class TestCreateAndNotify:
                 return_value={},
             ) as mock_send_notifications,
             patch(
-                "preloop.models.db.session.get_db_session",
-                return_value=iter([sync_db]),
+                "preloop.models.db.session.get_session_factory",
+                return_value=MagicMock(return_value=sync_db),
             ),
             patch(
                 "preloop.services.approval_summary.generate_approval_summary",
@@ -3768,3 +3770,77 @@ class TestNotificationStagger:
             c for c in mock_audit.call_args_list if c.kwargs.get("channel") == "email"
         ]
         assert any(c.kwargs.get("status") == "scheduled" for c in email_audits)
+
+
+@pytest.mark.parametrize("outcome", ["success", "failure", "cancelled"])
+async def test_create_and_notify_owns_summary_session_until_finished(
+    db_engine: Engine,
+    approval_service: ApprovalService,
+    sample_approval_request: MagicMock,
+    sample_approval_workflow: MagicMock,
+    outcome: str,
+) -> None:
+    """Summary gets an open owned Session, closed once off-loop on every exit."""
+    import asyncio
+    import threading
+    from sqlalchemy import select
+    from sqlalchemy.orm import Session
+    from preloop.api.loop_safety import run_db_off_loop
+
+    phases: list[str] = []
+    worker_threads: list[int] = []
+    loop_thread = threading.get_ident()
+
+    class OwnedSession(Session):
+        def close(self) -> None:
+            phases.append("closed")
+            worker_threads.append(threading.get_ident())
+            super().close()
+
+    def create_session() -> Session:
+        phases.append("created")
+        worker_threads.append(threading.get_ident())
+        return OwnedSession(db_engine, close_resets_only=False)
+
+    async def generate(db: Session, **kwargs: Any) -> None:
+        phases.append("summary")
+        assert await run_db_off_loop(lambda: db.execute(select(1)).scalar_one()) == 1
+        if outcome == "failure":
+            raise RuntimeError("local summary failure")
+        if outcome == "cancelled":
+            raise asyncio.CancelledError()
+
+    with (
+        patch(
+            "preloop.models.db.session.get_session_factory", return_value=create_session
+        ),
+        patch(
+            "preloop.services.approval_summary.generate_approval_summary",
+            side_effect=generate,
+        ),
+        patch.object(
+            approval_service,
+            "create_approval_request",
+            return_value=sample_approval_request,
+        ),
+        patch.object(
+            approval_service,
+            "_auto_approve_without_review",
+            return_value=sample_approval_request,
+        ),
+    ):
+        operation = approval_service.create_and_notify(
+            account_id="local-test",
+            tool_configuration_id=uuid.uuid4(),
+            approval_workflow=sample_approval_workflow,
+            tool_name="Read",
+            tool_args={},
+            standing_bypass_reason="native_tool_approvals_off",
+        )
+        if outcome == "cancelled":
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+        else:
+            await operation
+    assert phases == ["created", "summary", "closed"]
+    assert all(thread != loop_thread for thread in worker_threads)

--- a/backend/tests/services/test_flow_continuation_adoption.py
+++ b/backend/tests/services/test_flow_continuation_adoption.py
@@ -1,0 +1,228 @@
+"""Selected-publication adoption guards and bounded read-only preflight."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from preloop.schemas.flow_continuation import (
+    ContinuationAdoptRequest,
+    ContinuationPreview,
+)
+from preloop.services import flow_continuation_adoption as service
+from preloop.services.flow_feedback_provider import FeedbackState
+
+
+def preview(**changes: object) -> ContinuationPreview:
+    return ContinuationPreview(
+        **{
+            "execution_id": uuid4(),
+            "flow_id": uuid4(),
+            "pr_url": "https://github.com/a/b/pull/474",
+            "branch": "fix/474",
+            "head_sha": "a" * 40,
+            "feedback_enabled": True,
+            "artifact_upload_enabled": True,
+            "feedback_readable": True,
+            "native_resume_available": False,
+            "allowed_recovery_modes": ["published_branch_handoff"],
+            "warnings": [],
+            **changes,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "changes,body_changes,reason",
+    [
+        ({}, {"expected_head_sha": "b" * 40}, "head changed"),
+        ({"feedback_enabled": False}, {}, "must be enabled"),
+        ({"artifact_upload_enabled": False}, {}, "must be enabled"),
+        ({"feedback_readable": False}, {}, "cannot read"),
+        ({}, {"recovery_mode": "native_resume"}, "unavailable"),
+        ({}, {"acknowledge_fresh_conversation": False}, "Acknowledge"),
+    ],
+)
+def test_adoption_preconditions_do_not_open_write_session(
+    changes: dict, body_changes: dict, reason: str
+) -> None:
+    readiness = preview(**changes)
+    body = ContinuationAdoptRequest(
+        **{
+            "expected_head_sha": "a" * 40,
+            "recovery_mode": "published_branch_handoff",
+            "acknowledge_fresh_conversation": True,
+            **body_changes,
+        }
+    )
+    with (
+        patch.object(service, "preview_continuation", return_value=readiness),
+        patch.object(service, "get_session_factory") as factory,
+    ):
+        with pytest.raises(service.ContinuationAdoptionError, match=reason) as error:
+            service.adopt_continuation(uuid4(), readiness.execution_id, body)
+        assert error.value.status_code == 409
+        factory.assert_not_called()
+
+
+def test_cross_account_source_is_not_found() -> None:
+    account, execution = uuid4(), uuid4()
+    factory = MagicMock()
+    with (
+        patch.object(service, "get_session_factory", return_value=factory),
+        patch.object(service.crud_flow_execution, "get", return_value=None) as get,
+    ):
+        with pytest.raises(service.ContinuationAdoptionError) as error:
+            service._load_source(account, execution)
+        assert error.value.status_code == 404
+        assert get.call_args.kwargs == {"id": execution, "account_id": account}
+
+
+@pytest.mark.parametrize("status", ["FAILED", "RUNNING", "PENDING", "TIMED_OUT"])
+def test_only_successful_publisher_can_be_selected(status: str) -> None:
+    account, execution = uuid4(), uuid4()
+    flow = SimpleNamespace(id=uuid4(), account_id=account)
+    row = SimpleNamespace(flow_id=flow.id, status=status)
+    with (
+        patch.object(service, "get_session_factory", return_value=MagicMock()),
+        patch.object(service.crud_flow_execution, "get", return_value=row),
+        patch.object(service.crud_flow, "get", return_value=flow),
+    ):
+        with pytest.raises(service.ContinuationAdoptionError, match="successful"):
+            service._load_source(account, execution)
+
+
+@pytest.mark.asyncio
+async def test_preflight_detects_closed_pr_and_permission_failure() -> None:
+    source = {"provider": "github", "repository_id": "1", "number": "474", "policy": {}}
+    client = service._BoundedReadClient(MagicMock())
+    with patch.object(
+        service.FeedbackProvider,
+        "read",
+        AsyncMock(return_value=FeedbackState("head", closed=True)),
+    ):
+        result = await service._feedback_preflight(
+            client, source, {"open": True, "head_sha": "head"}
+        )
+        assert result["open"] is False
+    with patch.object(
+        service.FeedbackProvider, "read", AsyncMock(side_effect=ValueError("secret"))
+    ):
+        result = await service._feedback_preflight(
+            client, source, {"open": True, "head_sha": "head"}
+        )
+        assert result["feedback_readable"] is False
+        assert "secret" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_preflight_caps_requests_and_disallows_provider_writes() -> None:
+    raw = SimpleNamespace(_request=AsyncMock(return_value={}))
+    client = service._BoundedReadClient(raw)
+    for _ in range(12):
+        await client._request("GET", "/pulls/474")
+    with pytest.raises(service.ContinuationAdoptionError, match="limit"):
+        await client._request("GET", "/pulls/474")
+    assert raw._request.await_count == 12
+    with pytest.raises(service.ContinuationAdoptionError, match="reads only"):
+        await service._BoundedReadClient(raw)._request("POST", "/issues/474/comments")
+
+
+@pytest.mark.parametrize(
+    "route", ["preview_execution_continuation", "adopt_execution_continuation"]
+)
+def test_endpoints_release_auth_transaction_before_provider_and_sanitize_error(
+    route: str,
+) -> None:
+    from preloop.api.endpoints import flows
+
+    db, account, execution = MagicMock(), uuid4(), uuid4()
+    user = SimpleNamespace(account_id=account)
+    function = (
+        flows.preview_continuation
+        if route.startswith("preview")
+        else flows.adopt_continuation
+    )
+    del function
+    target = (
+        "preview_continuation" if route.startswith("preview") else "adopt_continuation"
+    )
+
+    def call(*args: object) -> None:
+        db.commit.assert_called_once()
+        assert args[:2] == (account, execution)
+        raise service.ContinuationAdoptionError("Selected publication changed")
+
+    args = {"db": db, "current_user": user, "execution_id": execution}
+    if route.startswith("adopt"):
+        args["request"] = ContinuationAdoptRequest(
+            recovery_mode="published_branch_handoff", expected_head_sha="a" * 40
+        )
+    with patch.object(flows, target, side_effect=call):
+        with pytest.raises(HTTPException) as error:
+            getattr(flows, route)(**args)
+        assert error.value.status_code == 409
+        assert error.value.detail == "Selected publication changed"
+
+
+@pytest.mark.parametrize("auth_type", ["github_app", "oauth_app"])
+def test_app_tracker_configuration_uses_scoped_external_installation(
+    auth_type: str,
+) -> None:
+    from preloop.services import flow_feedback_provider as provider
+
+    installation_id, account_id = uuid4(), uuid4()
+    tracker = SimpleNamespace(
+        tracker_type="github",
+        auth_type=auth_type,
+        oauth_installation_id=installation_id,
+        account_id=account_id,
+        url="https://api.github.com",
+        connection_details={"auth_type": "api_token", "github_installation_id": 999},
+    )
+    db = MagicMock()
+    with patch.object(
+        provider.crud_oauth_app_installation,
+        "get_by_id_provider_and_account",
+        return_value=SimpleNamespace(external_id=123),
+    ) as get:
+        options = provider.feedback_tracker_options(db, tracker)
+    assert options["auth_type"] == auth_type
+    assert options["github_installation_id"] == 123
+    get.assert_called_once_with(
+        db, id=installation_id, provider="github", account_id=account_id
+    )
+    with patch.object(
+        provider.crud_oauth_app_installation,
+        "get_by_id_provider_and_account",
+        return_value=None,
+    ):
+        with pytest.raises(ValueError, match="installation unavailable"):
+            provider.feedback_tracker_options(db, tracker)
+
+
+def test_pat_tracker_cannot_inherit_another_installation_from_json() -> None:
+    from preloop.services.flow_feedback_provider import feedback_tracker_options
+
+    tracker = SimpleNamespace(
+        tracker_type="github",
+        auth_type="api_token",
+        url="https://api.github.com",
+        connection_details={"auth_type": "github_app", "github_installation_id": 999},
+    )
+    assert feedback_tracker_options(MagicMock(), tracker) == {
+        "auth_type": "api_token",
+        "url": "https://api.github.com",
+    }
+
+
+def test_missing_app_configuration_is_a_sanitized_precondition() -> None:
+    with patch.object(
+        service, "_load_source", side_effect=ValueError("private auth details")
+    ):
+        with pytest.raises(service.ContinuationAdoptionError) as error:
+            service.preview_continuation(uuid4(), uuid4())
+    assert error.value.status_code == 409
+    assert str(error.value) == "Execution tracker configuration is unavailable"

--- a/backend/tests/services/test_flow_continuation_adoption.py
+++ b/backend/tests/services/test_flow_continuation_adoption.py
@@ -226,3 +226,18 @@ def test_missing_app_configuration_is_a_sanitized_precondition() -> None:
             service.preview_continuation(uuid4(), uuid4())
     assert error.value.status_code == 409
     assert str(error.value) == "Execution tracker configuration is unavailable"
+
+
+@pytest.mark.asyncio
+async def test_gitlab_preflight_rejects_non_get_methods() -> None:
+    gl = SimpleNamespace(http_get=object(), http_post=object())
+    raw = SimpleNamespace(gl=gl, _make_request=AsyncMock(return_value={"id": 474}))
+    client = service._BoundedReadClient(raw)
+    assert await client._make_request(
+        gl.http_get, "/projects/1/merge_requests/474"
+    ) == {"id": 474}
+    with pytest.raises(service.ContinuationAdoptionError, match="reads only"):
+        await client._make_request(gl.http_post, "/projects/1/merge_requests/474/notes")
+    raw._make_request.assert_awaited_once_with(
+        gl.http_get, "/projects/1/merge_requests/474"
+    )

--- a/backend/tests/services/test_flow_feedback_durable.py
+++ b/backend/tests/services/test_flow_feedback_durable.py
@@ -118,7 +118,7 @@ def test_register_thread_skips_non_uuid_tracker() -> None:
         id=uuid.uuid4(),
         account_id=uuid.uuid4(),
         trigger_event_source="webhook",
-        agent_config={"feedback": {"enabled": True}},
+        agent_config={"feedback": {"enabled": True, "debounce_seconds": 0}},
     )
     execution = SimpleNamespace(
         id=uuid.uuid4(),
@@ -186,6 +186,7 @@ def database() -> Generator[Engine, None, None]:
         models.FlowExecution.__table__.create(conn)
         models.FlowThread.__table__.create(conn)
         models.FlowFeedback.__table__.create(conn)
+        models.FlowArtifact.__table__.create(conn)
     try:
         yield engine
     finally:
@@ -214,7 +215,7 @@ def create_thread(db: Session) -> models.FlowThread:
         name="implementation",
         ai_model_id=model.id,
         agent_type="codex",
-        agent_config={"feedback": {"enabled": True}},
+        agent_config={"feedback": {"enabled": True, "debounce_seconds": 0}},
         prompt_template="repair",
         is_enabled=True,
     )
@@ -501,6 +502,9 @@ async def test_pg_worker_tick_recovers_discovery_and_debounces_feedback(
     with Session(database) as db:
         thread = create_thread(db)
         thread.policy = {"debounce_seconds": 30}
+        db.get(models.Flow, thread.flow_id).agent_config = {
+            "feedback": {"enabled": True, "debounce_seconds": 30}
+        }
         db.commit()
         provider = SimpleNamespace(
             read=AsyncMock(
@@ -566,3 +570,575 @@ async def test_pg_legacy_feedback_blocks_without_reserving_execution(
         assert thread.state == "blocked"
         assert thread.stop_reason == "model_identity_unavailable"
         assert thread.active_execution_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["disable", "revoke", "budget"])
+async def test_policy_changed_during_provider_read_cannot_reserve(
+    database: Engine, change: str
+) -> None:
+    """The operator edit commits while network I/O is in flight."""
+    with Session(database) as db, Session(database) as editor:
+        thread = create_thread(db)
+        flow_id = thread.flow_id
+
+        async def read() -> FeedbackState:
+            flow = editor.get(models.Flow, flow_id)
+            policy = dict(flow.agent_config["feedback"])
+            if change == "disable":
+                policy["enabled"] = False
+            elif change == "revoke":
+                policy["trusted_reviewer_ids"] = []
+            else:
+                policy["max_cost"] = 0.01
+            flow.agent_config = {"feedback": policy}
+            editor.commit()
+            return FeedbackState("head", feedback=[event("review")])
+
+        provider = SimpleNamespace(read=read)
+        with (
+            patch(
+                "preloop.services.flow_feedback.FeedbackProvider.for_thread",
+                AsyncMock(return_value=provider),
+            ),
+            patch(
+                "preloop.services.flow_execution_dispatcher.dispatch_execute",
+                AsyncMock(),
+            ) as dispatch,
+        ):
+            await _reconcile(db, *crud_flow_feedback.claim_due(db, now=NOW)[0], now=NOW)
+        db.refresh(thread)
+        assert thread.active_execution_id is None
+        assert thread.turns == 0
+        assert len(crud_flow_feedback.pending(db, thread.id)) == 1
+        dispatch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_feedback_pause_keeps_running_turn_and_reenable_keeps_budget(
+    database: Engine,
+) -> None:
+    with Session(database) as db:
+        thread = create_thread(db)
+        flow = db.get(models.Flow, thread.flow_id)
+        active = models.FlowExecution(
+            id=uuid.uuid4(), flow_id=flow.id, status="RUNNING"
+        )
+        db.add(active)
+        db.flush()
+        thread.active_execution_id = active.id
+        thread.turns, thread.cost, thread.no_progress = 2, 8.0, 1
+        deadline = thread.expires_at
+        flow.agent_config = {"feedback": {"enabled": False}}
+        db.commit()
+        with patch(
+            "preloop.services.flow_feedback.FeedbackProvider.for_thread"
+        ) as provider:
+            await _reconcile(db, *crud_flow_feedback.claim_due(db, now=NOW)[0], now=NOW)
+            provider.assert_not_called()
+        db.refresh(thread)
+        assert thread.state == "paused"
+        assert db.get(models.FlowExecution, active.id).status == "RUNNING"
+        assert (thread.turns, thread.cost, thread.no_progress) == (2, 8.0, 1)
+        assert thread.expires_at == deadline
+        crud_flow_feedback.sync_policy(
+            db, thread, {"enabled": True, "max_age_hours": 8760}
+        )
+        assert thread.expires_at == deadline
+        thread.created_at = NOW
+        db.commit()
+        crud_flow_feedback.sync_policy(
+            db, thread, {"enabled": True, "max_age_hours": 2}
+        )
+        assert thread.expires_at == NOW + timedelta(hours=2)
+        assert (thread.turns, thread.cost, thread.no_progress) == (2, 8.0, 1)
+
+
+def test_future_only_discovery_does_not_backfill_legacy_publication(
+    database: Engine,
+) -> None:
+    from preloop.services.flow_feedback import register_thread
+
+    with Session(database) as db:
+        thread = create_thread(db)
+        initial = db.get(models.FlowExecution, thread.latest_execution_id)
+        pr_url, branch = thread.pr_url, thread.branch
+        details = {
+            "source": "github",
+            "tracker_id": str(thread.tracker_id),
+            "payload": {"repository": {"id": "123"}},
+        }
+        initial.trigger_event_details = details
+        initial.result = {"pr_url": pr_url, "pr_source_branch": branch}
+        db.delete(thread)
+        db.commit()
+        assert crud_flow_feedback.unregistered_publications(db) == []
+        assert register_thread(db, initial, pr_url, branch) is None
+        initial.trigger_event_details = {
+            **details,
+            "_session_thread_id": str(uuid.uuid4()),
+        }
+        db.commit()
+        assert [x.id for x in crud_flow_feedback.unregistered_publications(db)] == [
+            initial.id
+        ]
+        registered = register_thread(db, initial, pr_url, branch)
+        assert registered is not None
+        assert crud_flow_feedback.unregistered_publications(db) == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_cold_source_reserves_once_then_requires_own_checkpoint(
+    database: Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from preloop.config import settings
+    from preloop.services.flow_feedback import resolve_native_checkpoint
+    from preloop.services.checkpoint_runtime import checkpoint_context
+    from preloop.agents.session_runtime import native_session_blocks
+
+    monkeypatch.setattr(settings, "flow_artifact_direct_upload", True)
+    with Session(database) as db:
+        thread = create_thread(db)
+        source_id = thread.latest_execution_id
+        thread.context = {
+            **thread.context,
+            "adoption": {
+                "source_execution_id": str(source_id),
+                "recovery_mode": "published_branch_handoff",
+            },
+        }
+        db.commit()
+        provider = SimpleNamespace(
+            read=AsyncMock(
+                return_value=FeedbackState(
+                    "head",
+                    feedback=[event("review"), event("review"), event("old", "stale")],
+                )
+            )
+        )
+        with (
+            patch(
+                "preloop.services.flow_feedback.FeedbackProvider.for_thread",
+                AsyncMock(return_value=provider),
+            ),
+            patch(
+                "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+                return_value=True,
+            ),
+            patch(
+                "preloop.services.flow_execution_dispatcher.dispatch_execute",
+                AsyncMock(),
+            ) as dispatch,
+        ):
+            await _reconcile(db, *crud_flow_feedback.claim_due(db, now=NOW)[0], now=NOW)
+            repair = db.get(models.FlowExecution, thread.active_execution_id)
+            assert repair is not None
+            assert len(repair.trigger_event_details["_feedback"]["items"]) == 1
+            resume = repair.trigger_event_details["_resume"]
+            assert "cli_session" not in resume
+            resolved = resolve_native_checkpoint(
+                db,
+                account_id=thread.account_id,
+                flow_id=thread.flow_id,
+                execution_id=repair.id,
+                resume=resume,
+            )
+            assert resolved == {"cold_handoff_authorized": True}
+            context = {
+                "account_id": str(thread.account_id),
+                "flow_id": str(thread.flow_id),
+                "execution_id": str(repair.id),
+                "trigger_event_data": repair.trigger_event_details,
+                "checkpoint_resume_authorized": True,
+                "published_branch_handoff_authorized": True,
+            }
+            with patch(
+                "preloop.api.endpoints.flow_artifacts.mint_artifact_capability",
+                return_value="scoped",
+            ):
+                env = checkpoint_context(db, context)
+            assert "PRELOOP_CHECKPOINT_GET_TOKEN" not in env
+            assert env["PRELOOP_CHECKPOINT_PUT_TOKEN"] == "scoped"
+            blocks = native_session_blocks(context, "codex", "/tmp/codex", '"$sid"')
+            assert "explicit_published_branch_adoption" in blocks["restore"]
+            assert "cold_handoff" in blocks["restore"]
+            with pytest.raises(ValueError, match="binding mismatch"):
+                resolve_native_checkpoint(
+                    db,
+                    account_id=uuid.uuid4(),
+                    flow_id=thread.flow_id,
+                    execution_id=repair.id,
+                    resume=resume,
+                )
+            with pytest.raises(ValueError, match="branch binding mismatch"):
+                resolve_native_checkpoint(
+                    db,
+                    account_id=thread.account_id,
+                    flow_id=thread.flow_id,
+                    execution_id=repair.id,
+                    resume={**resume, "source_branch": "attacker"},
+                )
+            later = NOW + timedelta(seconds=31)
+            await _reconcile(
+                db, *crud_flow_feedback.claim_due(db, now=later)[0], now=later
+            )
+            assert dispatch.await_count == 1
+            assert thread.turns == 1
+            repair.status = "SUCCEEDED"
+            repair.cli_session = None
+            db.commit()
+            provider.read.return_value = FeedbackState(
+                "new", feedback=[event("next", "new")]
+            )
+            later += timedelta(seconds=31)
+            await _reconcile(
+                db, *crud_flow_feedback.claim_due(db, now=later)[0], now=later
+            )
+            next_turn = db.get(models.FlowExecution, thread.active_execution_id)
+            assert next_turn.id != repair.id
+            with pytest.raises(ValueError, match="native checkpoint missing"):
+                resolve_native_checkpoint(
+                    db,
+                    account_id=thread.account_id,
+                    flow_id=thread.flow_id,
+                    execution_id=next_turn.id,
+                    resume=next_turn.trigger_event_details["_resume"],
+                )
+
+
+def test_adoption_registers_only_selected_legacy_pr_and_is_idempotent(
+    database: Engine,
+) -> None:
+    from preloop.services import flow_continuation_adoption as adoption
+    from preloop.schemas.flow_continuation import (
+        ContinuationAdoptRequest,
+        ContinuationPreview,
+    )
+    from sqlalchemy.orm import sessionmaker
+
+    with Session(database) as db:
+        old_thread = create_thread(db)
+        account, source_id, flow_id = (
+            old_thread.account_id,
+            old_thread.latest_execution_id,
+            old_thread.flow_id,
+        )
+        pr_url, branch, tracker_id = (
+            old_thread.pr_url,
+            old_thread.branch,
+            old_thread.tracker_id,
+        )
+        source = db.get(models.FlowExecution, source_id)
+        source.trigger_event_details = {
+            **source.trigger_event_details,
+            "source": "github",
+            "tracker_id": str(tracker_id),
+            "payload": {"repository": {"id": "123"}, "issue": {"number": 185}},
+        }
+        source.result = {"pr_url": pr_url, "pr_source_branch": branch}
+        db.delete(old_thread)
+        db.commit()
+        readiness = ContinuationPreview(
+            execution_id=source_id,
+            flow_id=flow_id,
+            pr_url=pr_url,
+            branch=branch,
+            head_sha="a" * 40,
+            feedback_enabled=True,
+            artifact_upload_enabled=True,
+            feedback_readable=True,
+            native_resume_available=False,
+            allowed_recovery_modes=["published_branch_handoff"],
+            warnings=[],
+        )
+        request = ContinuationAdoptRequest(
+            recovery_mode="published_branch_handoff",
+            expected_head_sha="a" * 40,
+            acknowledge_fresh_conversation=True,
+        )
+        with (
+            patch.object(adoption, "preview_continuation", return_value=readiness),
+            patch.object(
+                adoption, "get_session_factory", return_value=sessionmaker(database)
+            ),
+        ):
+            first = adoption.adopt_continuation(account, source_id, request)
+            assert first.thread_id == source_id
+            thread = db.get(models.FlowThread, first.thread_id)
+            deadline = thread.expires_at
+            thread.turns, thread.cost, thread.state = 3, 14.0, "stopped"
+            db.commit()
+            duplicate = adoption.adopt_continuation(account, source_id, request)
+            assert duplicate.thread_id == first.thread_id
+            assert duplicate.state == "stopped"
+            db.refresh(thread)
+            assert (thread.turns, thread.cost, thread.expires_at) == (3, 14.0, deadline)
+            assert thread.context["adoption"]["source_execution_id"] == str(source_id)
+            assert (
+                thread.context["adoption"]["recovery_mode"]
+                == "published_branch_handoff"
+            )
+
+
+@pytest.mark.asyncio
+async def test_provider_materializes_identity_and_releases_transaction_before_network(
+    database: Engine,
+) -> None:
+    from preloop.services.flow_feedback_provider import FeedbackProvider
+
+    with Session(database) as db:
+        thread = create_thread(db)
+        tracker = SimpleNamespace(
+            account_id=thread.account_id,
+            tracker_type="github",
+            id=thread.tracker_id,
+            resolved_api_key="synthetic",
+            url="https://github.com",
+            connection_details={},
+        )
+        thread_id = thread.id
+        thread.stop_reason = "pending-local-work"
+
+        async def create_client(*args: Any) -> object:
+            assert not db.in_transaction()
+            assert database.pool.checkedout() == 0
+            return object()
+
+        with (
+            patch(
+                "preloop.services.flow_feedback_provider.crud_tracker.get",
+                return_value=tracker,
+            ),
+            patch(
+                "preloop.services.flow_feedback_provider.create_tracker_client",
+                side_effect=create_client,
+            ),
+        ):
+            provider = await FeedbackProvider.for_thread(db, thread)
+        assert not db.in_transaction()
+        assert provider.thread.repository_id == "123"
+        assert provider.thread.pr_number == "7"
+        assert db.get(models.FlowThread, thread_id).stop_reason == "pending-local-work"
+
+
+@pytest.mark.asyncio
+async def test_native_repair_resolves_encrypted_workspace_and_selected_session(
+    database: Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json
+    from datetime import UTC
+    from preloop.config import settings
+    from preloop.services.flow_artifacts import put_artifact, get_artifact
+    from preloop.services.flow_feedback import resolve_native_checkpoint
+    from preloop.services.checkpoint_runtime import checkpoint_context
+    from preloop.agents.session_manifest import pack_session, unpack_session
+    from backend.tests.services.test_flow_artifacts import archive_with
+
+    monkeypatch.setattr(settings, "flow_artifact_direct_upload", True)
+    with Session(database) as db:
+        thread = create_thread(db)
+        source = db.get(models.FlowExecution, thread.latest_execution_id)
+        sid = source.cli_session["session_id"]
+        identity = {
+            "harness": "codex",
+            "harness_version": "0.153.4",
+            "session_id": sid,
+            "thread_id": str(thread.id),
+        }
+        files = {
+            "rollout.jsonl": json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {"id": sid, "fact": "selected conversation"},
+                }
+            ).encode()
+        }
+        native_bytes = pack_session(
+            files, **identity, expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+        scope = {
+            "account_id": thread.account_id,
+            "flow_id": thread.flow_id,
+            "execution_id": source.id,
+            "thread_id": str(thread.id),
+        }
+
+        def store(
+            session: Session, *, values: dict[str, Any], quota_bytes: int
+        ) -> models.FlowArtifact:
+            # This fixture's minimal account table omits unrelated account fields.
+            # Exercise real encrypted artifact service plus real scoped rows.
+            row = models.FlowArtifact(**values)
+            session.add(row)
+            session.commit()
+            return row
+
+        with patch("preloop.services.flow_artifacts.crud.store", side_effect=store):
+            workspace_ref = put_artifact(
+                db,
+                **scope,
+                kind="workspace",
+                archive=archive_with(
+                    "workspace/unpublished.txt", b"unpublished changes"
+                ),
+            )
+            native_ref = put_artifact(
+                db, **scope, kind="native_session", archive=native_bytes
+            )
+        source.cli_session = {
+            **source.cli_session,
+            "artifact_reference": native_ref.model_dump(mode="json"),
+        }
+        db.commit()
+        provider = SimpleNamespace(
+            read=AsyncMock(return_value=FeedbackState("head", feedback=[event("ci")]))
+        )
+        with (
+            patch(
+                "preloop.services.flow_feedback.FeedbackProvider.for_thread",
+                AsyncMock(return_value=provider),
+            ),
+            patch(
+                "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+                return_value=True,
+            ),
+            patch(
+                "preloop.services.flow_execution_dispatcher.dispatch_execute",
+                AsyncMock(),
+            ),
+        ):
+            await _reconcile(db, *crud_flow_feedback.claim_due(db, now=NOW)[0], now=NOW)
+        repair = db.get(models.FlowExecution, thread.active_execution_id)
+        resume = repair.trigger_event_details["_resume"]
+        native = resolve_native_checkpoint(
+            db,
+            account_id=thread.account_id,
+            flow_id=thread.flow_id,
+            execution_id=repair.id,
+            resume=resume,
+        )
+        assert native["session_id"] == sid
+        context = {
+            "account_id": str(thread.account_id),
+            "flow_id": str(thread.flow_id),
+            "execution_id": str(repair.id),
+            "trigger_event_data": repair.trigger_event_details,
+            "checkpoint_resume_authorized": True,
+            "native_session_reference": native["artifact_reference"],
+        }
+        with patch(
+            "preloop.api.endpoints.flow_artifacts.mint_artifact_capability",
+            return_value="scoped",
+        ):
+            env = checkpoint_context(db, context)
+        assert "PRELOOP_CHECKPOINT_GET_TOKEN" in env
+        assert "PRELOOP_NATIVE_SESSION_GET_TOKEN" in env
+        read_scope = {k: v for k, v in scope.items() if k != "execution_id"}
+        restored = get_artifact(db, **read_scope, reference=native_ref)
+        assert unpack_session(restored, **identity) == files
+        assert b"unpublished changes" in __import__("gzip").decompress(
+            get_artifact(db, **read_scope, reference=workspace_ref)
+        )
+        saved_session = dict(source.cli_session)
+        source.cli_session = {
+            "agent_type": "codex",
+            "artifact_reference": native_ref.model_dump(mode="json"),
+        }
+        db.commit()
+        with pytest.raises(ValueError, match="invalid native session identity"):
+            resolve_native_checkpoint(
+                db,
+                account_id=thread.account_id,
+                flow_id=thread.flow_id,
+                execution_id=repair.id,
+                resume=resume,
+            )
+        source.cli_session = saved_session
+        db.commit()
+        monkeypatch.setattr(settings, "flow_artifact_direct_upload", False)
+        with pytest.raises(ValueError, match="checkpoint uploads disabled"):
+            resolve_native_checkpoint(
+                db,
+                account_id=thread.account_id,
+                flow_id=thread.flow_id,
+                execution_id=repair.id,
+                resume=resume,
+            )
+        monkeypatch.setattr(settings, "flow_artifact_direct_upload", True)
+        native_row = db.get(models.FlowArtifact, native_ref.artifact_id)
+        native_row.ciphertext = None
+        db.commit()
+        with pytest.raises(ValueError, match="native checkpoint unavailable"):
+            resolve_native_checkpoint(
+                db,
+                account_id=thread.account_id,
+                flow_id=thread.flow_id,
+                execution_id=repair.id,
+                resume=resume,
+            )
+
+
+def test_reservation_waits_for_parent_before_locking_thread(database: Engine) -> None:
+    """A flow deletion owns the parent and must still acquire its child lock."""
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+    from sqlalchemy import event as sql_event, select, delete
+
+    with Session(database) as setup:
+        thread = create_thread(setup)
+        flow_id, thread_id = thread.flow_id, thread.id
+        claim = crud_flow_feedback.claim_due(setup, now=NOW)[0]
+    waiting = Event()
+
+    def before_execute(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if "FOR SHARE" in statement:
+            waiting.set()
+
+    def reserve() -> None:
+        with Session(database) as worker:
+            assert (
+                crud_flow_feedback.reserve(
+                    worker,
+                    *claim,
+                    event_data={},
+                    receipt_ids=[],
+                    head_sha="head",
+                    now=NOW,
+                )
+                is None
+            )
+
+    sql_event.listen(database, "before_cursor_execute", before_execute)
+    try:
+        with Session(database) as deletion, ThreadPoolExecutor(max_workers=1) as pool:
+            flow = deletion.execute(
+                select(models.Flow).where(models.Flow.id == flow_id).with_for_update()
+            ).scalar_one()
+            future = pool.submit(reserve)
+            try:
+                assert waiting.wait(timeout=5)
+                # NOWAIT would raise if reservation had locked the child first.
+                deletion.execute(
+                    select(models.FlowThread)
+                    .where(models.FlowThread.id == thread_id)
+                    .with_for_update(nowait=True)
+                ).scalar_one()
+                deletion.execute(
+                    delete(models.FlowExecution).where(
+                        models.FlowExecution.flow_id == flow.id
+                    )
+                )
+                deletion.execute(delete(models.Flow).where(models.Flow.id == flow.id))
+                deletion.commit()
+            finally:
+                deletion.rollback()
+            future.result(timeout=5)
+    finally:
+        sql_event.remove(database, "before_cursor_execute", before_execute)

--- a/backend/tests/services/test_flow_feedback_durable.py
+++ b/backend/tests/services/test_flow_feedback_durable.py
@@ -806,8 +806,12 @@ async def test_explicit_cold_source_reserves_once_then_requires_own_checkpoint(
                 )
 
 
+@pytest.mark.parametrize(
+    "existing_mode", ["new", "unadopted", "native_resume", "other_source"]
+)
 def test_adoption_registers_only_selected_legacy_pr_and_is_idempotent(
     database: Engine,
+    existing_mode: str,
 ) -> None:
     from preloop.services import flow_continuation_adoption as adoption
     from preloop.schemas.flow_continuation import (
@@ -836,7 +840,22 @@ def test_adoption_registers_only_selected_legacy_pr_and_is_idempotent(
             "payload": {"repository": {"id": "123"}, "issue": {"number": 185}},
         }
         source.result = {"pr_url": pr_url, "pr_source_branch": branch}
-        db.delete(old_thread)
+        if existing_mode == "new":
+            db.delete(old_thread)
+        else:
+            old_thread.turns, old_thread.cost, old_thread.state = 3, 14.0, "stopped"
+            if existing_mode != "unadopted":
+                old_thread.context = {
+                    **old_thread.context,
+                    "adoption": {
+                        "source_execution_id": str(uuid.uuid4())
+                        if existing_mode == "other_source"
+                        else str(source_id),
+                        "recovery_mode": "native_resume"
+                        if existing_mode == "native_resume"
+                        else "published_branch_handoff",
+                    },
+                }
         db.commit()
         readiness = ContinuationPreview(
             execution_id=source_id,
@@ -862,6 +881,29 @@ def test_adoption_registers_only_selected_legacy_pr_and_is_idempotent(
                 adoption, "get_session_factory", return_value=sessionmaker(database)
             ),
         ):
+            if existing_mode != "new":
+                stored = (
+                    old_thread.context,
+                    old_thread.turns,
+                    old_thread.cost,
+                    old_thread.state,
+                    old_thread.expires_at,
+                )
+                with pytest.raises(
+                    adoption.ContinuationAdoptionError,
+                    match="already has a continuation",
+                ) as error:
+                    adoption.adopt_continuation(account, source_id, request)
+                assert error.value.status_code == 409
+                db.refresh(old_thread)
+                assert (
+                    old_thread.context,
+                    old_thread.turns,
+                    old_thread.cost,
+                    old_thread.state,
+                    old_thread.expires_at,
+                ) == stored
+                return
             first = adoption.adopt_continuation(account, source_id, request)
             assert first.thread_id == source_id
             thread = db.get(models.FlowThread, first.thread_id)

--- a/backend/tests/services/test_flow_feedback_provider.py
+++ b/backend/tests/services/test_flow_feedback_provider.py
@@ -196,3 +196,118 @@ def test_untrusted_logs_are_bounded_and_redacted() -> None:
     assert "do-not-copy" not in result
     assert "[REDACTED]" in result
     assert len(result) <= 12000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["protection", "rules"])
+async def test_missing_repository_permission_allows_only_known_repairs(
+    endpoint: str,
+) -> None:
+    from datetime import datetime, timedelta
+    from preloop.services.flow_feedback import decide
+    from preloop.sync.exceptions import TrackerPermissionError
+
+    provider, paths = github_fixture()
+    provider.thread.policy.pop("required_checks")
+    original = provider.client._request.side_effect
+
+    async def request(method: str, path: str, data: Any = None) -> Any:
+        if path.endswith("/protection"):
+            if endpoint == "protection":
+                raise TrackerPermissionError("permission denied")
+            return {}
+        if "/rules/branches/" in path and endpoint == "rules":
+            raise TrackerPermissionError("permission denied")
+        return await original(method, path, data)
+
+    provider.client._request.side_effect = request
+    state = await provider.read()
+    assert state.blocked_reason == "repository_requirements_unavailable"
+    assert state.checks_passed is False and state.reviews_passed is False
+    assert {item["kind"] for item in state.feedback} == {
+        "inline_comment",
+        "review",
+        "ci",
+    }
+    assert len([path for path in paths if path.endswith("/pulls/7")]) == 2
+    now = datetime(2026, 9, 6)
+    thread = SimpleNamespace(
+        expires_at=now + timedelta(days=1),
+        policy={},
+        cursor={},
+        turns=0,
+        cost=0,
+        no_progress=0,
+    )
+    pending = [SimpleNamespace(**item) for item in state.feedback]
+    assert decide(thread, state, pending, now=now) == ("repair", None)
+    assert decide(thread, state, [], now=now) == (
+        "blocked",
+        "repository_requirements_unavailable",
+    )
+    state.checks_pending = True
+    assert decide(thread, state, pending, now=now) == ("waiting", "ci_pending")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["protection", "checks", "comments"])
+async def test_provider_generic_errors_never_authorize_partial_feedback(
+    endpoint: str,
+) -> None:
+    from preloop.sync.exceptions import TrackerResponseError
+
+    provider, _ = github_fixture()
+    provider.thread.policy.pop("required_checks")
+    original = provider.client._request.side_effect
+
+    async def request(method: str, path: str, data: Any = None) -> Any:
+        if (
+            (endpoint == "protection" and path.endswith("/protection"))
+            or (endpoint == "checks" and "/check-runs" in path)
+            or (endpoint == "comments" and "/issues/" in path)
+        ):
+            raise TrackerResponseError("GitHub API error: 403 - rate limit")
+        return await original(method, path, data)
+
+    provider.client._request.side_effect = request
+    with pytest.raises(TrackerResponseError):
+        await provider.read()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,message,headers,permission",
+    [
+        (403, "Resource not accessible by integration", {}, True),
+        (403, "Resource not accessible by personal access token", {}, True),
+        (403, "Must have admin rights to Repository.", {}, True),
+        (
+            403,
+            "Resource not accessible by integration",
+            {"x-ratelimit-remaining": "0"},
+            False,
+        ),
+        (403, "Resource not accessible by integration", {"retry-after": "60"}, False),
+        (403, "API rate limit exceeded", {}, False),
+        (429, "Resource not accessible by integration", {}, False),
+        (500, "Resource not accessible by integration", {}, False),
+    ],
+)
+async def test_github_classifies_only_explicit_permission_denials(
+    status: int, message: str, headers: dict[str, str], permission: bool
+) -> None:
+    import httpx
+    from unittest.mock import patch
+    from preloop.sync.trackers.github import GitHubTracker
+    from preloop.sync.exceptions import TrackerResponseError, TrackerPermissionError
+
+    tracker = GitHubTracker("test", "synthetic", {})
+    client = AsyncMock()
+    client.request.return_value = httpx.Response(
+        status, json={"message": message}, headers=headers
+    )
+    with patch("preloop.sync.trackers.github.httpx.AsyncClient", return_value=client):
+        client.__aenter__.return_value = client
+        with pytest.raises(TrackerResponseError) as error:
+            await tracker._request("GET", "/repositories/123/branches/main/protection")
+    assert isinstance(error.value, TrackerPermissionError) is permission

--- a/backend/tests/services/test_flow_orchestrator_model_list.py
+++ b/backend/tests/services/test_flow_orchestrator_model_list.py
@@ -110,3 +110,36 @@ class TestAuthorizedGatewayModelList:
             and "Could not resolve authorized gateway models" in record.getMessage()
             for record in caplog.records
         )
+
+
+async def test_explicit_cold_resolution_clears_stale_cli_and_legacy_archives(
+    orchestrator,
+):
+    orchestrator.trigger_event_data = {
+        "_resume": {
+            "thread_id": str(uuid4()),
+            "execution_id": str(uuid4()),
+            "cli_session": {"agent_type": "codex", "session_id": str(uuid4())},
+        }
+    }
+    with (
+        patch(
+            "preloop.services.flow_feedback.resolve_native_checkpoint",
+            return_value={"cold_handoff_authorized": True},
+        ),
+        patch(
+            "preloop.services.model_routing.validate_native_resume_identity"
+        ) as validate,
+        patch.object(orchestrator, "_resolve_workspace_restore_archive") as workspace,
+        patch.object(orchestrator, "_resolve_cli_session_restore_archive") as native,
+    ):
+        context, _, _ = await _prepare(
+            orchestrator, list_models=lambda *args, **kwargs: []
+        )
+    assert context["checkpoint_resume_authorized"] is True
+    assert context["published_branch_handoff_authorized"] is True
+    assert "cli_session" not in context["trigger_event_data"]["_resume"]
+    assert "native_session_reference" not in context
+    validate.assert_not_called()
+    workspace.assert_not_called()
+    native.assert_not_called()

--- a/backend/tests/services/test_flow_trigger_service.py
+++ b/backend/tests/services/test_flow_trigger_service.py
@@ -918,6 +918,7 @@ class TestTriggerFlow:
     @patch("preloop.services.flow_trigger_service.get_nats_client")
     @patch("preloop.services.flow_trigger_service.crud_flow_execution")
     @patch("preloop.services.flow_trigger_service.crud_flow")
+    @pytest.mark.parametrize("feedback_enabled", [False, True])
     async def test_trigger_flow_merges_custom_event_data(
         self,
         mock_crud_flow,
@@ -927,6 +928,7 @@ class TestTriggerFlow:
         mock_get_db,
         flow_trigger_service,
         sample_flow,
+        feedback_enabled,
     ):
         """Test triggering a flow with custom event data merges correctly."""
         mock_crud_flow.get.return_value = sample_flow
@@ -941,7 +943,14 @@ class TestTriggerFlow:
         mock_session = MagicMock()
         mock_get_db.return_value = iter([mock_session])
 
-        custom_event = {"source": "manual", "payload": {"test": True}}
+        sample_flow.agent_config = {"feedback": {"enabled": feedback_enabled}}
+        planted = str(uuid.uuid4())
+        custom_event = {
+            "source": "manual",
+            "payload": {"test": True},
+            "_session_thread_id": planted,
+            "_thread_id": planted,
+        }
         await flow_trigger_service.trigger_flow(
             sample_flow.id,
             test_mode=True,
@@ -953,6 +962,10 @@ class TestTriggerFlow:
         execution_data = create_call[1]["obj_in"]
         assert execution_data.trigger_event_details["test_mode"] is True
         assert execution_data.trigger_event_details["source"] == "manual"
+        assert "_thread_id" not in execution_data.trigger_event_details
+        marker = execution_data.trigger_event_details.get("_session_thread_id")
+        assert bool(marker) is feedback_enabled
+        assert marker != planted
 
 
 class TestCreateOrchestratorSession:

--- a/backend/tests/services/test_model_credentials.py
+++ b/backend/tests/services/test_model_credentials.py
@@ -502,7 +502,7 @@ class TestCapEnvEnforcement:
 
 
 class TestAttemptTimeout:
-    """A hanging primary must not consume the fallback's budget."""
+    """Attempt deadlines trigger fallback after shared-session work drains."""
 
     async def test_primary_timeout_triggers_fallback(self, mock_model, mock_db):
         _fallback_counters.clear()

--- a/backend/tests/services/test_oauth_refresh_locking.py
+++ b/backend/tests/services/test_oauth_refresh_locking.py
@@ -1,0 +1,169 @@
+"""OAuth refresh locks observe committed rotations and own only their savepoint."""
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+import json
+
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+from preloop.models.crud import crud_account, crud_ai_model
+from preloop.services.secret_service import SecretService
+from preloop.utils.encryption import encrypt_value
+
+
+@pytest.fixture(params=["oauth_openai_codex", "oauth_anthropic_claude_code"])
+def oauth_model(db_engine: Engine, request: pytest.FixtureRequest) -> Iterator[UUID]:
+    """Use synthetic committed credentials visible across worker sessions."""
+    with Session(db_engine) as db:
+        account = crud_account.create(
+            db, obj_in={"organization_name": "OAuth lock test"}
+        )
+        account_id = account.id
+        model = crud_ai_model.create_with_account(
+            db=db,
+            obj_in={
+                "name": "Synthetic OAuth model",
+                "provider_name": "openai"
+                if request.param == "oauth_openai_codex"
+                else "anthropic",
+                "model_identifier": "synthetic-model",
+                "credential_type": request.param,
+                "credential_payload": {
+                    "access": "synthetic-old",
+                    "refresh": "synthetic-old",
+                    "expires": 1,
+                },
+            },
+            account_id=account_id,
+        )
+        model_id = model.id
+    try:
+        yield model_id
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.AIModel).filter_by(id=model_id).delete()
+            db.query(models.SecretReference).filter_by(account_id=account_id).delete()
+            db.query(models.Account).filter_by(id=account_id).delete()
+            db.commit()
+
+
+def refresh_method(service: SecretService, model: models.AIModel) -> Any:
+    """Select the provider-specific path without making provider requests."""
+    return (
+        service._refresh_openai_codex_ai_model_credentials
+        if model.provider_name == "openai"
+        else service._refresh_anthropic_claude_code_ai_model_credentials
+    )
+
+
+def assert_secret_unlocked(db_engine: Engine, secret_id: UUID) -> None:
+    """A separate transaction can acquire the secret lock before caller cleanup."""
+    with Session(db_engine) as contender:
+        contender.execute(text("SET LOCAL lock_timeout = '250ms'"))
+        contender.query(models.SecretReference).filter_by(
+            id=secret_id
+        ).with_for_update().one()
+
+
+def test_rotated_payload_refreshes_identity_map_without_committing_caller_work(
+    db_engine: Engine, oauth_model: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = SecretService()
+    with Session(db_engine) as reader, Session(db_engine) as updater:
+        model = reader.get(models.AIModel, oauth_model)
+        secret = model.credentials_secret
+        secret_id = secret.id
+        unrelated_id = uuid4()
+        reader.add(
+            models.Account(id=unrelated_id, organization_name="Uncommitted caller work")
+        )
+        reader.flush()
+        rotated = {
+            "access": "synthetic-new",
+            "refresh": "synthetic-new",
+            "expires": 4102444800000,
+        }
+        fresh = updater.get(models.SecretReference, secret_id)
+        fresh.encrypted_value = encrypt_value(json.dumps(rotated))
+        updater.commit()
+
+        def no_provider_call(refresh_token: str) -> dict[str, Any]:
+            pytest.fail(
+                "A committed rotation must not trigger another provider refresh"
+            )
+
+        monkeypatch.setattr(service, "_refresh_openai_codex_token", no_provider_call)
+        monkeypatch.setattr(
+            service, "_refresh_anthropic_claude_code_token", no_provider_call
+        )
+        result = refresh_method(service, model)(
+            model, {"expires": 1, "refresh": "synthetic-old"}, db=reader
+        )
+        assert result == rotated
+        assert_secret_unlocked(db_engine, secret_id)
+        assert reader.in_transaction()
+        assert reader.get(models.Account, unrelated_id) is not None
+        with Session(db_engine) as observer:
+            assert observer.get(models.Account, unrelated_id) is None
+        reader.rollback()
+
+
+def test_missing_refresh_token_releases_only_owned_lock(
+    db_engine: Engine, oauth_model: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = SecretService()
+    with Session(db_engine) as setup:
+        model = setup.get(models.AIModel, oauth_model)
+        model.credentials_secret.encrypted_value = encrypt_value(
+            json.dumps({"access": "synthetic-old", "expires": 1})
+        )
+        setup.commit()
+    with Session(db_engine) as reader:
+        model = reader.get(models.AIModel, oauth_model)
+        secret_id = model.credentials_secret.id
+        unrelated_id = uuid4()
+        reader.add(
+            models.Account(id=unrelated_id, organization_name="Uncommitted caller work")
+        )
+        reader.flush()
+        result = refresh_method(service, model)(model, {"expires": 1}, db=reader)
+        assert result["expires"] == 1
+        assert_secret_unlocked(db_engine, secret_id)
+        assert reader.get(models.Account, unrelated_id) is not None
+        with Session(db_engine) as observer:
+            assert observer.get(models.Account, unrelated_id) is None
+        reader.rollback()
+
+
+def test_needed_refresh_keeps_exclusion_until_rotated_bundle_commits(
+    db_engine: Engine, oauth_model: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = SecretService()
+    with Session(db_engine) as reader:
+        model = reader.get(models.AIModel, oauth_model)
+        secret_id = model.credentials_secret.id
+        calls = []
+
+        def provider_refresh(refresh_token: str) -> dict[str, Any]:
+            with pytest.raises(OperationalError, match="lock timeout"):
+                assert_secret_unlocked(db_engine, secret_id)
+            calls.append(True)
+            return {
+                "access": "synthetic-new",
+                "refresh": "synthetic-new",
+                "expires": 4102444800000,
+            }
+
+        monkeypatch.setattr(service, "_refresh_openai_codex_token", provider_refresh)
+        monkeypatch.setattr(
+            service, "_refresh_anthropic_claude_code_token", provider_refresh
+        )
+        result = refresh_method(service, model)(model, {"expires": 1}, db=reader)
+        assert result["expires"] == 4102444800000
+        assert calls == [True]
+        assert_secret_unlocked(db_engine, secret_id)

--- a/backend/tests/test_auth_event_loop_resilience.py
+++ b/backend/tests/test_auth_event_loop_resilience.py
@@ -177,8 +177,7 @@ async def test_off_loop_cancellation_waits_for_session_owner() -> None:
     finally:
         release.set()
         with pytest.raises(asyncio.CancelledError):
-            cancelled = await task
-            raise AssertionError(f"canceled worker returned {cancelled!r}")
+            await asyncio.wait_for(task, timeout=3)
         assert await asyncio.to_thread(finished.wait, 3)
 
 
@@ -287,8 +286,9 @@ async def test_summary_timeout_does_not_reuse_active_worker_session(
         assert not task.done()
     finally:
         release.set()
-        timeout_result = await task
-        assert task.done()
+        timeout_result = await asyncio.wait_for(task, timeout=3)
+        assert timeout_result is None
+        assert fallback_started.is_set()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth_event_loop_resilience.py
+++ b/backend/tests/test_auth_event_loop_resilience.py
@@ -64,7 +64,7 @@ async def test_auth_row_lock_does_not_block_loop(
     user_id, key_id, username, token = committed_auth_identity
     locked = threading.Event()
     release = threading.Event()
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def hold_lock() -> None:
         try:
@@ -76,7 +76,7 @@ async def test_auth_row_lock_does_not_block_loop(
                 if not release.wait(3):
                     raise AssertionError("Lock owner did not receive release")
                 db.rollback()
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
             locked.set()
 
@@ -177,7 +177,8 @@ async def test_off_loop_cancellation_waits_for_session_owner() -> None:
     finally:
         release.set()
         with pytest.raises(asyncio.CancelledError):
-            await task
+            cancelled = await task
+            raise AssertionError(f"canceled worker returned {cancelled!r}")
         assert await asyncio.to_thread(finished.wait, 3)
 
 
@@ -286,7 +287,8 @@ async def test_summary_timeout_does_not_reuse_active_worker_session(
         assert not task.done()
     finally:
         release.set()
-        await task
+        timeout_result = await task
+        assert task.done()
 
 
 @pytest.mark.asyncio
@@ -332,6 +334,7 @@ async def test_anyio_cancellation_drains_worker_without_blocking_loop() -> None:
         assert not returned
     finally:
         release.set()
-        await task
+        drained = await task
         watchdog.cancel()
+    assert drained is None
     assert returned and finished.is_set()

--- a/backend/tests/test_auth_event_loop_resilience.py
+++ b/backend/tests/test_auth_event_loop_resilience.py
@@ -1,0 +1,337 @@
+"""Authentication must let the API loop progress during real row contention."""
+
+import asyncio
+from collections.abc import Iterator
+import threading
+from uuid import UUID, uuid4
+from typing import Any
+
+import pytest
+from sqlalchemy import Engine, event, select
+from sqlalchemy.orm import Session
+
+from preloop.api.auth.jwt import get_password_hash, get_user_from_token_if_valid
+from preloop.api.auth.router import authenticate_user
+from preloop.models import models
+from preloop.services.model_gateway_auth import authenticate_bearer_token
+
+
+@pytest.fixture
+def committed_auth_identity(db_engine: Engine) -> Iterator[tuple[UUID, UUID, str, str]]:
+    """Create an isolated identity visible to independent lock owners."""
+    account_id, user_id, key_id = uuid4(), uuid4(), uuid4()
+    username = f"loop-audit-{user_id}"
+    token = f"local-test-{key_id}"
+    with Session(db_engine) as db:
+        db.add(models.Account(id=account_id, organization_name="Loop regression"))
+        db.flush()
+        db.add(
+            models.User(
+                id=user_id,
+                account_id=account_id,
+                username=username,
+                email="loop-test@example.com",
+                is_active=True,
+                hashed_password=get_password_hash("local-test-password"),
+            )
+        )
+        db.flush()
+        db.add(
+            models.ApiKey(
+                id=key_id,
+                account_id=account_id,
+                user_id=user_id,
+                name="Local regression",
+                key=token,
+                is_active=True,
+            )
+        )
+        db.commit()
+    try:
+        yield user_id, key_id, username, token
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.Account).filter(models.Account.id == account_id).delete()
+            db.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["login", "gateway", "manual_token"])
+async def test_auth_row_lock_does_not_block_loop(
+    db_engine: Engine, committed_auth_identity: tuple[UUID, UUID, str, str], kind: str
+) -> None:
+    """A timer on the request loop can release a competing auth-row writer."""
+    user_id, key_id, username, token = committed_auth_identity
+    locked = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+
+    def hold_lock() -> None:
+        try:
+            with Session(db_engine) as db:
+                row = models.User if kind == "login" else models.ApiKey
+                row_id = user_id if kind == "login" else key_id
+                db.execute(select(row).where(row.id == row_id).with_for_update())
+                locked.set()
+                if not release.wait(3):
+                    raise AssertionError("Lock owner did not receive release")
+                db.rollback()
+        except BaseException as exc:
+            errors.append(exc)
+            locked.set()
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert await asyncio.to_thread(locked.wait, 3)
+    assert not errors
+    loop_released = False
+    write_started = threading.Event()
+    loop_thread = threading.get_ident()
+    loop_statements: list[str] = []
+
+    def observe_write(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if threading.get_ident() == loop_thread:
+            loop_statements.append(statement.split()[0])
+        if statement.startswith(
+            'UPDATE "user"' if kind == "login" else "UPDATE api_key"
+        ):
+            write_started.set()
+
+    event.listen(db_engine, "before_cursor_execute", observe_write)
+
+    def release_from_loop() -> None:
+        nonlocal loop_released
+        loop_released = True
+        release.set()
+
+    async def release_when_writer_waits() -> None:
+        assert await asyncio.to_thread(write_started.wait, 3)
+        await asyncio.sleep(0.05)
+        release_from_loop()
+
+    timer = asyncio.create_task(release_when_writer_waits())
+    # A blocked-loop regression must fail promptly rather than hang pytest.
+    watchdog = threading.Timer(0.7, release.set)
+    watchdog.start()
+    try:
+        with Session(db_engine) as db:
+            if kind == "login":
+                result = await authenticate_user(
+                    username, "local-test-password", db, source_ip="testclient"
+                )
+            elif kind == "gateway":
+                result = await authenticate_bearer_token(token, db)
+            else:
+                result = await get_user_from_token_if_valid(token, db)
+            assert result is not None
+            resolved_user = result.user if kind == "gateway" else result
+            assert resolved_user.id == user_id
+            assert not loop_statements, (
+                f"Auth or returned user loaded on loop: {loop_statements}"
+            )
+            assert loop_released, (
+                "Authentication blocked the loop until watchdog release"
+            )
+    finally:
+        release.set()
+        timer.cancel()
+        await asyncio.gather(timer, return_exceptions=True)
+        event.remove(db_engine, "before_cursor_execute", observe_write)
+        watchdog.cancel()
+        await asyncio.to_thread(holder.join, 3)
+    assert not errors
+
+
+@pytest.mark.asyncio
+async def test_off_loop_cancellation_waits_for_session_owner() -> None:
+    """Request cleanup must not race a canceled auth operation still using DB."""
+    from preloop.api.loop_safety import run_db_off_loop
+
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def operation() -> None:
+        started.set()
+        try:
+            assert release.wait(3)
+        finally:
+            finished.set()
+
+    task = asyncio.create_task(run_db_off_loop(operation))
+    assert await asyncio.to_thread(started.wait, 3)
+    try:
+        task.cancel()
+        await asyncio.sleep(0.02)
+        assert not task.done(), "Canceled request can clean up an active worker session"
+        task.cancel()  # Repeated cancellation must not break session ownership.
+        await asyncio.sleep(0.02)
+        assert not task.done()
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(finished.wait, 3)
+
+
+@pytest.mark.asyncio
+async def test_manual_auth_does_not_disguise_pool_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capacity errors must reach the shared overload handler, not become 401."""
+    from sqlalchemy.exc import TimeoutError as PoolTimeout
+    from preloop.api.auth import jwt
+
+    def exhausted(*args: Any, **kwargs: Any) -> None:
+        raise PoolTimeout("local pool exhausted")
+
+    monkeypatch.setattr(jwt.crud_api_key, "get_by_key", exhausted)
+    with pytest.raises(PoolTimeout, match="local pool exhausted"):
+        await get_user_from_token_if_valid("local-test-key", object())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["initial", "fallback"])
+async def test_summary_model_queries_run_off_loop(
+    monkeypatch: pytest.MonkeyPatch, phase: str
+) -> None:
+    """Both optional-summary lookup paths must avoid blocking the API loop."""
+    from types import SimpleNamespace
+    from preloop.services import approval_summary, model_credentials
+
+    loop_thread = threading.get_ident()
+    query_threads: list[int] = []
+
+    def lookup(*args: Any, **kwargs: Any) -> None:
+        query_threads.append(threading.get_ident())
+
+    monkeypatch.setattr(
+        approval_summary.crud_ai_model, "get_default_active_model", lookup
+    )
+    if phase == "initial":
+        await approval_summary.generate_approval_summary(
+            object(), account_id="local-test", tool_name="Read"
+        )
+    else:
+        monkeypatch.setattr(
+            model_credentials, "resolve_model_call_credentials", lambda *a, **k: {}
+        )
+
+        def fail(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("local primary unavailable")
+
+        await model_credentials.call_with_default_model_fallback(
+            db=object(),
+            account_id="local-test-fallback",
+            primary_model=SimpleNamespace(
+                id="primary", model_identifier="local", provider_name="local"
+            ),
+            caller=fail,
+            operation_name="local-test",
+        )
+    assert query_threads and all(thread != loop_thread for thread in query_threads)
+
+
+@pytest.mark.asyncio
+async def test_summary_timeout_does_not_reuse_active_worker_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback cannot use the same Session before a timed-out worker finishes."""
+    from types import SimpleNamespace
+    from preloop.services import model_credentials
+
+    started = threading.Event()
+    release = threading.Event()
+    fallback_started = threading.Event()
+
+    def credentials(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        started.set()
+        assert release.wait(3)
+        return {}
+
+    def fallback(*args: Any, **kwargs: Any) -> None:
+        fallback_started.set()
+
+    monkeypatch.setattr(
+        model_credentials, "resolve_model_call_credentials", credentials
+    )
+    monkeypatch.setattr(
+        model_credentials.crud_ai_model, "get_default_active_model", fallback
+    )
+    task = asyncio.create_task(
+        model_credentials.call_with_default_model_fallback(
+            db=object(),
+            account_id="local-worker-timeout",
+            primary_model=SimpleNamespace(
+                id="primary", model_identifier="local", provider_name="local"
+            ),
+            caller=lambda *a: "done",
+            operation_name="local-timeout",
+            attempt_timeout=0.02,
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 3)
+    try:
+        await asyncio.sleep(0.06)
+        assert not fallback_started.is_set(), (
+            "Fallback raced the original session owner"
+        )
+        assert not task.done()
+    finally:
+        release.set()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_anyio_cancellation_drains_worker_without_blocking_loop() -> None:
+    """ASGI-style cancellation must wait for the worker while timers still run."""
+    import anyio
+    from preloop.api.loop_safety import run_db_off_loop
+
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    scope_ready = asyncio.Event()
+    scopes: list[anyio.CancelScope] = []
+    returned = False
+
+    def operation() -> None:
+        started.set()
+        try:
+            assert release.wait(3)
+        finally:
+            finished.set()
+
+    async def request() -> None:
+        nonlocal returned
+        with anyio.CancelScope() as scope:
+            scopes.append(scope)
+            scope_ready.set()
+            try:
+                await run_db_off_loop(operation)
+            finally:
+                returned = True
+                assert finished.is_set(), "Dependency cleanup raced worker"
+
+    task = asyncio.create_task(request())
+    await scope_ready.wait()
+    assert await asyncio.to_thread(started.wait, 3)
+    watchdog = threading.Timer(1, release.set)
+    watchdog.start()
+    try:
+        scopes[0].cancel()
+        await asyncio.sleep(0.03)
+        assert not release.is_set(), "Loop failed to progress before watchdog"
+        assert not returned
+    finally:
+        release.set()
+        await task
+        watchdog.cancel()
+    assert returned and finished.is_set()

--- a/backend/tests/test_flow_matrix_batch.py
+++ b/backend/tests/test_flow_matrix_batch.py
@@ -73,12 +73,17 @@ def _patch_dispatch():
 
 class TestTriggerFlowMatrixService:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("feedback_enabled", [False, True])
     async def test_matrix_creates_one_execution_per_cell(
         self,
         db_session: Session,
         test_flow: Flow,
         test_ai_model: AIModel,
+        feedback_enabled: bool,
     ):
+        test_flow.agent_config = {"feedback": {"enabled": feedback_enabled}}
+        db_session.commit()
+        planted = str(uuid4())
         service = FlowTriggerService(db_session)
         matrix = [
             {},  # flow defaults (baseline cell)
@@ -92,7 +97,11 @@ class TestTriggerFlowMatrixService:
                 flow_id=test_flow.id,
                 matrix=matrix,
                 test_mode=True,
-                trigger_event_data={"payload": {"message": "hello"}},
+                trigger_event_data={
+                    "payload": {"message": "hello"},
+                    "_thread_id": planted,
+                    "_session_thread_id": planted,
+                },
             )
 
         assert result["flow_id"] == str(test_flow.id)
@@ -135,6 +144,14 @@ class TestTriggerFlowMatrixService:
         for row in rows:
             assert row.trigger_event_details["payload"] == {"message": "hello"}
             assert row.trigger_event_details["test_mode"] is True
+            assert "_thread_id" not in row.trigger_event_details
+            marker = row.trigger_event_details.get("_session_thread_id")
+            assert bool(marker) is feedback_enabled
+            assert marker != planted
+        if feedback_enabled:
+            assert len(
+                {row.trigger_event_details["_session_thread_id"] for row in rows}
+            ) == len(rows)
 
     @pytest.mark.asyncio
     async def test_matrix_rejects_empty_and_oversized(

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -53,3 +53,49 @@ The detailed schema is defined using SQLAlchemy models within the `preloop.model
 *   **Other Metadata:** Tables for comments, users, API keys, etc., as needed.
 
 Schema migrations are managed using Alembic within `preloop.models`.
+
+
+## Transactions and asynchronous request handling
+
+Keep synchronous CRUD and password/credential work off the API event loop.
+Synchronous FastAPI handlers and dependencies already execute in workers. Async
+callers can use `preloop.api.loop_safety.run_db_off_loop` for a complete, sequential
+unit of database work. Do not let cancellation close a session while that worker
+still uses it: the helper drains the worker before propagating cancellation,
+including repeated asyncio cancellation and AnyIO cancellation scopes. Provider
+calls must have their own I/O timeout because draining can exceed a coroutine
+deadline.
+
+Avoid keeping database connections while waiting for a human. Native permission
+checks resolve authentication into immutable scalar fields in a worker-owned
+session, close that session, then await the approval. Read response DTOs while
+their session is open; an ORM object that survives rollback can have expired
+attributes even when `expire_on_commit=False`.
+
+Account halt/admission and artifact quota transactions use PostgreSQL
+`FOR NO KEY UPDATE`. This still excludes competing owners while allowing the
+`KEY SHARE` foreign-key checks performed by independent child audit and usage
+inserts. This choice assumes the transaction does not change the referenced
+account identity. Other row locks protect distinct invariants and must not be
+weakened mechanically. Heartbeats and operator lifecycle transactions both
+update the managed-agent row before the runtime-session row.
+
+OAuth credential refresh must serialize single-use refresh tokens. Its CRUD
+helper reloads the locked row with `populate_existing` so an earlier identity-map
+read cannot win over a peer's committed rotation. If rotation is no longer needed,
+only the helper's savepoint is rolled back to release its new lock, leaving
+caller work uncommitted and intact. A necessary refresh retains exclusion through
+the existing rotation transaction; its provider request has a bounded timeout.
+
+Use independent PostgreSQL sessions and bounded lock timeouts to test lock
+compatibility and ordering. Include a live event-loop task in blocking-I/O and
+cancellation tests; mock-only session tests do not exercise these failure modes.
+Monitor lock waiters, transaction age, pool checkout pressure, and event-loop
+latency separately from CPU and memory. Increasing a pool cannot resolve a lock
+cycle.
+
+These changes cover the admission, authentication, summary, and refresh paths
+described above. Gateway preparation still needs a separate connection-lifetime
+change before long provider streams, and the agent-control WebSocket still needs
+worker-owned per-message sessions. Those broader lifecycle changes are not implied
+by moving individual authentication calls into workers.

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -3,7 +3,8 @@
 The Automated Issue Implementation preset can keep a PR moving through review
 and CI without leaving an agent container waiting. Each repair gets a new
 FlowExecution, its own execution budgets and fresh credentials. The implementation
-thread keeps the PR branch and exact native conversation across those turns.
+thread keeps the PR branch and, when recovery files are available, the exact native
+conversation across those turns.
 Reviewers remain separate flows and conversations. Merging remains a human action.
 
 ## Enable a subscription
@@ -32,6 +33,15 @@ agent_config:
     required_checks: ["Backend Tests", "UI Tests"]
     required_approvals: 1
 ```
+
+Enabling feedback applies to future executions. The server records opt-in when
+an execution starts; turning the setting on does not discover and repair an old
+PR backlog. An older successful publication requires explicit adoption below.
+Turning feedback off pauses future repairs without cancelling a running turn.
+Re-enabling keeps consumed turns, cost, no-progress history and the deadline.
+Current reviewer trust and budget settings apply on every reconciliation and are
+checked again when reserving a repair. Reducing the maximum age can shorten the
+original deadline; increasing it never extends an existing subscription.
 
 Use the actual reviewer integration's actor ID in `trusted_reviewer_ids`.
 Unlisted bots and the configured implementer actor are ignored. A copied HTML
@@ -73,8 +83,11 @@ check never becomes ready simply because a webhook was missing.
 
 Readiness requires passing checks and review gates on the current head. Provider
 permission errors, pagination beyond the bounded reconciliation window, and
-ruleset workflow/code-scanning gates that require additional evidence fail closed
-with a reason. Resolve the blocker or provide the required gate integration;
+ruleset workflow/code-scanning gates that require additional evidence prevent
+readiness with a reason. Explicit permission denials on GitHub branch protection
+or ruleset discovery still allow repairs to fully read, current-head review and
+CI feedback. They never establish that repository requirements passed. Other
+provider failures, rate limits or incomplete feedback block repairs as well. Resolve the blocker or provide the required gate integration;
 Preloop does not interpret unavailable evidence as approval. The PR remains open
 for manual merge.
 
@@ -97,8 +110,11 @@ Providing another issue's execution ID or artifact reference does not authorize
 its session. Private runners must advertise native checkpoint support; a runner
 without it reports a cold handoff and does not upload its home directory.
 
-Restore begins in an empty session directory. Missing/expired state produces
-`cold_handoff` with a reason, using current issue/PR evidence. Corrupt, mismatched,
+Restore begins in an empty session directory. Missing or expired recovery files
+stop a durable native resume. Only an explicitly adopted original publication may
+start a fresh conversation on its published branch and report `cold_handoff`.
+That exception is consumed by the first repair: later repairs need their own
+workspace and native checkpoints. Corrupt, mismatched,
 unsupported or incompatible existing state produces `resume_failed`. A failed
 native CLI resume preserves the checkpoint and does not silently select another
 conversation. The execution result records `native_resume`, `cold_handoff` or
@@ -117,6 +133,49 @@ and completion reminders always use explicit IDs, never latest-session flags.
 Wrappers install the selected CLI before one native restore, enter the primary
 checkout after setup, and log the actual CLI version and configured image reference.
 A configured image tag is not proof of the resolved runtime image digest.
+
+## Adopt one existing publication
+
+First enable feedback on the flow and direct artifact uploads on the API and
+execution workers (`FLOW_ARTIFACT_DIRECT_UPLOAD=true`). The worker must reach
+`PRELOOP_URL` and share the existing encryption configuration. Retain workspace
+and native artifacts for the desired repair window. A native session ID alone is
+not sufficient to resume a conversation.
+
+Use the execution detail action, or preview the original successful publishing
+execution through `GET /api/v1/flows/executions/{execution_id}/continuation`.
+The preview verifies account ownership, the tracker and current PR repository,
+branch, URL and head. It also exercises review, CI and repository gate reads with
+at most twelve provider requests and a 25-second deadline. It writes no thread
+and dispatches no execution. `feedback_readable=false` means feedback read permissions
+or provider availability must be fixed before adoption. A permission denial
+limited to repository requirement discovery permits adoption and bounded repairs,
+with a warning that readiness remains unverified. Other gate blockers
+remain visible in `feedback_blocked_reason` and the warnings.
+
+Submit the returned head using
+`POST /api/v1/flows/executions/{execution_id}/continuation`:
+
+```json
+{
+  "recovery_mode": "published_branch_handoff",
+  "expected_head_sha": "<head_sha from the preview>",
+  "acknowledge_fresh_conversation": true
+}
+```
+
+Use `native_resume` when it appears in `allowed_recovery_modes`; fresh-conversation
+acknowledgement is then unnecessary. `published_branch_handoff` explicitly gives
+up unavailable unpublished workspace and native conversation state and starts
+from the verified published PR branch. The controller binds that permission to
+the selected source execution and its reserved first repair. Trigger payloads
+cannot grant the exception. Subsequent turns must restore their own checkpoints.
+
+A changed head, closed PR, disabled flow, missing checkpoint capability or
+unreadable provider returns HTTP 409, requiring a new preview. Repeated adoption
+returns the existing thread without resetting its counters, deadline or terminal
+state. Adoption starts the bounded subscription; it does not immediately create
+an agent run. The scheduler first reconciles current trusted feedback and gates.
 
 ## Local validation
 

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -264,7 +264,9 @@ cannot grant the exception. Subsequent turns must restore their own checkpoints.
 A changed head, closed PR, disabled flow, missing checkpoint capability or
 unreadable provider returns HTTP 409, requiring a new preview. Repeated adoption
 returns the existing thread without resetting its counters, deadline or terminal
-state. Adoption starts the bounded subscription; it does not immediately create
+state when its recorded source and recovery mode match. Adopting an already
+subscribed PR with a different or unrecorded mode returns HTTP 409; this endpoint
+does not change an existing thread's recovery authority. Adoption starts the bounded subscription; it does not immediately create
 an agent run. The scheduler first reconciles current trusted feedback and gates.
 
 ## Local validation

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -33,6 +33,16 @@ agent_config:
     required_approvals: 1
 ```
 
+In the console, edit a flow and enable **Continue implementation after PR review
+or CI failure** under **PR review and CI follow-up**. Enter the reviewer's and
+implementer's numeric GitHub or GitLab actor IDs, then choose limits for repair
+turns, cumulative estimated cost in USD, lifetime, and feedback debounce. The
+initial values match the policy defaults above. Saving an existing flow without
+opting in leaves follow-up disabled. Other policy fields set through the API are
+preserved when editing these controls. A compatible saved checkpoint is required
+for native conversation resume; otherwise an eligible repair reports its cold
+handoff explicitly. Turning on the option does not merge a PR.
+
 Use the actual reviewer integration's actor ID in `trusted_reviewer_ids`.
 Unlisted bots and the configured implementer actor are ignored. A copied HTML
 review marker never grants trust. All comment and CI text is untrusted task data.

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -118,6 +118,65 @@ Wrappers install the selected CLI before one native restore, enter the primary
 checkout after setup, and log the actual CLI version and configured image reference.
 A configured image tag is not proof of the resolved runtime image digest.
 
+## Deployment prerequisites
+
+Enable checkpoint uploads only after deploying the transaction-resilience backend
+and its EE companion. In particular, the artifact quota lock must use
+`FOR NO KEY UPDATE` so checkpoint inserts do not recreate account foreign-key
+contention. Apply database migrations before starting the updated API and flow
+workers. Merely enabling feedback on a saved flow does not enable artifact upload.
+
+The chart already supports shared `extraEnv` on the API, gateway, execution workers
+and scheduler. Its defaults leave `FLOW_ARTIFACT_DIRECT_UPLOAD` disabled. The
+optional [native checkpoint overlay](../../../helm/preloop/values-native-checkpoints.yaml)
+enables it and retains both workspace and native artifacts for seven days. Copy
+and review that file with your installation values; do not enable it merely by
+setting an environment variable on the Helm client or CI job.
+
+The overlay caps compressed uploads at 16 MiB through
+`WORKSPACE_SNAPSHOT_MAX_BYTES`, which applies to both artifact kinds. This is below
+the chart's default 32 MiB ingress and console proxy body limit. Oversized archives
+fail explicitly; increase application and every proxy limit together only after
+checking memory and database capacity. Expanded archives retain their separate
+`FLOW_ARTIFACT_EXPANDED_MAX_BYTES` limit (default 2 GiB), and
+`FLOW_ARTIFACT_ACCOUNT_QUOTA_BYTES` limits stored account data (default 4 GiB).
+Retention consumes that quota, so cleanup and database headroom must cover the
+selected retention window. The checkpoint interval defaults to 300 seconds.
+
+Helm merges maps but **replaces lists**. Merge these entries with any existing
+`extraEnv`, preserving database, private-CA and other installation entries. An
+additional values file must not silently replace that list. Render the combined
+values and verify that the same direct-upload flag reaches the API and execution
+workers. Confirm the existing signing/encryption Secret references remain intact;
+never print key values in CI logs.
+
+All API and worker replicas must share a stable `SECRET_KEY`, used to sign and
+verify scoped upload/download capabilities. Artifacts use the existing encryption
+configuration: a stable `SECURITY__ENCRYPTION_KEY` when configured, otherwise the
+existing encryption key derived from `SECRET_KEY`. Preserve the installation's
+current mode and keys. Switching to a new dedicated key or rotating either key is
+not part of enabling checkpoints and can make existing encrypted data unreadable.
+If an existing dedicated key comes from a Kubernetes Secret, preserve its
+`valueFrom.secretKeyRef` entry in the combined values. A non-empty key check only
+proves presence, not continuity with previously stored data.
+
+`PRELOOP_URL` must be reachable from the actual agent execution namespace or
+private runner, including DNS, TLS trust and egress to its resolved destination.
+The native client uploads directly to
+`/api/v1/flows/executions/{execution_id}/artifacts`; MCP access alone does not prove
+this route works. An internal ingress may need an explicit existing network-policy
+rule for its namespace and HTTPS port. Do not widen agent egress merely to bypass
+a failed readiness check. Check upload timeouts as well as size limits.
+
+Use a local or staging acceptance run to verify an encrypted workspace and native
+artifact row, then a fresh-container native resume for the same implementation
+thread. The two-turn image smoke below proves the harness's selected-session
+restore separately from the encrypted HTTP transport. Old executions without an
+uploaded checkpoint cannot regain their lost native context by enabling this
+setting; they require an explicit cold handoff. Disable future direct uploads by
+removing this overlay or setting `FLOW_ARTIFACT_DIRECT_UPLOAD=false` consistently,
+while preserving stored artifacts and keys for recovery.
+
 ## Local validation
 
 Unit fixtures cover archive identity, traversal, symlinks, credential isolation,

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -43,6 +43,15 @@ preserved when editing these controls. A compatible saved checkpoint is required
 for native conversation resume; otherwise an eligible repair reports its cold
 handoff explicitly. Turning on the option does not merge a PR.
 
+For an existing PR, open the successful execution that published it and choose
+**Set up PR follow-up**. This fetches a read-only preview of the exact PR, branch,
+current head and recovery options. Confirm a fresh conversation explicitly if its
+saved state cannot be resumed. If the head changes, review the refreshed preview
+and confirm again. The action requires enabled flow feedback and deployment
+support for saved execution state uploads; unavailable prerequisites are shown in
+the preview. A failed network response triggers a status refresh, not an automatic
+second adoption request.
+
 Use the actual reviewer integration's actor ID in `trusted_reviewer_ids`.
 Unlisted bots and the configured implementer actor are ignored. A copied HTML
 review marker never grants trust. All comment and CI text is untrusted task data.

--- a/docs/guide/flows/durable-implementation-feedback.md
+++ b/docs/guide/flows/durable-implementation-feedback.md
@@ -133,15 +133,26 @@ enables it and retains both workspace and native artifacts for seven days. Copy
 and review that file with your installation values; do not enable it merely by
 setting an environment variable on the Helm client or CI job.
 
-The overlay caps compressed uploads at 16 MiB through
+The example overlay caps compressed uploads at 16 MiB through
 `WORKSPACE_SNAPSHOT_MAX_BYTES`, which applies to both artifact kinds. This is below
-the chart's default 32 MiB ingress and console proxy body limit. Oversized archives
+the chart's default 32 MiB ingress and console proxy body limit. Measure a
+representative workspace and native-session archive locally before choosing this
+limit: repository history and generated assets can exceed it. For example, a
+44.5 MiB compressed checkpoint requires a larger application limit, such as
+64 MiB (`67108864` bytes), with `gateway.proxy.bodySize: "80m"` to update both
+ingress and console limits. Check for explicit ingress annotation overrides in
+the installation values. Oversized archives
 fail explicitly; increase application and every proxy limit together only after
 checking memory and database capacity. Expanded archives retain their separate
 `FLOW_ARTIFACT_EXPANDED_MAX_BYTES` limit (default 2 GiB), and
 `FLOW_ARTIFACT_ACCOUNT_QUOTA_BYTES` limits stored account data (default 4 GiB).
 Retention consumes that quota, so cleanup and database headroom must cover the
 selected retention window. The checkpoint interval defaults to 300 seconds.
+Upload buffering, encryption and database driver copies can require several times
+the compressed archive size in memory. The expanded-size limit is validated with
+streaming reads, but it still bounds restore disk usage and processing work.
+Keep upload concurrency bounded during initial validation; increasing a size
+limit alone does not establish sufficient memory or storage headroom.
 
 Helm merges maps but **replaces lists**. Merge these entries with any existing
 `extraEnv`, preserving database, private-CA and other installation entries. An

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3013,6 +3013,85 @@ export async function getFlowExecution(executionId: string): Promise<any> {
   return response.json();
 }
 
+export type ContinuationRecoveryMode =
+  'native_resume' | 'published_branch_handoff';
+
+export interface FlowContinuationPreview {
+  execution_id: string;
+  flow_id: string;
+  pr_url: string;
+  branch: string;
+  head_sha: string;
+  feedback_enabled: boolean;
+  feedback_readable: boolean;
+  feedback_blocked_reason: string | null;
+  artifact_upload_enabled: boolean;
+  native_resume_available: boolean;
+  existing_thread_id: string | null;
+  existing_thread_state?: string | null;
+  allowed_recovery_modes: ContinuationRecoveryMode[];
+  warnings: string[];
+}
+
+export interface FlowContinuationResult {
+  thread_id: string;
+  state: string;
+  pr_url: string;
+  recovery_mode: ContinuationRecoveryMode;
+}
+
+export class FlowContinuationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+async function continuationResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new FlowContinuationError(
+      typeof error.detail === 'string'
+        ? error.detail
+        : 'Unable to configure PR follow-up.',
+      response.status
+    );
+  }
+  return response.json();
+}
+
+export async function previewFlowContinuation(
+  executionId: string
+): Promise<FlowContinuationPreview> {
+  return continuationResponse(
+    await fetchWithAuth(
+      `/api/v1/flows/executions/${encodeURIComponent(executionId)}/continuation`
+    )
+  );
+}
+
+export async function adoptFlowContinuation(
+  executionId: string,
+  options: {
+    recovery_mode: ContinuationRecoveryMode;
+    expected_head_sha: string;
+    acknowledge_fresh_conversation: boolean;
+  }
+): Promise<FlowContinuationResult> {
+  return continuationResponse(
+    await fetchWithAuth(
+      `/api/v1/flows/executions/${encodeURIComponent(executionId)}/continuation`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(options),
+      }
+    )
+  );
+}
+
 export async function getFlowExecutionMetrics(executionId: string): Promise<{
   tool_calls: number;
   api_requests: number;

--- a/frontend/src/components/preloop-execution-continuation.test.ts
+++ b/frontend/src/components/preloop-execution-continuation.test.ts
@@ -1,0 +1,257 @@
+import {
+  expect,
+  fixture,
+  fixtureCleanup,
+  html,
+  waitUntil,
+} from '@open-wc/testing';
+import sinon from 'sinon';
+import './preloop-execution-continuation';
+import type { PreloopExecutionContinuation } from './preloop-execution-continuation';
+import type { FlowContinuationPreview } from '../api';
+
+const execution = {
+  id: 'exec-1',
+  flow_id: 'flow-1',
+  status: 'SUCCEEDED',
+  result: { pr_url: 'https://github.com/team/repo/pull/7' },
+};
+const initialPreview: FlowContinuationPreview = {
+  execution_id: 'exec-1',
+  flow_id: 'flow-1',
+  pr_url: execution.result.pr_url,
+  branch: 'fix/issue',
+  head_sha: 'a'.repeat(40),
+  feedback_enabled: true,
+  feedback_readable: true,
+  feedback_blocked_reason: null,
+  artifact_upload_enabled: true,
+  native_resume_available: false,
+  existing_thread_id: null,
+  existing_thread_state: null,
+  allowed_recovery_modes: ['published_branch_handoff'],
+  warnings: [],
+};
+
+describe('Execution PR follow-up adoption', () => {
+  let fetchStub: sinon.SinonStub;
+  let preview: FlowContinuationPreview;
+  let postResponse: () => Promise<Response>;
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-token');
+    preview = structuredClone(initialPreview);
+    postResponse = async () =>
+      new Response(
+        JSON.stringify({
+          thread_id: 'thread-1',
+          state: 'waiting',
+          pr_url: preview.pr_url,
+          recovery_mode: 'published_branch_handoff',
+        })
+      );
+    fetchStub = sinon.stub(window, 'fetch').callsFake(async (_input, init) => {
+      return init?.method === 'POST'
+        ? postResponse()
+        : new Response(JSON.stringify(preview));
+    });
+  });
+  afterEach(() => {
+    fixtureCleanup();
+    sinon.restore();
+    localStorage.clear();
+  });
+  const mount = () =>
+    fixture<PreloopExecutionContinuation>(
+      html`<preloop-execution-continuation
+        .execution=${structuredClone(execution)}
+      ></preloop-execution-continuation>`
+    );
+  const control = (
+    element: PreloopExecutionContinuation,
+    name: string
+  ): any => {
+    const value = element.shadowRoot!.querySelector(
+      `[data-continuation-${name}]`
+    );
+    expect(value, name).to.exist;
+    return value;
+  };
+  const open = async (element: PreloopExecutionContinuation) => {
+    control(element, 'preview').click();
+    await waitUntil(() => !(element as any).loading);
+    await element.updateComplete;
+  };
+  const acknowledge = async (element: PreloopExecutionContinuation) => {
+    const checkbox = control(element, 'ack');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('sl-change', { bubbles: true }));
+    await element.updateComplete;
+  };
+  const requests = () =>
+    fetchStub
+      .getCalls()
+      .filter((call) => String(call.args[0]).endsWith('/continuation'));
+  const posts = () =>
+    fetchStub.getCalls().filter((call) => call.args[1]?.method === 'POST');
+  const confirm = async (element: PreloopExecutionContinuation) => {
+    control(element, 'confirm').click();
+    await waitUntil(
+      () => !(element as any).saving && !(element as any).loading
+    );
+    await element.updateComplete;
+  };
+
+  it('does not fetch until explicitly opened and never adopts during preview', async () => {
+    const element = await mount();
+    expect(requests().length).to.equal(0);
+    await open(element);
+    expect(requests().length).to.equal(1);
+    expect(requests()[0].args[0]).to.equal(
+      '/api/v1/flows/executions/exec-1/continuation'
+    );
+    expect(posts()).to.have.length(0);
+    expect(element.shadowRoot!.querySelector('a')!.href).to.equal(
+      preview.pr_url
+    );
+    expect(control(element, 'ack').checked).to.equal(false);
+    expect(control(element, 'confirm').disabled).to.equal(true);
+  });
+
+  it('requires explicit fresh-conversation acknowledgment and submits the reviewed head', async () => {
+    const element = await mount();
+    await open(element);
+    await (element as any).adopt();
+    expect(posts()).to.have.length(0);
+    await acknowledge(element);
+    await confirm(element);
+    expect(posts()).to.have.length(1);
+    expect(JSON.parse(posts()[0].args[1].body)).to.deep.equal({
+      recovery_mode: 'published_branch_handoff',
+      expected_head_sha: 'a'.repeat(40),
+      acknowledge_fresh_conversation: true,
+    });
+    expect(element.shadowRoot!.textContent).to.include(
+      'PR follow-up is configured'
+    );
+  });
+
+  it('uses native resume only when offered and keeps fresh-conversation acknowledgment false', async () => {
+    preview.native_resume_available = true;
+    preview.allowed_recovery_modes = [
+      'native_resume',
+      'published_branch_handoff',
+    ];
+    const element = await mount();
+    await open(element);
+    expect(element.shadowRoot!.querySelector('[data-continuation-ack]')).to.not
+      .exist;
+    await confirm(element);
+    expect(JSON.parse(posts()[0].args[1].body)).to.deep.equal({
+      recovery_mode: 'native_resume',
+      expected_head_sha: 'a'.repeat(40),
+      acknowledge_fresh_conversation: false,
+    });
+  });
+
+  for (const field of [
+    'feedback_enabled',
+    'feedback_readable',
+    'artifact_upload_enabled',
+    'allowed_recovery_modes',
+    'existing_thread_id',
+  ] as const) {
+    it(`does not allow adoption when ${field} is unavailable`, async () => {
+      if (field === 'allowed_recovery_modes') preview[field] = [];
+      else if (field === 'existing_thread_id')
+        preview[field] = 'existing-thread';
+      else preview[field] = false;
+      const element = await mount();
+      await open(element);
+      expect(control(element, 'confirm').disabled).to.equal(true);
+      await (element as any).adopt();
+      expect(posts()).to.have.length(0);
+      if (field === 'feedback_enabled')
+        expect(
+          element.shadowRoot!.querySelector(
+            'a[href="/console/flows/flow-1?edit=true"]'
+          )
+        ).to.exist;
+    });
+  }
+
+  it('refreshes a conflicting head and clears acknowledgment without resubmitting', async () => {
+    postResponse = async () => {
+      preview.head_sha = 'b'.repeat(40);
+      return new Response(JSON.stringify({ detail: 'Head changed' }), {
+        status: 409,
+      });
+    };
+    const element = await mount();
+    await open(element);
+    await acknowledge(element);
+    await confirm(element);
+    expect(posts()).to.have.length(1);
+    expect(requests().length).to.equal(3);
+    expect(control(element, 'ack').checked).to.equal(false);
+    expect(control(element, 'confirm').disabled).to.equal(true);
+    expect(element.shadowRoot!.textContent).to.include('b'.repeat(40));
+    expect(control(element, 'error').textContent).to.include('confirm again');
+  });
+
+  it('checks adoption state after an uncertain POST failure without another POST', async () => {
+    postResponse = async () => {
+      preview.existing_thread_id = 'accepted-thread';
+      preview.existing_thread_state = 'waiting';
+      throw new TypeError('Network interrupted');
+    };
+    const element = await mount();
+    await open(element);
+    await acknowledge(element);
+    await confirm(element);
+    expect(posts()).to.have.length(1);
+    expect(requests().length).to.equal(3);
+    expect(element.shadowRoot!.textContent).to.include(
+      'already has follow-up configured'
+    );
+    expect(control(element, 'confirm').disabled).to.equal(true);
+  });
+
+  it('ignores an old preview response after navigating to another execution', async () => {
+    let release: (response: Response) => void = () => {};
+    fetchStub.callsFake(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        })
+    );
+    const element = await mount();
+    control(element, 'preview').click();
+    await element.updateComplete;
+    element.execution = { ...execution, id: 'exec-2' };
+    await element.updateComplete;
+    release(new Response(JSON.stringify(initialPreview)));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await element.updateComplete;
+    expect((element as any).preview).to.equal(null);
+    expect((element as any).open).to.equal(false);
+    expect(posts()).to.have.length(0);
+  });
+
+  for (const change of [
+    { status: 'RUNNING' },
+    { status: 'FAILED' },
+    { result: {} },
+    {
+      result: { ...execution.result, continuation: { thread_id: 'thread-1' } },
+    },
+  ]) {
+    it(`hides the action for ineligible execution ${JSON.stringify(change)}`, async () => {
+      const element = await mount();
+      element.execution = { ...execution, ...change };
+      await element.updateComplete;
+      expect(element.shadowRoot!.querySelector('[data-continuation-preview]'))
+        .to.not.exist;
+      expect(requests().length).to.equal(0);
+    });
+  }
+});

--- a/frontend/src/components/preloop-execution-continuation.test.ts
+++ b/frontend/src/components/preloop-execution-continuation.test.ts
@@ -239,6 +239,7 @@ describe('Execution PR follow-up adoption', () => {
 
   for (const change of [
     { status: 'RUNNING' },
+    { status: 'COMPLETED' },
     { status: 'FAILED' },
     { result: {} },
     {

--- a/frontend/src/components/preloop-execution-continuation.ts
+++ b/frontend/src/components/preloop-execution-continuation.ts
@@ -78,7 +78,7 @@ export class PreloopExecutionContinuation extends LitElement {
   private eligible() {
     return (
       this.execution &&
-      ['SUCCEEDED', 'COMPLETED'].includes(this.execution.status) &&
+      this.execution.status === 'SUCCEEDED' &&
       Boolean(this.execution.result?.pr_url) &&
       !this.execution.result?.continuation?.thread_id &&
       !this.execution.trigger_event_details?._thread_id

--- a/frontend/src/components/preloop-execution-continuation.ts
+++ b/frontend/src/components/preloop-execution-continuation.ts
@@ -1,0 +1,310 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { PropertyValues } from 'lit';
+import {
+  previewFlowContinuation,
+  adoptFlowContinuation,
+  FlowContinuationError,
+  type FlowContinuationPreview,
+  type ContinuationRecoveryMode,
+} from '../api';
+import { consoleDialogStyles } from '../styles/console-dialog';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+
+interface PublishedExecution {
+  id: string;
+  flow_id: string;
+  status: string;
+  result?: { pr_url?: string; continuation?: { thread_id?: string } };
+  trigger_event_details?: { _thread_id?: string };
+}
+
+@customElement('preloop-execution-continuation')
+export class PreloopExecutionContinuation extends LitElement {
+  static styles = [
+    consoleDialogStyles,
+    css`
+      :host {
+        display: block;
+      }
+      .action {
+        margin: var(--sl-spacing-medium) 0;
+      }
+      sl-alert,
+      sl-checkbox {
+        margin-top: var(--sl-spacing-medium);
+      }
+      p {
+        line-height: 1.5;
+      }
+      a {
+        color: var(--sl-color-primary-600);
+        overflow-wrap: anywhere;
+      }
+      code {
+        overflow-wrap: anywhere;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) execution?: PublishedExecution;
+  @state() private open = false;
+  @state() private preview: FlowContinuationPreview | null = null;
+  @state() private loading = false;
+  @state() private saving = false;
+  @state() private acknowledged = false;
+  @state() private error = '';
+  @state() private adopted = false;
+  private generation = 0;
+
+  protected willUpdate(changes: PropertyValues) {
+    const previous = changes.get('execution') as PublishedExecution | undefined;
+    if (changes.has('execution') && previous?.id !== this.execution?.id) {
+      this.generation++;
+      this.open = false;
+      this.preview = null;
+      this.acknowledged = false;
+      this.error = '';
+      this.loading = false;
+      this.saving = false;
+      this.adopted = false;
+    }
+  }
+
+  private eligible() {
+    return (
+      this.execution &&
+      ['SUCCEEDED', 'COMPLETED'].includes(this.execution.status) &&
+      Boolean(this.execution.result?.pr_url) &&
+      !this.execution.result?.continuation?.thread_id &&
+      !this.execution.trigger_event_details?._thread_id
+    );
+  }
+
+  private mode(): ContinuationRecoveryMode | null {
+    const preview = this.preview;
+    if (
+      !preview ||
+      !preview.feedback_enabled ||
+      !preview.feedback_readable ||
+      !preview.artifact_upload_enabled ||
+      preview.existing_thread_id
+    )
+      return null;
+    if (
+      preview.native_resume_available &&
+      preview.allowed_recovery_modes.includes('native_resume')
+    )
+      return 'native_resume';
+    return preview.allowed_recovery_modes.includes('published_branch_handoff')
+      ? 'published_branch_handoff'
+      : null;
+  }
+
+  private async loadPreview() {
+    if (!this.execution || this.loading || this.saving) return;
+    const executionId = this.execution.id;
+    const generation = ++this.generation;
+    this.open = true;
+    this.loading = true;
+    this.preview = null;
+    this.acknowledged = false;
+    this.error = '';
+    try {
+      const preview = await previewFlowContinuation(executionId);
+      if (generation !== this.generation) return;
+      if (
+        preview.execution_id !== executionId ||
+        preview.flow_id !== this.execution?.flow_id
+      ) {
+        throw new Error(
+          'The preview does not match this execution. Reload and try again.'
+        );
+      }
+      this.preview = preview;
+    } catch (error) {
+      if (generation === this.generation)
+        this.error =
+          error instanceof Error
+            ? error.message
+            : 'Unable to preview follow-up.';
+    } finally {
+      if (generation === this.generation) this.loading = false;
+    }
+  }
+
+  private async adopt() {
+    const mode = this.mode();
+    if (
+      !mode ||
+      !this.preview?.head_sha ||
+      this.loading ||
+      this.saving ||
+      (mode === 'published_branch_handoff' && !this.acknowledged)
+    )
+      return;
+    const executionId = this.execution!.id;
+    const generation = this.generation;
+    this.saving = true;
+    this.error = '';
+    try {
+      await adoptFlowContinuation(executionId, {
+        recovery_mode: mode,
+        expected_head_sha: this.preview.head_sha,
+        acknowledge_fresh_conversation:
+          mode === 'published_branch_handoff' && this.acknowledged,
+      });
+      if (generation !== this.generation) return;
+      this.adopted = true;
+      this.open = false;
+    } catch (error) {
+      if (generation !== this.generation) return;
+      if (error instanceof FlowContinuationError && error.status === 409) {
+        this.saving = false;
+        await this.loadPreview();
+        if (this.execution?.id === executionId && this.open) {
+          this.error =
+            'The PR or follow-up state changed. Review the refreshed preview and confirm again.';
+        }
+      } else if (
+        !(error instanceof FlowContinuationError) ||
+        error.status >= 500
+      ) {
+        this.saving = false;
+        await this.loadPreview();
+        if (
+          this.execution?.id === executionId &&
+          this.open &&
+          !this.preview?.existing_thread_id
+        ) {
+          this.error =
+            'Could not confirm whether follow-up was enabled. Check the refreshed preview before trying again.';
+        }
+      } else {
+        this.error =
+          error instanceof Error ? error.message : 'Unable to start follow-up.';
+      }
+    } finally {
+      if (this.execution?.id === executionId) this.saving = false;
+    }
+  }
+
+  private close() {
+    if (this.saving) return;
+    this.generation++;
+    this.open = false;
+    this.loading = false;
+    this.acknowledged = false;
+  }
+
+  render() {
+    if (!this.eligible()) return nothing;
+    if (this.adopted)
+      return html`<sl-alert open variant="success"
+        >PR follow-up is configured. Repairs will use this PR and the flow's
+        limits. Merge remains manual.</sl-alert
+      >`;
+    const preview = this.preview;
+    const mode = this.mode();
+    const prUrl =
+      preview?.pr_url && /^https?:\/\//.test(preview.pr_url)
+        ? preview.pr_url
+        : '';
+    return html`
+      <div class="action">
+        <sl-button data-continuation-preview @click=${this.loadPreview}
+          >Set up PR follow-up</sl-button
+        >
+      </div>
+      <sl-dialog
+        label="Set up PR follow-up"
+        .open=${this.open}
+        @sl-request-close=${(event: Event) => {
+          event.preventDefault();
+          this.close();
+        }}
+      >
+        ${
+          this.loading
+            ? html`<sl-spinner></sl-spinner>
+                <p>Checking this PR and its saved execution state...</p>`
+            : nothing
+        }
+        ${
+          preview
+            ? html`
+                <p>
+                  Enable review and CI repairs for
+                  <a href=${prUrl} target="_blank" rel="noopener noreferrer"
+                    >${preview.pr_url}</a
+                  >.
+                </p>
+                <p>
+                  Branch: <code>${preview.branch}</code><br />Current commit:
+                  <code>${preview.head_sha}</code>
+                </p>
+                ${preview.existing_thread_id ? html`<sl-alert open>This PR already has follow-up configured (${preview.existing_thread_state || 'registered'}).</sl-alert>` : nothing}
+                ${!preview.feedback_enabled ? html`<sl-alert open>Enable PR review and CI follow-up in <a href=${`/console/flows/${encodeURIComponent(preview.flow_id)}?edit=true`}>this flow's settings</a>, then reload this preview.</sl-alert>` : nothing}
+                ${!preview.artifact_upload_enabled ? html`<sl-alert open>Saved execution state uploads must be enabled by your deployment administrator before follow-up can start.</sl-alert>` : nothing}
+                ${!preview.feedback_readable ? html`<sl-alert open variant="warning">Review and CI access must be available before follow-up can start. ${preview.feedback_blocked_reason || ''}</sl-alert>` : nothing}
+                ${preview.warnings.map((warning) => html`<sl-alert open variant="warning">${warning}</sl-alert>`)}
+                ${mode === 'native_resume' ? html`<p>The next repair will continue the previous agent conversation using its saved checkpoint.</p>` : nothing}
+                ${
+                  mode === 'published_branch_handoff'
+                    ? html` <p>
+                          The previous conversation cannot be restored. The next
+                          repair starts a fresh conversation from this published
+                          branch and the current issue and PR context.
+                        </p>
+                        <sl-checkbox
+                          data-continuation-ack
+                          .checked=${this.acknowledged}
+                          ?disabled=${this.saving}
+                          @sl-change=${(event: Event) => {
+                            this.acknowledged = (
+                              event.target as HTMLInputElement
+                            ).checked;
+                          }}
+                        >
+                          I understand that follow-up starts a fresh
+                          conversation and unpublished workspace changes will
+                          not be recovered.
+                        </sl-checkbox>`
+                    : nothing
+                }
+                ${!mode && !preview.existing_thread_id ? html`<p>Follow-up is unavailable until the requirements above are met.</p>` : nothing}
+                <p>
+                  Future review findings or failed CI can start repairs within
+                  the flow's limits. Merge remains manual.
+                </p>
+              `
+            : nothing
+        }
+        ${this.error ? html`<sl-alert data-continuation-error variant="danger" open>${this.error}</sl-alert>` : nothing}
+        <sl-button slot="footer" @click=${this.close} ?disabled=${this.saving}
+          >Cancel</sl-button
+        >
+        <sl-button
+          slot="footer"
+          data-continuation-reload
+          @click=${this.loadPreview}
+          ?disabled=${this.loading || this.saving}
+          >Reload preview</sl-button
+        >
+        <sl-button
+          slot="footer"
+          data-continuation-confirm
+          variant="primary"
+          @click=${this.adopt}
+          ?loading=${this.saving}
+          ?disabled=${this.loading || this.saving || !mode || !preview?.head_sha || (mode === 'published_branch_handoff' && !this.acknowledged)}
+          >Enable follow-up for this PR</sl-button
+        >
+      </sl-dialog>
+    `;
+  }
+}

--- a/frontend/src/components/preloop-flow-form-feedback.test.ts
+++ b/frontend/src/components/preloop-flow-form-feedback.test.ts
@@ -92,7 +92,9 @@ describe('PreloopFlowForm PR feedback controls', () => {
       max_age_hours: 72,
       debounce_seconds: 0,
     });
-    expect(element.shadowRoot!.textContent).to.include('cold handoff');
+    expect(element.shadowRoot!.textContent).to.include(
+      'starts fresh from the issue and PR context'
+    );
     expect(element.shadowRoot!.textContent).to.include('Merge remains manual');
   });
 

--- a/frontend/src/components/preloop-flow-form-feedback.test.ts
+++ b/frontend/src/components/preloop-flow-form-feedback.test.ts
@@ -1,0 +1,196 @@
+import { expect, fixture, fixtureCleanup, html } from '@open-wc/testing';
+import sinon, { SinonSandbox } from 'sinon';
+import './preloop-flow-form.ts';
+import type { PreloopFlowForm } from './preloop-flow-form';
+
+describe('PreloopFlowForm PR feedback controls', () => {
+  let sandbox: SinonSandbox;
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    sandbox = sinon.createSandbox();
+    sandbox.stub(window, 'fetch').callsFake(async () => new Response('[]'));
+  });
+  afterEach(() => {
+    fixtureCleanup();
+    sandbox.restore();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  const mount = async (agentConfig?: unknown) => {
+    const element = await fixture<PreloopFlowForm>(
+      html`<preloop-flow-form
+        .flow=${{ id: 'saved-flow', name: 'Implement', agent_type: 'codex', agent_config: agentConfig }}
+      ></preloop-flow-form>`
+    );
+    while ((element as any)._loadingReferenceData) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await element.updateComplete;
+    return element;
+  };
+  const control = (element: PreloopFlowForm, field: string): any => {
+    const input = element.shadowRoot!.querySelector(
+      `[data-feedback="${field}"]`
+    );
+    expect(input, `feedback ${field} control`).to.exist;
+    return input;
+  };
+  const toggle = async (element: PreloopFlowForm, checked: boolean) => {
+    const input = control(element, 'enabled');
+    input.checked = checked;
+    input.dispatchEvent(new Event('sl-change', { bubbles: true }));
+    await element.updateComplete;
+  };
+  const change = async (
+    element: PreloopFlowForm,
+    field: string,
+    value: string
+  ) => {
+    const input = control(element, field);
+    input.value = value;
+    input.dispatchEvent(new Event('sl-input', { bubbles: true }));
+    await element.updateComplete;
+  };
+  const submit = async (element: PreloopFlowForm) => {
+    const listener = sandbox.spy();
+    element.addEventListener('flow-submit', listener, { once: true });
+    await (element as any).handleFormSubmit(new Event('submit'));
+    return listener;
+  };
+
+  it('keeps existing flows opted out without inventing policy on save', async () => {
+    const element = await mount({ image: 'project:test' });
+    expect(control(element, 'enabled').checked).to.equal(false);
+    expect(element.shadowRoot!.querySelector('[data-feedback="max_turns"]')).to
+      .not.exist;
+    const event = await submit(element);
+    expect(event.firstCall.args[0].detail.flow.agent_config).to.deep.equal({
+      image: 'project:test',
+    });
+  });
+
+  it('opts in through rendered controls and serializes bounded numeric policy and exact IDs', async () => {
+    const element = await mount();
+    await toggle(element, true);
+    await change(element, 'trusted_reviewer_ids', '123, 9007199254740993');
+    await change(element, 'implementer_actor_ids', '456');
+    await change(element, 'max_turns', '7');
+    await change(element, 'max_cost', '12.50');
+    await change(element, 'max_age_hours', '72');
+    await change(element, 'debounce_seconds', '0');
+    const event = await submit(element);
+    expect(event.callCount).to.equal(1);
+    expect(
+      event.firstCall.args[0].detail.flow.agent_config.feedback
+    ).to.deep.equal({
+      enabled: true,
+      trusted_reviewer_ids: ['123', '9007199254740993'],
+      implementer_actor_ids: ['456'],
+      max_turns: 7,
+      max_cost: 12.5,
+      max_age_hours: 72,
+      debounce_seconds: 0,
+    });
+    expect(element.shadowRoot!.textContent).to.include('cold handoff');
+    expect(element.shadowRoot!.textContent).to.include('Merge remains manual');
+  });
+
+  it('hydrates JSON configuration and preserves routing, execution and advanced feedback keys', async () => {
+    const saved = {
+      execution_path: 'persistent',
+      target_agent_id: 'agent-1',
+      environment_profile: 'tests',
+      custom_option: { keep: true },
+      model_routing: {
+        version: 1,
+        rules: [
+          {
+            id: 'rule',
+            labels: { any: ['docs'] },
+            ai_model_id: 'model-1',
+            agent_type: 'codex',
+          },
+        ],
+      },
+      feedback: {
+        enabled: true,
+        trusted_reviewer_ids: [123],
+        implementer_actor_ids: ['456'],
+        max_turns: 9,
+        max_cost: 23,
+        max_age_hours: 48,
+        debounce_seconds: 60,
+        required_checks: ['unit'],
+        max_no_progress: 3,
+        future_policy: { keep: true },
+      },
+    };
+    const element = await mount(JSON.stringify(saved));
+    expect(control(element, 'enabled').checked).to.equal(true);
+    expect(control(element, 'trusted_reviewer_ids').value).to.equal('123');
+    expect(control(element, 'max_turns').value).to.equal('9');
+    const event = await submit(element);
+    expect(event.firstCall.args[0].detail.flow.agent_config).to.deep.equal(
+      saved
+    );
+    await toggle(element, false);
+    const disabled = await submit(element);
+    expect(disabled.firstCall.args[0].detail.flow.agent_config).to.deep.equal({
+      ...saved,
+      feedback: { ...saved.feedback, enabled: false },
+    });
+  });
+
+  it('refreshes controls when a preset is selected and clears them for a blank flow', async () => {
+    const element = await mount({ feedback: { enabled: true, max_turns: 9 } });
+    await (element as any).selectPreset({
+      id: 'preset',
+      name: 'Preset',
+      agent_type: 'codex',
+      agent_config: { feedback: { enabled: true, max_turns: 2 } },
+    });
+    await element.updateComplete;
+    expect(control(element, 'max_turns').value).to.equal('2');
+    (element as any).selectBlankFlow();
+    await element.updateComplete;
+    expect(control(element, 'enabled').checked).to.equal(false);
+    expect(element.flow.agent_config).to.equal(undefined);
+  });
+
+  it('does not mutate the original config while editing feedback', async () => {
+    const saved = {
+      feedback: { enabled: true, max_turns: 5, trusted_reviewer_ids: [123] },
+      image: 'project:test',
+    };
+    const element = await mount(saved);
+    await change(element, 'max_turns', '8');
+    await change(element, 'trusted_reviewer_ids', '789');
+    expect(saved.feedback).to.deep.equal({
+      enabled: true,
+      max_turns: 5,
+      trusted_reviewer_ids: [123],
+    });
+  });
+
+  for (const [field, value] of [
+    ['max_turns', '0'],
+    ['max_turns', '1.5'],
+    ['max_cost', '-1'],
+    ['max_cost', ''],
+    ['max_age_hours', '8761'],
+    ['debounce_seconds', '-1'],
+    ['trusted_reviewer_ids', 'review-bot'],
+    ['implementer_actor_ids', '1.5'],
+  ]) {
+    it(`rejects invalid ${field} ${JSON.stringify(value)} before submit`, async () => {
+      const element = await mount();
+      await toggle(element, true);
+      await change(element, field, value);
+      const event = await submit(element);
+      expect(event.callCount).to.equal(0);
+      expect((element as any).formError).to.include('Follow-up');
+      expect(control(element, field).value).to.equal(value);
+    });
+  }
+});

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -954,10 +954,10 @@ export class PreloopFlowForm extends LitElement {
         </div>
         <p class="notifications-help">
           Repair review findings and failing CI on pull or merge requests
-          published by this flow. Each repair starts a new execution and resumes
-          the saved native conversation when a compatible checkpoint is
-          available. Otherwise it reports an explicit cold handoff using current
-          issue and PR context. Merge remains manual.
+          published by this flow. Each repair starts a new execution and
+          continues the previous agent conversation when its saved checkpoint is
+          compatible. Otherwise it starts fresh from the issue and PR context
+          and reports that choice. Merge remains manual.
         </p>
         <sl-checkbox
           data-feedback="enabled"
@@ -975,8 +975,8 @@ export class PreloopFlowForm extends LitElement {
                   Limits apply across the PR's repair turns. The cost limit is
                   cumulative estimated USD; each execution also keeps its own
                   budget. Pending CI waits for results without keeping the agent
-                  running. Existing PRs need an eligible recorded publication
-                  before follow-up can begin.
+                  running. Enabling applies to future runs. Existing PRs require
+                  explicit adoption from the execution that published them.
                 </p>
                 <div class="form-grid">
                   ${[

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -45,6 +45,37 @@ import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 export const FLOW_TIMEOUT_MIN_SECONDS = 60;
 export const FLOW_TIMEOUT_MAX_SECONDS = 86400;
 
+const FEEDBACK_LIMITS = {
+  max_turns: {
+    label: 'Maximum repair turns',
+    default: 5,
+    min: 1,
+    max: 100,
+    step: 1,
+  },
+  max_cost: {
+    label: 'Cumulative cost limit (USD)',
+    default: 100,
+    min: 0.01,
+    max: 1000000,
+    step: 0.01,
+  },
+  max_age_hours: {
+    label: 'Follow-up lifetime (hours)',
+    default: 168,
+    min: 1,
+    max: 8760,
+    step: 1,
+  },
+  debounce_seconds: {
+    label: 'Feedback debounce (seconds)',
+    default: 30,
+    min: 0,
+    max: 3600,
+    step: 1,
+  },
+} as const;
+
 @customElement('preloop-flow-form')
 export class PreloopFlowForm extends LitElement {
   static styles = [
@@ -841,6 +872,159 @@ export class PreloopFlowForm extends LitElement {
     });
   }
 
+  private feedbackConfig(): Record<string, unknown> {
+    const feedback = this.parseAgentConfig(this.flow.agent_config).feedback;
+    return feedback && typeof feedback === 'object' && !Array.isArray(feedback)
+      ? { ...(feedback as Record<string, unknown>) }
+      : {};
+  }
+
+  private updateFeedback(field: string, value: unknown) {
+    const config = this.parseAgentConfig(this.flow.agent_config);
+    const feedback = this.feedbackConfig();
+    if (field === 'enabled' && value === true) {
+      for (const [key, limit] of Object.entries(FEEDBACK_LIMITS)) {
+        if (!(key in feedback)) feedback[key] = limit.default;
+      }
+    }
+    this.flow = {
+      ...this.flow,
+      agent_config: { ...config, feedback: { ...feedback, [field]: value } },
+    };
+  }
+
+  private validatedFeedback(): Record<string, unknown> {
+    const feedback = this.feedbackConfig();
+    if (feedback.enabled !== true) return feedback;
+    for (const [key, limit] of Object.entries(FEEDBACK_LIMITS)) {
+      if (!(key in feedback)) continue;
+      const raw = feedback[key];
+      const value =
+        typeof raw === 'number' || (typeof raw === 'string' && raw.trim())
+          ? Number(raw)
+          : NaN;
+      if (
+        !Number.isFinite(value) ||
+        value < limit.min ||
+        value > limit.max ||
+        (limit.step === 1 && !Number.isInteger(value))
+      ) {
+        throw new Error(
+          `Follow-up: ${limit.label} must be ${limit.step === 1 ? 'a whole number' : 'a number'} between ${limit.min} and ${limit.max}.`
+        );
+      }
+      feedback[key] = value;
+    }
+    for (const key of ['trusted_reviewer_ids', 'implementer_actor_ids']) {
+      if (!(key in feedback)) continue;
+      const raw = feedback[key];
+      const ids =
+        typeof raw === 'string'
+          ? raw
+              .split(',')
+              .map((id) => id.trim())
+              .filter(Boolean)
+          : raw;
+      if (
+        !Array.isArray(ids) ||
+        ids.some(
+          (id) =>
+            !(
+              (typeof id === 'string' && /^[1-9][0-9]*$/.test(id)) ||
+              (typeof id === 'number' && Number.isSafeInteger(id) && id > 0)
+            )
+        )
+      ) {
+        throw new Error(
+          'Follow-up: enter comma-separated numeric provider actor IDs, not usernames.'
+        );
+      }
+      feedback[key] = ids;
+    }
+    return feedback;
+  }
+
+  private renderFeedbackControls() {
+    const feedback = this.feedbackConfig();
+    const enabled = feedback.enabled === true;
+    return html`
+      <sl-card data-feedback-editor>
+        <div slot="header" class="card-header-title">
+          <sl-icon name="arrow-repeat"></sl-icon> PR review and CI follow-up
+        </div>
+        <p class="notifications-help">
+          Repair review findings and failing CI on pull or merge requests
+          published by this flow. Each repair starts a new execution and resumes
+          the saved native conversation when a compatible checkpoint is
+          available. Otherwise it reports an explicit cold handoff using current
+          issue and PR context. Merge remains manual.
+        </p>
+        <sl-checkbox
+          data-feedback="enabled"
+          .checked=${enabled}
+          @sl-change=${(e: Event) => this.updateFeedback('enabled', (e.target as HTMLInputElement).checked)}
+          >Continue implementation after PR review or CI failure</sl-checkbox
+        >
+        ${
+          enabled
+            ? html`
+                <p
+                  class="notifications-help"
+                  style="margin-top: var(--sl-spacing-medium);"
+                >
+                  Limits apply across the PR's repair turns. The cost limit is
+                  cumulative estimated USD; each execution also keeps its own
+                  budget. Pending CI waits for results without keeping the agent
+                  running. Existing PRs need an eligible recorded publication
+                  before follow-up can begin.
+                </p>
+                <div class="form-grid">
+                  ${[
+                    [
+                      'trusted_reviewer_ids',
+                      'Trusted reviewer actor IDs',
+                      'Comma-separated GitHub or GitLab numeric user IDs from the reviewer account or integration. Unlisted bots are ignored; comment markers do not grant trust.',
+                    ],
+                    [
+                      'implementer_actor_ids',
+                      'Implementer actor IDs',
+                      'Comma-separated numeric user IDs used by the implementing agent. Their own comments are ignored to prevent feedback loops.',
+                    ],
+                  ].map(
+                    ([key, label, help]) => html`
+                      <sl-input
+                        data-feedback=${key}
+                        label=${label}
+                        help-text=${help}
+                        .value=${Array.isArray(feedback[key]) ? (feedback[key] as unknown[]).join(', ') : String(feedback[key] ?? '')}
+                        @sl-input=${(e: Event) => this.updateFeedback(key, (e.target as HTMLInputElement).value)}
+                      ></sl-input>
+                    `
+                  )}
+                  ${Object.entries(FEEDBACK_LIMITS).map(
+                    ([key, limit]) => html`
+                      <sl-input
+                        data-feedback=${key}
+                        type="number"
+                        label=${limit.label}
+                        min=${limit.min}
+                        max=${limit.max}
+                        step=${limit.step}
+                        required
+                        help-text=${key === 'debounce_seconds' ? 'Collect nearby feedback into one repair turn before starting work.' : `${limit.min}–${limit.max}.`}
+                        .value=${String(feedback[key] ?? limit.default)}
+                        @sl-input=${(e: Event) => this.updateFeedback(key, (e.target as HTMLInputElement).value)}
+                      ></sl-input>
+                    `
+                  )}
+                </div>
+              `
+            : nothing
+        }
+      </sl-card>
+    `;
+  }
+
   private buildAgentConfig(): Record<string, unknown> {
     const config = this.parseAgentConfig(this.flow.agent_config);
     if (this.longRunningAgents.length > 0) {
@@ -849,6 +1033,9 @@ export class PreloopFlowForm extends LitElement {
         this.flowExecutionPath === 'persistent'
           ? this.targetAgentId
           : undefined;
+    }
+    if (config.feedback !== undefined) {
+      config.feedback = this.validatedFeedback();
     }
     const rules = this.normalizedRoutingRules();
     if (rules.length > 0) {
@@ -2332,6 +2519,8 @@ export class PreloopFlowForm extends LitElement {
               : nothing
           }
         </sl-card>
+
+        ${this.renderFeedbackControls()}
 
         <sl-card>
           <div slot="header" class="card-header-title">

--- a/frontend/src/views/authed/flow-execution-view.ts
+++ b/frontend/src/views/authed/flow-execution-view.ts
@@ -46,6 +46,7 @@ import {
 } from '../../utils/execution-presentation';
 import { renderFailureCategoryChip } from '../../utils/failure-category';
 import '../../components/preloop-gateway-event.ts';
+import '../../components/preloop-execution-continuation';
 import '../../components/view-header.ts';
 import '../../components/json-tree.ts';
 import '../../components/session-chat-view';
@@ -2903,6 +2904,9 @@ ${execution.resolved_input_prompt}</pre>
       <div class="column-layout wide">
         <div class="main-column">
           ${this.renderSummaryStrip(execution)}
+          <preloop-execution-continuation
+            .execution=${execution}
+          ></preloop-execution-continuation>
           ${
             errorLine
               ? html`<div

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -771,3 +771,13 @@ point in time), they do not restore in place:
 ### To 1.0.0
 
 No special actions are required when upgrading from previous versions.
+
+### Native conversation checkpoints
+
+`values-native-checkpoints.yaml` is an optional overlay using the existing shared
+`extraEnv` support. Chart defaults remain disabled. Deploy the transaction lock
+corrections before enabling uploads, preserve existing signing/encryption keys,
+and merge the overlay entries into your full `extraEnv` list. The overlay's
+16 MiB compressed upload cap fits below the default 32 MiB proxy limit. See the
+[deployment prerequisites](../../docs/guide/flows/durable-implementation-feedback.md#deployment-prerequisites)
+for retention, quota, egress, rollback and validation requirements.

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -778,6 +778,7 @@ No special actions are required when upgrading from previous versions.
 `extraEnv` support. Chart defaults remain disabled. Deploy the transaction lock
 corrections before enabling uploads, preserve existing signing/encryption keys,
 and merge the overlay entries into your full `extraEnv` list. The overlay's
-16 MiB compressed upload cap fits below the default 32 MiB proxy limit. See the
+16 MiB example compressed upload cap fits below the default 32 MiB proxy limit;
+measure representative archives and adjust both limits before use. See the
 [deployment prerequisites](../../docs/guide/flows/durable-implementation-feedback.md#deployment-prerequisites)
 for retention, quota, egress, rollback and validation requirements.

--- a/helm/preloop/values-native-checkpoints.yaml
+++ b/helm/preloop/values-native-checkpoints.yaml
@@ -1,4 +1,5 @@
-# Optional native-conversation and workspace checkpoint overlay.
+# Optional example native-conversation and workspace checkpoint overlay.
+# Size a representative archive before use; 16 MiB will not fit every repository.
 # Deploy the transaction-resilience backend and EE companion first.
 # Review docs/guide/flows/durable-implementation-feedback.md before enabling.
 #

--- a/helm/preloop/values-native-checkpoints.yaml
+++ b/helm/preloop/values-native-checkpoints.yaml
@@ -1,0 +1,18 @@
+# Optional native-conversation and workspace checkpoint overlay.
+# Deploy the transaction-resilience backend and EE companion first.
+# Review docs/guide/flows/durable-implementation-feedback.md before enabling.
+#
+# Helm replaces lists: merge these entries into any existing extraEnv list.
+# This file does not set, rotate or change the source of either encryption
+# or signing keys, and does not increase ingress/console body-size limits.
+extraEnv:
+  - name: FLOW_ARTIFACT_DIRECT_UPLOAD
+    value: "true"
+  # Both workspace and native archive uploads use this compressed-byte cap.
+  # 16 MiB stays below the default ingress/console limit of 32 MiB.
+  - name: WORKSPACE_SNAPSHOT_MAX_BYTES
+    value: "16777216"
+  - name: FLOW_NATIVE_SESSION_RETENTION_HOURS
+    value: "168"
+  - name: WORKSPACE_SNAPSHOT_TTL_HOURS
+    value: "168"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7903,6 +7903,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/flows/executions/{execution_id}/continuation:
+    get:
+      tags:
+      - Flows
+      summary: Preview Execution Continuation
+      description: Inspect one publication without enabling repairs or holding DB
+        during I/O.
+      operationId: preview_execution_continuation_api_v1_flows_executions__execution_id__continuation_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: execution_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Execution Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContinuationPreview'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - Flows
+      summary: Adopt Execution Continuation
+      description: Explicitly subscribe one previously published PR to bounded repairs.
+      operationId: adopt_execution_continuation_api_v1_flows_executions__execution_id__continuation_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: execution_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Execution Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContinuationAdoptRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContinuationAdoptResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/flows/executions/{execution_id}/result:
     get:
       tags:
@@ -13373,6 +13439,126 @@ components:
         \    - \"args.command.contains('rm -rf')\"\n    - \"args.path.startsWith('/etc/')\"\
         \n    - \"args.tags.exists(t, t == 'production')\"\n    - \"args.amount >\
         \ 1000 && args.approved == false\""
+    ContinuationAdoptRequest:
+      properties:
+        recovery_mode:
+          type: string
+          enum:
+          - native_resume
+          - published_branch_handoff
+          title: Recovery Mode
+        expected_head_sha:
+          type: string
+          pattern: ^[0-9a-fA-F]{40,64}$
+          title: Expected Head Sha
+        acknowledge_fresh_conversation:
+          type: boolean
+          title: Acknowledge Fresh Conversation
+          default: false
+      type: object
+      required:
+      - recovery_mode
+      - expected_head_sha
+      title: ContinuationAdoptRequest
+    ContinuationAdoptResponse:
+      properties:
+        thread_id:
+          type: string
+          format: uuid
+          title: Thread Id
+        state:
+          type: string
+          title: State
+        pr_url:
+          type: string
+          title: Pr Url
+        recovery_mode:
+          type: string
+          enum:
+          - native_resume
+          - published_branch_handoff
+          title: Recovery Mode
+      type: object
+      required:
+      - thread_id
+      - state
+      - pr_url
+      - recovery_mode
+      title: ContinuationAdoptResponse
+    ContinuationPreview:
+      properties:
+        execution_id:
+          type: string
+          format: uuid
+          title: Execution Id
+        flow_id:
+          type: string
+          format: uuid
+          title: Flow Id
+        pr_url:
+          type: string
+          title: Pr Url
+        branch:
+          type: string
+          title: Branch
+        head_sha:
+          type: string
+          title: Head Sha
+        feedback_enabled:
+          type: boolean
+          title: Feedback Enabled
+        artifact_upload_enabled:
+          type: boolean
+          title: Artifact Upload Enabled
+        feedback_readable:
+          type: boolean
+          title: Feedback Readable
+          default: false
+        feedback_blocked_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Feedback Blocked Reason
+        native_resume_available:
+          type: boolean
+          title: Native Resume Available
+        existing_thread_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Existing Thread Id
+        existing_thread_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Existing Thread State
+        allowed_recovery_modes:
+          items:
+            type: string
+            enum:
+            - native_resume
+            - published_branch_handoff
+          type: array
+          title: Allowed Recovery Modes
+        warnings:
+          items:
+            type: string
+          type: array
+          title: Warnings
+      type: object
+      required:
+      - execution_id
+      - flow_id
+      - pr_url
+      - branch
+      - head_sha
+      - feedback_enabled
+      - artifact_upload_enabled
+      - native_resume_available
+      - allowed_recovery_modes
+      - warnings
+      title: ContinuationPreview
     CostAnalyticsSummaryResponse:
       properties:
         period_start:


### PR DESCRIPTION
Existing implementation flows could publish a PR without subscribing to its reviews or CI. Enabling feedback later could sweep historical PRs, and a stored CLI session ID alone could not restore a conversation. This adds visible flow settings and an explicit preview/adoption action for a selected successful publishing execution.

- Enable bounded follow-up for future runs without adopting the backlog. Existing PRs require verified repository/branch ownership and current-head confirmation; starting without the original checkpoint requires an explicit fresh-conversation acknowledgment.
- Recheck current reviewer trust, budgets and activation state before reserving a repair. Preserve spent budgets and lifetime across pause/resume; duplicate adoption/events do not create duplicate turns.
- Construct GitHub App credentials from account-scoped installation metadata. Missing permission to discover repository requirements allows repairs from fully read, trusted feedback while keeping readiness unverified. Other incomplete provider reads remain blocked.
- Document and provide an optional checkpoint Helm overlay, including retention, shared encryption/signing keys and upload/proxy sizing. Deployment remains opt-in. The paired EE change accepts a reviewed deployment values file.

Validation: **539 backend tests and 152 browser tests passed**, including encrypted artifact transport, adoption/lease races, policy changes, trigger spoofing, provider permissions, migration compatibility and execution UI. All changed-file hooks passed, including generated OpenAPI. A separate immutable-image Codex smoke restored the selected conversation across two fresh containers using a local model fixture. No paid model or production flow was run for validation.

Includes prerequisite #477 until it merges; merge that reliability fix first. The main integration preserves approval API-key attribution while keeping authentication sessions closed before human waits. No automatic merge behavior is introduced.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium**
> Changes to important logic (auth, DB lock ordering, and checkpoint-recovery adoption), but no security vulnerabilities found and the change is well-tested.

> **Overview**
> Makes PR-feedback continuation explicit and resumable: gates opt-in to future runs, adds a preview-and-adopt API for one past publication, re-checks policy/trust/budgets at atomic repair reservation, and hardens DB/cancellation/credential handling. Verified account ownership, secret handling, fail-closed recovery, and trigger-spoofing guards; no blocking issues found.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 721351f5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->