### PR TITLE
Bell: a handled approval leaves the notifications list, acknowledged or not

### DIFF
--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -675,21 +675,28 @@ describe('console-header approval deadlines', () => {
     localStorage.removeItem('accessToken');
   });
 
-  async function mount(): Promise<void> {
-    el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
-    // Fetch + json() are native promises. Flush them without advancing
-    // expiry timers (those are at least 1ms).
+  /**
+   * Fetch + json() are native promises, so a single tickAsync(0) can fire
+   * the coalesced refresh timer without the list answer landing. Flush
+   * microtasks without advancing expiry timers (those are at least 1ms).
+   */
+  async function flushApprovalReads(count: number): Promise<void> {
     for (let i = 0; i < 25; i++) {
       await Promise.resolve();
       await clock.tickAsync(0);
       await el.updateComplete;
-      if (approvalReads >= 1) {
+      if (approvalReads >= count) {
         await Promise.resolve();
         await clock.tickAsync(0);
         await el.updateComplete;
-        break;
+        return;
       }
     }
+  }
+
+  async function mount(): Promise<void> {
+    el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
+    await flushApprovalReads(1);
   }
 
   function names(): string[] {
@@ -811,10 +818,7 @@ describe('console-header approval deadlines', () => {
     window.dispatchEvent(new Event('focus'));
     changeState(ConnectionState.CONNECTED);
     window.dispatchEvent(new Event('focus'));
-    await clock.tickAsync(0);
-    await el.updateComplete;
-    await clock.tickAsync(0);
-    await el.updateComplete;
+    await flushApprovalReads(2);
     expect(names()).to.deep.equal(['new-request']);
     expect(badge()).to.equal('1');
     expect(approvalReads).to.equal(2);
@@ -831,8 +835,7 @@ describe('console-header approval deadlines', () => {
     approvals = [approval('visible-request', 10_000)];
     visibility.get(() => 'visible');
     document.dispatchEvent(new Event('visibilitychange'));
-    await clock.tickAsync(0);
-    await el.updateComplete;
+    await flushApprovalReads(2);
     expect(names()).to.deep.equal(['visible-request']);
     expect(badge()).to.equal('1');
     expect(approvalReads).to.equal(2);
@@ -843,8 +846,7 @@ describe('console-header approval deadlines', () => {
     await mount();
     approvals = [];
     changeState(ConnectionState.CONNECTED);
-    await clock.tickAsync(0);
-    await el.updateComplete;
+    await flushApprovalReads(2);
     expect(names()).to.deep.equal([]);
     expect(badge()).to.equal(undefined);
     expect(approvalReads).to.equal(2);
@@ -862,8 +864,7 @@ describe('console-header approval deadlines', () => {
     await clock.tickAsync(2_000);
     expect(approvalReads).to.equal(1);
     document.body.append(el);
-    await clock.tickAsync(0);
-    await el.updateComplete;
+    await flushApprovalReads(2);
     expect(names()).to.deep.equal([]);
     expect(badge()).to.equal(undefined);
     expect(approvalReads).to.equal(2);

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -211,6 +211,16 @@ describe('console-header bell empty state', () => {
   });
 });
 
+/**
+ * A handled approval is not a notification.
+ *
+ * The bell used to leave an unread "Approval approved" row behind every
+ * resolution, so policy auto-approvals nobody ever looked at pushed the badge
+ * up for good: there is no read-all, and nothing ages an entry out. The bell
+ * now converges on the server's truth, which is pending unexpired approvals
+ * and nothing else. The history of what was decided lives on the Approvals
+ * page and in the audit trail.
+ */
 describe('console-header bell approvals', () => {
   const APPROVAL = {
     id: 'ar-1',
@@ -221,11 +231,19 @@ describe('console-header bell approvals', () => {
     expires_at: new Date(Date.now() + 600_000).toISOString(),
     execution_id: 'exec-1',
   };
+  const OTHER_APPROVAL = {
+    ...APPROVAL,
+    id: 'ar-2',
+    tool_name: 'read_file',
+  };
 
   let restoreFetch: () => void;
   let restoreSubscribe: () => void;
   let approvalListeners: ((message: any) => void)[];
   let approvals: any[];
+  let approvalReads: number;
+  /** When set, the pending list request waits on it before answering. */
+  let gate: Promise<void> | null;
   let routes: string[];
   let restoreRouterGo: () => void;
 
@@ -236,7 +254,12 @@ describe('console-header bell approvals', () => {
       const url = typeof input === 'string' ? input : input.toString();
       let body: unknown = [];
       if (url.includes('/users/me')) body = USER;
-      else if (url.includes('/approval-requests')) body = approvals;
+      else if (url.includes('/approval-requests')) {
+        approvalReads++;
+        if (gate) await gate;
+        // Read after the gate, so a test can change the answer mid-flight.
+        body = approvals;
+      }
       return new Response(JSON.stringify(body), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -250,6 +273,8 @@ describe('console-header bell approvals', () => {
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-token');
     approvals = [APPROVAL];
+    approvalReads = 0;
+    gate = null;
     approvalListeners = [];
     routes = [];
     restoreFetch = stubApprovalFetch();
@@ -307,31 +332,79 @@ describe('console-header bell approvals', () => {
     );
   }
 
-  it('leaves an approval notification when one resolves elsewhere', async () => {
-    const el = await header();
+  function names(el: ConsoleHeader): string[] {
+    return [...el.shadowRoot!.querySelectorAll('.approval-name')].map((row) =>
+      row.textContent!.trim()
+    );
+  }
 
-    emit({
-      type: 'approval_declined',
-      approval_request_id: 'ar-1',
-      tool_name: 'write_file',
+  function badge(el: ConsoleHeader): string | undefined {
+    return el
+      .shadowRoot!.querySelector('.notification-badge')
+      ?.textContent?.trim();
+  }
+
+  function unreadCount(el: ConsoleHeader): number {
+    return (el as unknown as { _userNotifications: { read: boolean }[] })
+      ._userNotifications.length;
+  }
+
+  /**
+   * Every way an approval can stop waiting, including the one nobody looked
+   * at: a policy bypass approving without review. The badge has to drop for
+   * all of them, and none may leave an unread row behind.
+   */
+  const RESOLUTIONS: { label: string; message: Record<string, unknown> }[] = [
+    {
+      label: 'approved by another operator',
+      message: { type: 'approval_approved', tool_name: 'write_file' },
+    },
+    {
+      label: 'auto-approved by policy with nobody watching',
+      message: {
+        type: 'approval_approved',
+        tool_name: 'write_file',
+        status: 'approved',
+        auto_approved_reason: 'configured_bypass',
+        summary: 'Auto-approved without review: native tool approvals are off',
+      },
+    },
+    {
+      label: 'declined',
+      message: { type: 'approval_declined', tool_name: 'write_file' },
+    },
+    {
+      label: 'expired',
+      message: { type: 'approval_expired', tool_name: 'write_file' },
+    },
+    {
+      label: 'cancelled',
+      message: { type: 'approval_cancelled', tool_name: 'write_file' },
+    },
+  ];
+
+  RESOLUTIONS.forEach(({ label, message }) => {
+    it(`drops a request ${label} from the list and the badge`, async () => {
+      approvals = [APPROVAL, OTHER_APPROVAL];
+      const el = await header();
+      expect(names(el)).to.deep.equal(['write_file', 'read_file']);
+      expect(badge(el)).to.equal('2');
+
+      emit({ ...message, approval_request_id: 'ar-1' });
+      await el.updateComplete;
+
+      expect(names(el), 'pending rows').to.deep.equal(['read_file']);
+      expect(badge(el), 'badge').to.equal('1');
+      // Nothing was left for the operator to acknowledge.
+      expect(notificationItems(el), 'notification rows').to.have.lengthOf(0);
+      expect(unreadCount(el), 'stored notifications').to.equal(0);
     });
-    await el.updateComplete;
-
-    const items = notificationItems(el);
-    expect(items.length, 'notification rows').to.equal(1);
-    expect(items[0].textContent).to.contain('Approval declined');
-    expect(items[0].textContent).to.contain('write_file');
-    expect(items[0].querySelector('sl-icon')?.getAttribute('name')).to.equal(
-      'shield-check'
-    );
-    // The pending row is gone, so the notification is the only trace left.
-    expect(el.shadowRoot!.querySelectorAll('.approval-item').length).to.equal(
-      0
-    );
   });
 
-  it('opens the approval when its notification is clicked', async () => {
+  it('empties the bell when the last pending request resolves', async () => {
     const el = await header();
+    expect(badge(el)).to.equal('1');
+
     emit({
       type: 'approval_approved',
       approval_request_id: 'ar-1',
@@ -339,14 +412,28 @@ describe('console-header bell approvals', () => {
     });
     await el.updateComplete;
 
-    const item = notificationItems(el)[0];
-    expect(item.getAttribute('data-href')).to.equal('/console/approval/ar-1');
-    item.click();
+    expect(names(el)).to.deep.equal([]);
+    expect(badge(el), 'badge is gone, not "1"').to.equal(undefined);
+    expect(notificationItems(el)).to.have.lengthOf(0);
+    expect(
+      el.shadowRoot!.querySelector('.empty-state')?.textContent
+    ).to.contain('No new notifications');
+  });
+
+  it('ignores a resolution for a request this bell never carried', async () => {
+    const el = await header();
+
+    emit({
+      type: 'approval_approved',
+      approval_request_id: 'somebody-elses-request',
+      tool_name: 'deploy',
+    });
     await el.updateComplete;
 
-    expect(routes).to.deep.equal(['/console/approval/ar-1']);
-    // Reading it also marks it read, so the badge stops counting it.
-    expect(item.classList.contains('unread')).to.be.false;
+    expect(names(el)).to.deep.equal(['write_file']);
+    expect(badge(el)).to.equal('1');
+    expect(notificationItems(el), 'notification rows').to.have.lengthOf(0);
+    expect(unreadCount(el), 'stored notifications').to.equal(0);
   });
 
   it('says nothing about a decision made in this bell', async () => {
@@ -368,7 +455,84 @@ describe('console-header bell approvals', () => {
     });
     await el.updateComplete;
 
-    expect(notificationItems(el).length, 'notification rows').to.equal(0);
+    expect(notificationItems(el), 'notification rows').to.have.lengthOf(0);
+  });
+
+  it('does not resurrect a resolved row when a later list still says pending', async () => {
+    const el = await header();
+
+    emit({
+      type: 'approval_approved',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+    expect(names(el)).to.deep.equal([]);
+
+    // The refresh on focus answers with the row still pending, either from a
+    // read replica behind the decision or from a response prepared before it.
+    window.dispatchEvent(new Event('focus'));
+    await waitUntil(() => approvalReads >= 2, 'refresh never ran');
+    await el.updateComplete;
+
+    expect(names(el), 'resolved row came back').to.deep.equal([]);
+    expect(badge(el)).to.equal(undefined);
+    expect(notificationItems(el)).to.have.lengthOf(0);
+  });
+
+  it('does not resurrect a row resolved while a list fetch is in flight', async () => {
+    approvals = [APPROVAL, OTHER_APPROVAL];
+    const el = await header();
+    expect(names(el)).to.deep.equal(['write_file', 'read_file']);
+
+    let release!: () => void;
+    gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    window.dispatchEvent(new Event('focus'));
+    await waitUntil(() => approvalReads >= 2, 'refresh never started');
+
+    emit({
+      type: 'approval_declined',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+    expect(names(el)).to.deep.equal(['read_file']);
+
+    release();
+    gate = null;
+    await waitUntil(
+      () => names(el).length > 0,
+      'in-flight answer never applied'
+    );
+    await el.updateComplete;
+
+    expect(names(el), 'resolved row came back').to.deep.equal(['read_file']);
+    expect(badge(el)).to.equal('1');
+    expect(notificationItems(el)).to.have.lengthOf(0);
+  });
+
+  it('forgets a resolution once the server list agrees', async () => {
+    const el = await header();
+    emit({
+      type: 'approval_approved',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+
+    const held = (el as unknown as { resolvedApprovals: Map<string, number> })
+      .resolvedApprovals;
+    expect(held.has('ar-1'), 'held back until the server agrees').to.be.true;
+
+    approvals = [];
+    window.dispatchEvent(new Event('focus'));
+    await waitUntil(() => approvalReads >= 2, 'refresh never ran');
+    await el.updateComplete;
+
+    // A tab left open for a day must not accumulate one entry per approval.
+    expect(held.size, 'resolved ids held').to.equal(0);
   });
 
   it('keeps a notification with no target reachable and marks it read', async () => {
@@ -400,6 +564,31 @@ describe('console-header bell approvals', () => {
     expect(notificationItems(el)[0].classList.contains('unread')).to.be.false;
     // Nothing to open, so nothing was opened.
     expect(routes).to.deep.equal([]);
+  });
+
+  it('opens a notification that names a destination and marks it read', async () => {
+    const el = await header();
+    (el as unknown as { _userNotifications: unknown[] })._userNotifications = [
+      {
+        id: 'n-2',
+        type: 'policy_added',
+        title: 'Policy assigned',
+        message: 'Production guardrails',
+        created_at: new Date().toISOString(),
+        read: false,
+        href: '/console/policies',
+      },
+    ];
+    el.requestUpdate();
+    await el.updateComplete;
+
+    const item = notificationItems(el)[0];
+    expect(item.getAttribute('data-href')).to.equal('/console/policies');
+    item.click();
+    await el.updateComplete;
+
+    expect(routes).to.deep.equal(['/console/policies']);
+    expect(item.classList.contains('unread')).to.be.false;
   });
 
   it('drops an approval that expires while the tab stays open', async () => {

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -62,7 +62,6 @@ interface ApprovalRequest {
 interface UserNotification {
   id: string;
   type:
-    | 'approval'
     | 'team_added'
     | 'team_removed'
     | 'policy_added'
@@ -77,14 +76,6 @@ interface UserNotification {
   href?: string;
   metadata?: Record<string, unknown>;
 }
-
-/** Bell headline for each way an approval can stop waiting. */
-const APPROVAL_RESOLUTION_TITLES: Record<string, string> = {
-  approval_approved: 'Approval approved',
-  approval_declined: 'Approval declined',
-  approval_expired: 'Approval expired',
-  approval_cancelled: 'Approval cancelled',
-};
 
 @customElement('console-header')
 export class ConsoleHeader extends LitElement {
@@ -151,9 +142,20 @@ export class ConsoleHeader extends LitElement {
   private shownExecutionNotifications: Set<string> = new Set();
   private shownApprovalNotifications: Set<string> = new Set();
 
-  // Approvals decided from this bell. The resolution broadcast comes back to
-  // this tab too, and telling the operator about their own click is noise.
-  private decidedHere: Set<string> = new Set();
+  /**
+   * Approvals known to be resolved, each stamped with the number of pending
+   * list fetches that had started when the resolution arrived.
+   *
+   * A fetch that started before the resolution can still answer with the row
+   * as `pending` (the server read it before the decision landed), and
+   * applying that answer would resurrect a row the bell has already dropped.
+   * An id is forgotten again as soon as a fetch that started after its
+   * resolution has answered, so this cannot grow with the session.
+   */
+  private resolvedApprovals: Map<string, number> = new Map();
+
+  /** How many pending list fetches have started in this tab. */
+  private approvalFetchesStarted = 0;
 
   static styles = css`
     :host {
@@ -480,6 +482,7 @@ export class ConsoleHeader extends LitElement {
     try {
       do {
         this.pendingApprovalsReload = false;
+        const startedAt = ++this.approvalFetchesStarted;
         const approvals = await api.listApprovalRequests({
           status: 'pending',
         });
@@ -496,9 +499,12 @@ export class ConsoleHeader extends LitElement {
             agent_reasoning: approval.agent_reasoning,
             managed_agent_name: approval.managed_agent_name,
           }))
-          .filter((approval: ApprovalRequest) =>
-            this.isUnexpiredPendingApproval(approval)
+          .filter(
+            (approval: ApprovalRequest) =>
+              this.isUnexpiredPendingApproval(approval) &&
+              !this.resolvedApprovals.has(approval.id)
           );
+        this.forgetApprovalsSettledBefore(startedAt);
       } while (this.pendingApprovalsReload && this.isConnected);
     } catch (error) {
       console.error('Failed to load pending approvals:', error);
@@ -524,16 +530,11 @@ export class ConsoleHeader extends LitElement {
   private async handleApprove(approvalId: string, event: Event) {
     event.stopPropagation();
     this._processingApproval = approvalId;
-    this.decidedHere.add(approvalId);
     try {
       await api.approveRequest(approvalId);
-      this._pendingApprovals = this._pendingApprovals.filter(
-        (a) => a.id !== approvalId
-      );
+      this.markApprovalResolved(approvalId);
     } catch (error) {
       console.error('Failed to approve request:', error);
-      // The decision never landed, so a later resolution is news again.
-      this.decidedHere.delete(approvalId);
     } finally {
       this._processingApproval = null;
     }
@@ -542,62 +543,55 @@ export class ConsoleHeader extends LitElement {
   private async handleDecline(approvalId: string, event: Event) {
     event.stopPropagation();
     this._processingApproval = approvalId;
-    this.decidedHere.add(approvalId);
     try {
       await api.declineRequest(approvalId);
-      this._pendingApprovals = this._pendingApprovals.filter(
-        (a) => a.id !== approvalId
-      );
+      this.markApprovalResolved(approvalId);
     } catch (error) {
       console.error('Failed to decline request:', error);
-      // The decision never landed, so a later resolution is news again.
-      this.decidedHere.delete(approvalId);
     } finally {
       this._processingApproval = null;
     }
   }
 
   /**
-   * Turn an approval resolution into a bell notification.
+   * Drop a resolved approval from the bell, whoever resolved it.
    *
-   * Only for requests this bell was carrying: an approval nobody here was
-   * waiting on is somebody else's news. Decisions made in this tab are
-   * skipped too, because the operator who clicked Approve does not need to
-   * be told that it was approved.
+   * A handled approval is not a notification: approved, declined, expired or
+   * cancelled, by a human, a rule, a policy bypass or a timeout, it is off
+   * the list and out of the badge the moment its resolution arrives, with no
+   * acknowledgement asked of anybody. The trail of what happened lives in the
+   * Approvals page history and the audit timeline, which is where an operator
+   * can read it later without carrying an unread count around.
+   *
+   * The id is remembered so a list fetch that was already in flight cannot
+   * answer this row back into the bell. Unknown ids are recorded the same
+   * way, which makes a resolution for something this tab never carried
+   * (another operator's request) a no-op here.
    */
-  private recordApprovalResolution(message: {
-    type: string;
-    approval_request_id?: string;
-    tool_name?: string;
-    summary?: string;
-  }) {
-    const approvalId = message.approval_request_id;
+  private markApprovalResolved(approvalId: string | undefined): void {
     if (!approvalId) return;
-    if (this.decidedHere.has(approvalId)) {
-      this.decidedHere.delete(approvalId);
-      return;
-    }
-    const pending = this._pendingApprovals.find(
-      (approval) => approval.id === approvalId
+    this.resolvedApprovals.set(approvalId, this.approvalFetchesStarted);
+    const remaining = this._pendingApprovals.filter(
+      (approval) => approval.id !== approvalId
     );
-    if (!pending) return;
+    if (remaining.length !== this._pendingApprovals.length) {
+      this._pendingApprovals = remaining;
+    }
+  }
 
-    const title = APPROVAL_RESOLUTION_TITLES[message.type];
-    if (!title) return;
-
-    const notification: UserNotification = {
-      id: `approval-${approvalId}-${message.type}`,
-      type: 'approval',
-      title,
-      message: message.summary || message.tool_name || pending.tool_name,
-      created_at: new Date().toISOString(),
-      read: false,
-      href: `/console/approval/${approvalId}`,
-    };
-    this._userNotifications = [
-      notification,
-      ...this._userNotifications.filter((n) => n.id !== notification.id),
-    ];
+  /**
+   * Forget resolutions the server has since confirmed.
+   *
+   * A fetch numbered `fetchSequence` started after every resolution stamped
+   * with a lower number, so its answer already reflects them and the ids no
+   * longer have to be held back.
+   */
+  private forgetApprovalsSettledBefore(fetchSequence: number): void {
+    for (const [id, resolvedAt] of this.resolvedApprovals) {
+      if (resolvedAt < fetchSequence) {
+        this.resolvedApprovals.delete(id);
+      }
+    }
   }
 
   private markNotificationAsRead(notificationId: string) {
@@ -749,20 +743,16 @@ export class ConsoleHeader extends LitElement {
           message.type === 'approval_expired' ||
           message.type === 'approval_cancelled'
         ) {
-          // Show desktop notification for resolution
+          // A desktop notification is transient and uncounted, so it can
+          // still announce the outcome.
           this.showApprovalResolvedNotification(
             message.approval_request_id,
             message.tool_name || 'Tool',
             message.type
           );
-          // Leave a trail in the bell before the row disappears: an approval
-          // that resolved elsewhere is the one bell item an operator most
-          // wants to reopen, and until now it vanished without a word.
-          this.recordApprovalResolution(message);
-          // Remove from pending approvals
-          this._pendingApprovals = this._pendingApprovals.filter(
-            (approval) => approval.id !== message.approval_request_id
-          );
+          // Out of the list and out of the badge, with nothing left to
+          // acknowledge.
+          this.markApprovalResolved(message.approval_request_id);
         }
       }
     );
@@ -1219,7 +1209,6 @@ export class ConsoleHeader extends LitElement {
 
   private getNotificationIcon(type: UserNotification['type']): string {
     const iconMap: Record<UserNotification['type'], string> = {
-      approval: 'shield-check',
       team_added: 'people',
       team_removed: 'people',
       policy_added: 'file-earmark-text',

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -149,8 +149,11 @@ export class ConsoleHeader extends LitElement {
    * A fetch that started before the resolution can still answer with the row
    * as `pending` (the server read it before the decision landed), and
    * applying that answer would resurrect a row the bell has already dropped.
-   * An id is forgotten again as soon as a fetch that started after its
-   * resolution has answered, so this cannot grow with the session.
+   * Ids are forgotten once a fetch that started after the resolution has
+   * answered. That fetch only runs on initial load, focus, visibility, or
+   * websocket reconnect, so a tab that stays focused holds one entry per
+   * resolution until then. The bell list and badge do not wait on this map:
+   * the websocket drops a handled row immediately.
    */
   private resolvedApprovals: Map<string, number> = new Map();
 


### PR DESCRIPTION
# Bell: a handled approval leaves the notifications list, acknowledged or not

## The rule
A resolved approval is not a notification. Approved, declined, expired or cancelled,
by a human, a rule, an AI decision, a policy bypass or a timeout, it leaves the bell
list and the badge count the moment its resolution arrives, and it never creates an
unread trail entry. Only pending, unexpired approvals count. The desktop OS
notification stays: it is transient and uncounted. The history of what was decided
already lives on the Approvals page and in the audit timeline, and no new surface was
added for it.

## Root cause
- `frontend/src/components/console-header.ts:745-766` (before this change): the
  `approvals` websocket handler, on `approval_approved | approval_declined |
  approval_expired | approval_cancelled`, called `recordApprovalResolution(message)`
  before dropping the row from `_pendingApprovals`.
- `frontend/src/components/console-header.ts:559-601` (before): `recordApprovalResolution`
  pushed a `UserNotification` with `read: false` for every resolution of a row the bell
  was carrying, unless the operator had decided it in this tab (`decidedHere`, line 156).
- `frontend/src/components/console-header.ts:622-630` (before, 616-624 now): `totalNotificationCount` adds
  `_userNotifications.filter((n) => !n.read).length` to running executions and unexpired
  pending approvals. There is no read-all and nothing ages an entry out, so each
  resolution nobody clicked (a policy auto-approval, a bypass, an AI decision, a
  timeout) added 1 to the badge permanently. That is the founder's "count keeps
  increasing".
- Secondary, ordering: `loadPendingApprovals` (476-508) replaced the list with the
  server answer without regard for resolutions already seen, so a focus, visibility or
  reconnect refresh whose response was prepared before a decision landed could put a
  resolved row back into the bell.

Wave 3 (#468) introduced the trail; #473 only pruned expiry.

## What changed (frontend/src/components/console-header.ts)
- Deleted `recordApprovalResolution`, the `APPROVAL_RESOLUTION_TITLES` map, the
  `decidedHere` set and the now-unused `'approval'` kind of `UserNotification` (grepped:
  nothing else created or read an approval notification; the icon map entry went with
  it). Other unread notification kinds (team, policy, role, system) are untouched.
- Added `markApprovalResolved(id)`: removes the row from `_pendingApprovals` and records
  the id in `resolvedApprovals` with the number of pending list fetches started so far.
  Used by the websocket resolution branch and by the local approve/decline handlers.
- `loadPendingApprovals` reconciles against the server: it replaces `_pendingApprovals`
  with the fetched list filtered by `isUnexpiredPendingApproval` and by
  `resolvedApprovals`, so a response prepared before a resolution cannot resurrect the
  row. `forgetApprovalsSettledBefore(startedAt)` then drops every id resolved before
  that fetch started, so a long-lived tab does not accumulate ids. No polling was added:
  the mechanism is still the websocket plus the focus/visibility/reconnect refresh
  from #473.
- A resolution for an id the bell never carried is a no-op on the list and the badge.

## Tests (real browser, web-test-runner + Chromium)
- `npx web-test-runner src/components/console-header.test.ts`: 33 passed, 0 failed
  (24 on main). New or rewritten cases:
  - each resolution kind (approved, declined, expired, cancelled) plus an auto-approval
    shaped message (`auto_approved_reason: 'configured_bypass'`): the row goes, the badge
    goes 2 to 1, no notification row and no stored `_userNotifications` entry;
  - the last pending request resolving leaves no badge at all and the empty state;
  - a resolution for an unknown id: list, badge and notifications unchanged;
  - a refresh after a resolution that still answers `pending` does not resurrect the row;
  - a resolution arriving while a list fetch is in flight does not come back when that
    fetch answers;
  - the held resolved id is forgotten once the server list agrees.
- The 9 new assertions fail against the pre-change component (verified by running the
  new test file against the old source: 24 passed, 9 failed).
- Whole frontend suite `npm test`: 168 test files, 2071 passed, 0 failed.
- `pre-commit run --files` on both changed files: passed.

## Follow-ups (not in this PR)
- `backend/preloop/services/approval_service.py:877-910`: the late-decision expiry path
  marks a request `expired` without calling `_broadcast_approval_update`, so no
  `approval_expired` reaches the console. The bell still converges for expiry because it
  filters on `expires_at` client-side (`isUnexpiredPendingApproval`), but the Approvals
  page relies on the broadcast.
- `backend/preloop/services/approval_helper.py:986-992` and `1017-1023`: the polling
  helper's own timeouts set `status="expired"` with no broadcast either. Same note.
- `backend/preloop/services/approval_service.py:530-575`: the broadcast payload carries
  no `auto_approved_reason` or `approver_comment`, so a console cannot tell an
  unsupervised approval from a human one from the websocket message alone. Not needed
  for this fix (all resolutions are treated alike), but it would matter if the Approvals
  page ever wants to label live rows.
- The bell has no server-backed notification store (`loadUserNotifications` is still a
  TODO at console-header.ts:519-528), so unread state for the remaining kinds is
  per-tab and vanishes on reload.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> A contained frontend fix with thorough browser tests; the reconciliation scheme is race-free and the only note is a minor unbounded-growth caveat in the resolved-id map.
>
> **Overview**
> Removes the unread-trail side effect so a resolved approval always leaves the bell and badge immediately. Replaces it with a stamping mechanism that prevents in-flight list fetches from resurrecting already-resolved rows, with no notification trail left behind.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1c18cde3. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->