### PR TITLE
Fix Google model listing: list over plain HTTPS, not the optional SDK

### DIFF
--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -248,22 +248,27 @@ async def get_available_models_for_provider(
         return _fallback([], ERROR_UNSUPPORTED)
 
 
-def _discovery_http_client() -> Optional[Any]:
+def _discovery_http_client(*, required: bool = False) -> Optional[Any]:
     """Return an httpx client that trusts a mounted private CA, if configured.
 
     The OpenAI SDK uses certifi by default and ignores SSL_CERT_FILE.
     Operators mount a CA via Helm extraVolumes and set SSL_CERT_FILE;
     that path is passed as httpx ``verify``.
+
+    SDK-backed paths only need a client when a private CA is configured, so
+    the default is to return None and let the SDK build its own. Paths that
+    speak plain HTTPS themselves (Google) pass ``required=True`` and always
+    get a client, with the private CA applied when one is configured.
     """
     verify = ssl_verify_setting()
-    if verify is None:
+    if verify is None and not required:
         return None
     import httpx
 
-    return httpx.AsyncClient(
-        verify=verify,
-        timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
-    )
+    client_kwargs: Dict[str, Any] = {"timeout": MODEL_DISCOVERY_TIMEOUT_SECONDS}
+    if verify is not None:
+        client_kwargs["verify"] = verify
+    return httpx.AsyncClient(**client_kwargs)
 
 
 def validate_discovery_endpoint(api_endpoint: str) -> str:
@@ -620,127 +625,124 @@ async def _get_anthropic_models(api_key: Optional[str] = None) -> ModelDiscovery
     return _live(model_ids)
 
 
-# Fallback catalog used when the Google listing call cannot be made.
-# Provenance: hand-curated current Gemini ids, no deprecated preview/exp names.
-def _build_scoped_google_client(api_key: str) -> Optional[object]:
-    """Build a Gemini model client bound to ``api_key`` only, or None.
+GOOGLE_MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
-    ``genai.configure(api_key=...)`` mutates PROCESS-GLOBAL SDK state, so two
-    concurrent discovery requests for different accounts can race and one
-    account's listing can be made with the other's key. Building a per-call
-    client keeps the key on the call stack instead.
+# Page size for the Google listing call. The API caps a page at 1000 entries
+# and Google serves far fewer chat models than that, so one page is normally
+# enough; nextPageToken is still followed, bounded by GOOGLE_MAX_LIST_PAGES so
+# a misbehaving upstream cannot make this loop forever.
+GOOGLE_LIST_PAGE_SIZE = 200
+GOOGLE_MAX_LIST_PAGES = 10
 
-    The pinned SDK (google-generativeai 0.8.x) has no ``genai.Client``, but
-    ``genai.list_models`` accepts a ``client`` argument, and the underlying
-    ``ModelServiceClient`` takes a per-instance api_key through
-    ``ClientOptions``. Returns None when that construction is unavailable, so
-    the caller can fall back rather than lose listing entirely.
+
+def _extract_google_model_ids(payload: Any) -> List[str]:
+    """Pull bare Gemini ids out of one v1beta ``models.list`` page.
+
+    Names arrive as ``models/gemini-2.5-pro``; the picker and the gateway use
+    the bare ``gemini-...`` form, so the prefix is stripped (this matches what
+    the old SDK path produced). Entries are kept only when
+    ``supportedGenerationMethods`` includes ``generateContent``: the same
+    listing also carries embedding and token-counting-only models, which are
+    not usable as chat models. An entry with no methods field at all is kept,
+    as it was on the SDK path, so a future response shape does not empty the
+    picker.
     """
-    try:
-        import google.ai.generativelanguage as glm
-        from google.api_core import client_options as client_options_lib
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("models")
+    if not isinstance(entries, list):
+        return []
 
-        return glm.ModelServiceClient(
-            client_options=client_options_lib.ClientOptions(api_key=api_key)
-        )
-    except Exception as e:
-        # Never log the key or the exception text; the type name is enough to
-        # tell an operator which construction path is unavailable.
-        logger.debug(
-            "Key-scoped Google client unavailable (%s), falling back to "
-            "process-global configure()",
-            type(e).__name__,
-        )
-        return None
+    model_ids: List[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        methods = entry.get("supportedGenerationMethods")
+        if isinstance(methods, list) and "generateContent" not in methods:
+            continue
+        model_id = name.strip().removeprefix("models/").strip()
+        if model_id:
+            model_ids.append(model_id)
+    return model_ids
 
 
 async def _get_google_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """List Google Gemini models live via ``genai.list_models``.
+    """List Google Gemini models live via the REST listing endpoint.
 
-    Listing API: Google AI Generative Language ``models.list``
-    (https://generativelanguage.googleapis.com/v1beta/models). ``list_models``
-    itself fails on a bad key, so no separate paid ``generate_content``
+    ``GET https://generativelanguage.googleapis.com/v1beta/models``, paginated
+    on ``nextPageToken``. This is plain HTTPS on purpose: the SDK
+    (google-generativeai) is an optional ``ai-providers`` extra that the
+    hash-pinned runtime lock the image installs does not carry, so every
+    container answered ``sdk_missing`` for Google while every other provider
+    listed fine.
+
+    The key travels in the ``x-goog-api-key`` HEADER, never the documented
+    ``?key=`` query parameter: query strings are written to access logs and
+    proxy logs in plaintext (2026-08-04 key-leak incident; the same rule is
+    stated for our own API in the endpoint docstring).
+
+    The listing itself authenticates, so no separate paid ``generateContent``
     validation ping is made.
     """
-    if not api_key:
+    if not (api_key or "").strip():
         return _fallback([], ERROR_MISSING_KEY)
 
+    # required=True never returns None, hence the plain Any annotation.
+    client: Any = _discovery_http_client(required=True)
+    fetched_models: List[str] = []
     try:
-        import google.generativeai as genai
-    except ImportError:
-        logger.warning("Google GenerativeAI package not installed, cannot list models")
-        return _fallback([], ERROR_SDK_MISSING)
-
-    try:
-        fetched_models = []
-        list_models = getattr(genai, "list_models", None)
-        if not callable(list_models):
-            logger.warning("genai.list_models unavailable")
-            return _fallback([], ERROR_SDK_MISSING)
-
-        scoped_client = _build_scoped_google_client(api_key)
-        if scoped_client is not None:
-            listing = list_models(client=scoped_client)
-        else:
-            # No key-scoped client available: fall back to the process-global
-            # configure() so listing keeps working on older/newer SDKs. This
-            # path carries the cross-request contamination risk described in
-            # _build_scoped_google_client.
-            genai.configure(api_key=api_key)
-            listing = list_models()
-
-        for model in listing:
-            model_name = getattr(model, "name", "")
-            supported_methods = set(
-                getattr(model, "supported_generation_methods", []) or []
+        page_token: Optional[str] = None
+        for _ in range(GOOGLE_MAX_LIST_PAGES):
+            params: Dict[str, str] = {"pageSize": str(GOOGLE_LIST_PAGE_SIZE)}
+            if page_token:
+                params["pageToken"] = page_token
+            response = await client.get(
+                GOOGLE_MODELS_URL,
+                params=params,
+                headers={"x-goog-api-key": api_key},
             )
-            if model_name.startswith("models/"):
-                model_name = model_name.removeprefix("models/")
-            if model_name and (
-                not supported_methods or "generateContent" in supported_methods
-            ):
-                fetched_models.append(model_name)
+            status = int(getattr(response, "status_code", 0) or 0)
+            if status in (401, 403):
+                # Never log or surface the provider body: it can echo the
+                # request URL and, on some proxies, the credential.
+                logger.warning("Google authentication failed listing models")
+                raise ProviderAuthError(
+                    "Invalid Google API key. Please check your API key and try again."
+                )
+            if status >= 400:
+                logger.warning("Google model listing failed with HTTP %d", status)
+                return _fallback([], ERROR_UNKNOWN)
+
+            payload = response.json()
+            fetched_models.extend(_extract_google_model_ids(payload))
+
+            next_token = (
+                payload.get("nextPageToken") if isinstance(payload, dict) else None
+            )
+            page_token = next_token.strip() if isinstance(next_token, str) else None
+            if not page_token:
+                break
+    except ProviderAuthError:
+        raise
     except Exception as e:
-        error_msg = str(e).lower()
-        error_type = type(e).__name__.lower()
-        # Check for authentication errors by message content and exception type
-        if any(
-            keyword in error_msg
-            for keyword in [
-                "401",
-                "403",
-                "unauthorized",
-                "unauthenticated",
-                "permission",
-                "invalid",
-                "api key",
-            ]
-        ) or any(
-            keyword in error_type
-            for keyword in [
-                "authentication",
-                "permission",
-                "unauthorized",
-                "unauthenticated",
-                "invalidargument",
-            ]
-        ):
-            logger.warning("Google authentication failed: %s", type(e).__name__)
-            raise ProviderAuthError(
-                "Invalid Google API key. Please check your API key and try again."
-            )
-        logger.warning(
-            "Failed to list Google models: %s",
-            type(e).__name__,
-        )
+        # Type name only: provider messages embed URLs and can embed keys.
+        logger.warning("Failed to list Google models: %s", type(e).__name__)
         return _fallback([], _classify_fetch_error(e))
+    finally:
+        aclose = getattr(client, "aclose", None)
+        if callable(aclose):
+            await aclose()
 
     if not fetched_models:
         logger.info("Google returned no models")
         return _fallback([], ERROR_EMPTY_RESPONSE)
 
     logger.info("Listed %d Google models", len(fetched_models))
-    return _live(sorted(set(fetched_models), reverse=True))
+    # Same shape as before: de-duplicated, newest-looking ids first.
+    return _live(sorted(set(fetched_models), reverse=True)[:MAX_DISCOVERED_MODELS])
 
 
 async def _get_catalog_provider_models(

--- a/backend/tests/agents/test_session_manifest.py
+++ b/backend/tests/agents/test_session_manifest.py
@@ -240,7 +240,9 @@ def test_current_opencode_sqlite_scopes_events_and_excludes_credentials(
         "session_id": "a",
         "thread_id": "thread-a",
     }
-    archive = pack_session(files, **identity, expires_at=NOW + timedelta(days=1))
+    archive = pack_session(
+        files, **identity, now=NOW, expires_at=NOW + timedelta(days=1)
+    )
     assert unpack_session(archive, **identity, now=NOW) == files
     # A manifest alone cannot authorize foreign table rows added to a selected DB.
     dirty = tmp_path / "dirty.db"
@@ -250,6 +252,7 @@ def test_current_opencode_sqlite_scopes_events_and_excludes_credentials(
     archive = pack_session(
         {"opencode.db": dirty.read_bytes()},
         **identity,
+        now=NOW,
         expires_at=NOW + timedelta(days=1),
     )
     with pytest.raises(SessionRestoreError, match="unrelated database"):

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -14,8 +14,12 @@ from preloop.services.ai_model_provider import (
     ERROR_EMPTY_RESPONSE,
     ERROR_MISSING_KEY,
     ERROR_SDK_MISSING,
+    ERROR_TIMEOUT,
     ERROR_UNKNOWN,
     FALLBACK_ERROR_REASONS,
+    GOOGLE_LIST_PAGE_SIZE,
+    GOOGLE_MAX_LIST_PAGES,
+    GOOGLE_MODELS_URL,
     MODEL_DISCOVERY_TIMEOUT_SECONDS,
     ModelDiscoveryResult,
     ProviderAuthError,
@@ -572,8 +576,53 @@ class TestGetAnthropicModels:
             assert model_id in prices, f"{model_id} missing from model_prices.json"
 
 
+class _StubGoogleResponse:
+    """Minimal stand-in for an httpx Response from the Gemini listing call."""
+
+    def __init__(self, payload, status_code=200):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _StubGoogleClient:
+    """Stub HTTP client that hands back queued responses (or raises them)."""
+
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.calls = []
+        self.closed = False
+
+    async def get(self, url, params=None, headers=None):
+        self.calls.append(
+            {"url": url, "params": params or {}, "headers": headers or {}}
+        )
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _google_entry(name, methods=("generateContent",)):
+    """One entry as the v1beta models.list REST response shapes it."""
+    entry = {"name": name}
+    if methods is not None:
+        entry["supportedGenerationMethods"] = list(methods)
+    return entry
+
+
+class _FakeTimeoutError(Exception):
+    """Type name carries "timeout", which is how _classify_fetch_error maps it."""
+
+
 class TestGetGoogleModels:
-    """Test _get_google_models function."""
+    """Google listing over plain HTTPS (no SDK: it is an optional extra that
+    the runtime lock the image installs does not carry)."""
 
     @pytest.mark.asyncio
     async def test_get_google_models_without_key(self):
@@ -584,248 +633,250 @@ class TestGetGoogleModels:
         assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
-    async def test_get_google_models_with_valid_key_lists_live(self):
-        """A valid key returns the live listing with provenance live."""
-        mock_google = MagicMock()
-        mock_genai = MagicMock()
-
-        live_entry = MagicMock()
-        live_entry.name = "models/gemini-3.0-pro"
-        live_entry.supported_generation_methods = ["generateContent"]
-        mock_genai.list_models = MagicMock(return_value=[live_entry])
-        mock_google.generativeai = mock_genai
-
-        with patch.dict(
-            sys.modules,
-            {"google": mock_google, "google.generativeai": mock_genai},
-            clear=False,
-        ):
-            result = await _get_google_models("valid_key")
-
-            assert result.source == "live"
-            assert result.models == ["gemini-3.0-pro"]
-            # Under a fully mocked google package the key-scoped client cannot
-            # be constructed, so this exercises the documented fallback path:
-            # process-global configure(). The scoped path (which must NOT call
-            # configure) is covered by the real-SDK tests below.
-            mock_genai.configure.assert_called_once_with(api_key="valid_key")
-            # No paid generate_content validation ping.
-            mock_genai.GenerativeModel.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_get_google_models_empty_listing_is_reported_fallback(self):
-        """A fetch that produces nothing is a REPORTED fallback, not a silent
-        return of known_models (the old behavior)."""
-        mock_google = MagicMock()
-        mock_genai = MagicMock()
-        mock_genai.list_models = MagicMock(return_value=[])
-        mock_google.generativeai = mock_genai
-
-        with patch.dict(
-            sys.modules,
-            {"google": mock_google, "google.generativeai": mock_genai},
-            clear=False,
-        ):
-            result = await _get_google_models("valid_key")
-
-            assert result.models == []
-            assert result.source == "fallback"
-            assert result.error == "empty_response"
-            # And no paid generate_content ping was fired to "validate".
-            mock_genai.GenerativeModel.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_get_google_models_authentication_error(self):
-        """Auth failures during listing raise the ValueError."""
-        mock_google = MagicMock()
-        mock_genai = MagicMock()
-        mock_genai.list_models = MagicMock(
-            side_effect=Exception("403 permission denied")
+    async def test_lists_live_and_follows_pagination(self):
+        """Both pages are merged and nextPageToken is followed."""
+        client = _StubGoogleClient(
+            _StubGoogleResponse(
+                {
+                    "models": [_google_entry("models/gemini-3.0-pro")],
+                    "nextPageToken": "page-2",
+                }
+            ),
+            _StubGoogleResponse({"models": [_google_entry("models/gemini-2.5-flash")]}),
         )
-        mock_google.generativeai = mock_genai
 
-        with patch.dict(
-            sys.modules,
-            {"google": mock_google, "google.generativeai": mock_genai},
-            clear=False,
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
         ):
-            with pytest.raises(ValueError, match="Invalid Google API key"):
-                await _get_google_models("invalid_key")
+            result = await _get_google_models("AIza-key")
+
+        assert result.source == "live"
+        assert result.error is None
+        # Bare ids (no "models/" prefix), de-duplicated, newest first.
+        assert result.models == ["gemini-3.0-pro", "gemini-2.5-flash"]
+        assert len(client.calls) == 2
+        assert client.calls[0]["url"] == GOOGLE_MODELS_URL
+        assert client.calls[0]["params"] == {"pageSize": str(GOOGLE_LIST_PAGE_SIZE)}
+        assert client.calls[1]["params"]["pageToken"] == "page-2"
+        assert client.closed is True
 
     @pytest.mark.asyncio
-    async def test_get_google_models_url_with_api_key_param_is_not_auth(self):
-        """A URL carrying an api_key query param must not be read as an auth failure."""
-        mock_google = MagicMock()
-        mock_genai = MagicMock()
-        mock_genai.list_models = MagicMock(
-            side_effect=Exception(
-                "Connection refused: https://proxy.internal/v1beta/models?api_key=redacted"
+    async def test_key_travels_in_header_never_in_the_query_string(self):
+        """A key in the query string lands in access logs (2026-08-04 leak)."""
+        client = _StubGoogleClient(
+            _StubGoogleResponse({"models": [_google_entry("models/gemini-2.5-pro")]})
+        )
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            await _get_google_models("AIza-secret-key")
+
+        call = client.calls[0]
+        assert call["headers"]["x-goog-api-key"] == "AIza-secret-key"
+        assert "key" not in call["params"]
+        assert "AIza-secret-key" not in str(call["params"])
+        assert "?" not in call["url"]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_supported_generation_method(self):
+        """Embedding-only models are not usable in the picker."""
+        client = _StubGoogleClient(
+            _StubGoogleResponse(
+                {
+                    "models": [
+                        _google_entry("models/gemini-2.5-pro"),
+                        _google_entry(
+                            "models/text-embedding-004", methods=["embedContent"]
+                        ),
+                        _google_entry(
+                            "models/gemini-legacy-counter", methods=["countTokens"]
+                        ),
+                        # No methods field at all: kept, as on the old SDK path.
+                        _google_entry("models/gemini-unknown-shape", methods=None),
+                    ]
+                }
             )
         )
-        mock_google.generativeai = mock_genai
 
-        with patch.dict(
-            sys.modules,
-            {"google": mock_google, "google.generativeai": mock_genai},
-            clear=False,
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
         ):
-            result = await _get_google_models("valid_key")
+            result = await _get_google_models("AIza-key")
+
+        assert result.source == "live"
+        assert result.models == ["gemini-unknown-shape", "gemini-2.5-pro"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_rejected_key_raises_auth(self, status):
+        """401/403 tell the user the key is bad instead of an empty picker."""
+        client = _StubGoogleClient(
+            _StubGoogleResponse({"error": {"message": "API key not valid"}}, status)
+        )
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            with pytest.raises(ProviderAuthError, match="Invalid Google API key"):
+                await _get_google_models("bad-key")
+
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_other_http_error_is_a_safe_fallback(self):
+        """A 500 is a fallback with a vocabulary reason, no provider text."""
+        client = _StubGoogleClient(_StubGoogleResponse({"error": "boom"}, 500))
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            result = await _get_google_models("AIza-key")
+
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == ERROR_UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_classified_as_timeout(self):
+        """A hung endpoint maps to the existing timeout reason."""
+        client = _StubGoogleClient(_FakeTimeoutError("read timed out"))
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            result = await _get_google_models("AIza-key")
+
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == ERROR_TIMEOUT
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_network_error_never_leaks_provider_text(self):
+        """A URL carrying an api_key must not reach the caller or be read as auth."""
+        client = _StubGoogleClient(
+            ConnectionError(
+                "Connection refused: https://proxy.internal/v1beta/models?key=redacted"
+            )
+        )
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            result = await _get_google_models("AIza-key")
 
         assert result.source == "fallback"
+        assert result.error in FALLBACK_ERROR_REASONS
+        assert "://" not in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_get_google_models_import_error(self):
-        """Test handling when Google package not installed."""
-        genai_module = sys.modules.pop("google.generativeai", None)
-        try:
-            import builtins
+    async def test_empty_listing_is_reported_fallback(self):
+        """A fetch that produces nothing is a REPORTED fallback, not a catalog."""
+        client = _StubGoogleClient(_StubGoogleResponse({"models": []}))
 
-            original_import = builtins.__import__
-
-            def mock_import(name, *args, **kwargs):
-                if name == "google.generativeai":
-                    raise ImportError("No module named 'google.generativeai'")
-                return original_import(name, *args, **kwargs)
-
-            with patch("builtins.__import__", side_effect=mock_import):
-                result = await _get_google_models("test_key")
-                assert result.models == []
-                assert result.error == "sdk_missing"
-        finally:
-            if genai_module is not None:
-                sys.modules["google.generativeai"] = genai_module
-
-    @pytest.mark.asyncio
-    async def test_get_google_models_network_error(self):
-        """Non-auth failures fall back with a reason."""
-        mock_genai = MagicMock()
-        mock_genai.list_models = MagicMock(side_effect=Exception("Connection reset"))
-
-        with patch.dict(sys.modules, {"google.generativeai": mock_genai}):
-            result = await _get_google_models("test_key")
-            assert result.models == []
-            assert result.source == "fallback"
-            assert result.error in FALLBACK_ERROR_REASONS
-
-    @pytest.mark.asyncio
-    async def test_scoped_google_client_isolates_keys(self):
-        """The key must live on a per-call client, not in global SDK state.
-
-        genai.configure() mutates PROCESS-GLOBAL state, so two concurrent
-        discovery requests for different accounts could race and list one
-        account's models with the other's key. These assertions run against
-        the REAL SDK: a fully mocked google package makes the scoped client
-        unconstructible, which is why the mocked tests above cannot cover it.
-        """
-        from preloop.services.ai_model_provider import _build_scoped_google_client
-
-        first = _build_scoped_google_client("AIza-key-one")
-        second = _build_scoped_google_client("AIza-key-two")
-        if first is None or second is None:
-            pytest.skip("google.ai.generativelanguage not available")
-
-        assert first is not second
-        assert first.transport._credentials.token == "AIza-key-one"
-        assert second.transport._credentials.token == "AIza-key-two"
-
-    @pytest.mark.asyncio
-    async def test_scoped_path_does_not_touch_global_configure_mocked(self):
-        """Regression: the scoped path must never call genai.configure().
-
-        This is the SDK-free twin of the real-SDK test below. The google
-        packages are optional extras (``ai-providers``) and are not installed
-        in CI, so the real-SDK test skips there and this one carries the
-        assertion instead.
-
-        The round-3 trap this avoids: mocking the whole google package makes
-        _build_scoped_google_client() fail and return None, which silently
-        routes the call to the FALLBACK branch, so a naive mocked test asserts
-        nothing about the scoped branch. Here the builder itself is patched to
-        hand back a sentinel, which forces the scoped branch to be taken.
-        """
-        from preloop.services import ai_model_provider as module
-
-        sentinel_client = object()
-        mock_google = MagicMock()
-        mock_genai = MagicMock()
-
-        captured = {}
-
-        def fake_list_models(client=None):
-            captured["client"] = client
-            entry = MagicMock()
-            entry.name = "models/gemini-2.5-pro"
-            entry.supported_generation_methods = ["generateContent"]
-            return [entry]
-
-        mock_genai.list_models = MagicMock(side_effect=fake_list_models)
-        mock_google.generativeai = mock_genai
-
-        with patch.dict(
-            sys.modules,
-            {"google": mock_google, "google.generativeai": mock_genai},
-            clear=False,
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
         ):
-            with patch.object(
-                module, "_build_scoped_google_client", return_value=sentinel_client
-            ):
-                result = await _get_google_models("AIza-scoped-key")
+            result = await _get_google_models("AIza-key")
+
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == ERROR_EMPTY_RESPONSE
+
+    @pytest.mark.asyncio
+    async def test_listing_does_not_need_the_optional_google_sdk(self):
+        """Regression for the prod bug: with google.generativeai unimportable
+        the listing still works, because it is plain HTTPS now."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name.startswith("google"):
+                raise ImportError(f"No module named {name!r}")
+            return original_import(name, *args, **kwargs)
+
+        client = _StubGoogleClient(
+            _StubGoogleResponse({"models": [_google_entry("models/gemini-2.5-pro")]})
+        )
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            with patch("builtins.__import__", side_effect=blocked_import):
+                result = await _get_google_models("AIza-key")
 
         assert result.source == "live"
         assert result.models == ["gemini-2.5-pro"]
-        # The whole point: global state was never mutated.
-        mock_genai.configure.assert_not_called()
-        # ...and the key-scoped client travelled on the call instead.
-        assert captured["client"] is sentinel_client
 
     @pytest.mark.asyncio
-    async def test_live_listing_does_not_touch_global_configure(self):
-        """Regression: the scoped path must never call genai.configure().
+    async def test_pagination_is_bounded(self):
+        """An upstream that always returns a token cannot loop forever."""
+        pages = [
+            _StubGoogleResponse(
+                {
+                    "models": [_google_entry(f"models/gemini-{i}")],
+                    "nextPageToken": f"page-{i}",
+                }
+            )
+            for i in range(GOOGLE_MAX_LIST_PAGES + 5)
+        ]
+        client = _StubGoogleClient(*pages)
 
-        Runs against the REAL SDK, which additionally proves the key rides on
-        the client's credentials. The google packages are optional extras and
-        are absent in CI, hence importorskip; the assertion still runs in CI
-        in mocked form via the test above.
-        """
-        real_genai = pytest.importorskip(
-            "google.generativeai",
-            reason="google-generativeai extra not installed",
-        )
-        pytest.importorskip(
-            "google.ai.generativelanguage",
-            reason="google-generativeai extra not installed",
-        )
-        from preloop.services import ai_model_provider as module
-
-        if module._build_scoped_google_client("AIza-probe") is None:
-            pytest.skip("google.ai.generativelanguage not available")
-
-        configure_calls = []
-        captured = {}
-
-        def fake_list_models(client=None):
-            captured["client"] = client
-            entry = MagicMock()
-            entry.name = "models/gemini-2.5-pro"
-            entry.supported_generation_methods = ["generateContent"]
-            return [entry]
-
-        with (
-            patch.object(
-                real_genai,
-                "configure",
-                side_effect=lambda **kw: configure_calls.append(kw),
-            ),
-            patch.object(real_genai, "list_models", side_effect=fake_list_models),
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
         ):
-            result = await _get_google_models("AIza-scoped-key")
+            result = await _get_google_models("AIza-key")
+
+        assert len(client.calls) == GOOGLE_MAX_LIST_PAGES
+        assert result.source == "live"
+
+    @pytest.mark.asyncio
+    async def test_request_shape_against_a_real_httpx_client(self):
+        """Same path with a real httpx client on a mock transport.
+
+        The stubs above cannot catch a wrong httpx call signature, so this
+        one drives the actual client and asserts on the wire-level request:
+        the key is a header and the URL carries no credential.
+        """
+        import httpx
+
+        seen = []
+
+        def handler(request):
+            seen.append(request)
+            return httpx.Response(
+                200,
+                json={"models": [_google_entry("models/gemini-2.5-pro")]},
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+        with patch(
+            "preloop.services.ai_model_provider._discovery_http_client",
+            return_value=client,
+        ):
+            result = await _get_google_models("AIza-wire-key")
 
         assert result.source == "live"
         assert result.models == ["gemini-2.5-pro"]
-        # The whole point: global state was never mutated.
-        assert configure_calls == []
-        # ...and the key travelled on the per-call client instead.
-        assert captured["client"].transport._credentials.token == "AIza-scoped-key"
+        request = seen[0]
+        assert request.method == "GET"
+        assert str(request.url).startswith(GOOGLE_MODELS_URL)
+        assert request.headers["x-goog-api-key"] == "AIza-wire-key"
+        assert "AIza-wire-key" not in str(request.url)
+        assert client.is_closed is True
 
 
 class TestGetQwenModels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,10 @@ dev = [
 ]
 ai-providers = [
     "anthropic>=0.39.0",  # For Anthropic Claude API key validation
-    "google-generativeai>=0.8.0",  # For Google Gemini API key validation
+    # Used only by ai_approval_service._call_google. Model listing no longer
+    # needs it: it speaks plain HTTPS, because this extra is absent from the
+    # hash-pinned runtime lock the image installs.
+    "google-generativeai>=0.8.0",
 ]
 push-notifications = [
     "firebase-admin>=6.0.0",  # For Android FCM push notifications


### PR DESCRIPTION
# Fix Google "Fetch models from provider": list over plain HTTPS, not the optional SDK

## Root cause (confirmed from the locks and the Dockerfile)

`_get_google_models` was the only provider path that depended on an OPTIONAL
extra. The image does not install that extra, so every container answered
`sdk_missing` for Google while every other provider listed fine.

- `backend/preloop/services/ai_model_provider.py:669` (pre-fix) did
  `import google.generativeai as genai` and returned
  `_fallback([], ERROR_SDK_MISSING)` on ImportError. The frontend maps that to
  the founder's message (`frontend/src/components/add-ai-model-modal.ts:126`,
  "provider SDK not installed").
- The SDK is only in the optional extra:

```
$ grep -n "google-generativeai" pyproject.toml
141:    "google-generativeai>=0.8.0",  # For Google Gemini API key validation
```

- The image installs the hash-pinned runtime lock (Dockerfile:23 and :29),
  compiled with no `--extra`, so `ai-providers` is excluded:

```
$ head -2 requirements/runtime.txt
# This file was autogenerated by uv via the following command:
#    uv pip compile --universal --generate-hashes --python-version 3.11 pyproject.toml -o requirements/runtime.txt

$ grep -c "generativeai" requirements/runtime.txt
0
$ grep -n "^anthropic==" requirements/runtime.txt
160:anthropic==0.125.0 \
```

  anthropic is present because it is a CORE dependency (pyproject.toml:44), not
  because the extra was compiled in. That is exactly why Anthropic listing works
  in prod and Google does not.

## What changed

`backend/preloop/services/ai_model_provider.py`

- `_get_google_models` (:672) now calls
  `GET https://generativelanguage.googleapis.com/v1beta/models` directly, with
  `pageSize` and pagination on `nextPageToken` bounded by `GOOGLE_MAX_LIST_PAGES`,
  through the existing `_discovery_http_client` so a mounted private CA still
  applies. The API key rides in the `x-goog-api-key` HEADER, never the documented
  `?key=` query parameter, which would land in access and proxy logs (the same
  rule the endpoint docstring states for our own API).
- `_extract_google_model_ids` (:638) keeps entries whose
  `supportedGenerationMethods` include `generateContent` (the listing also serves
  embedding and count-tokens-only models) and strips the `models/` prefix, so the
  ids stay the bare `gemini-...` form the picker and the gateway already use.
  Result shaping is unchanged: de-duplicated, reverse-sorted, capped by
  `MAX_DISCOVERED_MODELS`.
- 401/403 raise the existing `ProviderAuthError` ("Invalid Google API key"),
  other HTTP >= 400 return `unknown`, exceptions go through
  `_classify_fetch_error` (timeouts -> `timeout`, connection errors -> `network`).
  No provider text, URL, or key ever reaches the caller or the logs; failures are
  logged by exception TYPE name only.
- `_discovery_http_client` (:251) takes `required=True` so a non-SDK path always
  gets a client (previous behavior, returning None when no private CA is set, is
  unchanged for every existing caller).
- `_build_scoped_google_client` is gone with the SDK path, and with it the
  `genai.configure()` process-global key race it existed to work around.

`pyproject.toml:144` keeps `google-generativeai` in the `ai-providers` extra
because `ai_approval_service._call_google` still imports it (grepped the whole
backend: that is the only other importer). The comment now names that use.

No API schema, route, or frontend change: the `sdk_missing` reason still exists
for the SDK-backed providers, so the frontend mapping is untouched.

## Tests

`backend/tests/services/test_ai_model_provider.py`: the SDK-mock Google tests are
replaced by stubbed-HTTP-client tests (14 in the class): live listing with
pagination, key in header and never in the query string, filtering by
`generateContent`, 401 and 403 -> auth error, HTTP 500 -> safe fallback, timeout
-> `timeout`, connection error -> a vocabulary reason with no leaked URL, empty
list -> `empty_response`, bounded pagination, a regression test that listing works
with every `google*` import blocked, and one test that drives a REAL httpx client
over `MockTransport` to pin the wire-level request shape.

Measured (local Postgres 16 + pgvector in docker, `alembic upgrade head`):

- `pytest backend/tests -k "ai_model" -q`: 254 passed, 2 skipped, 8177 deselected
  (baseline on this branch point: 251 passed, 2 skipped).
- Without a database the same selection reports 67 errors from DB fixtures, both
  before and after this change.
- `pytest backend/tests/services backend/tests/endpoints/test_ai_models.py
  backend/tests/endpoints/test_ai_models_overview.py -q`: 3872 passed, 23 skipped.
- `pre-commit run --files <changed files>`: all hooks pass, openapi.yaml unchanged.

## CI on the PR

Run https://github.com/preloop/preloop/actions/runs/34076163795: Lint & Format
pass, Runtime Plugin Tests pass, CodeQL pass, Backend Tests shards 2-8 pass,
shard 1/8 fail with ONE unrelated test:

```
FAILED backend/tests/agents/test_session_manifest.py::test_current_opencode_sqlite_scopes_events_and_excludes_credentials
  - preloop.agents.session_manifest.SessionRestoreError: invalid session checkpoint identity or expiry
= 1 failed, 1046 passed, 5 skipped, 7381 deselected in 185.52s =
```

Pre-existing and date-dependent, not caused by this branch. Reproduced on
unmodified `origin/main` locally: `pytest backend/tests/agents/test_session_manifest.py -q`
gives `1 failed, 16 passed` on main and the identical `1 failed, 16 passed` on
this branch (the checkpoint fixture has expired against today's date).

## Live verification

Not verified live: no Google API key is available to this environment
(the credentials file holds only a staging username and password), and calls to
preloop.ai / staging were out of scope. The wire shape is pinned by the
MockTransport test instead.

## Follow-ups

- `ai_approval_service._call_google` still imports `google.generativeai`, which is
  absent from the runtime lock, so Google-backed AI approval evaluation fails in
  the same way in prod. Either port it to the REST endpoint or add the extra to
  the runtime lock (`uv pip compile --universal --generate-hashes
  --python-version 3.11 --extra ai-providers ...`).
- Consider a CI check that the runtime lock covers every module the backend
  imports at runtime, so an optional extra cannot silently become a prod
  dependency again.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-tested bug fix that swaps the Google model-listing path from an optional SDK to plain HTTPS; no security regressions, and key handling is actually improved.
>
> **Overview**
> Fixes Google "Fetch models from provider" by listing over the REST endpoint instead of the optional `google-generativeai` SDK, which the prod image's runtime lock doesn't install. Moves the API key to the `x-goog-api-key` header, preserves the error vocabulary, and removes a process-global key race. Backed by 14 stub + wire-level tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 3bde381a. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->