### PR TITLE
Fix Alpine CLI tests for host-exec zombies and missing python3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -426,7 +426,8 @@ test:unit:cli:
   needs: []
   image: golang:1.26-alpine
   before_script:
-    - apk add --no-cache gcc musl-dev bash
+    # python3 runs the private-runner result export the CLI tests execute.
+    - apk add --no-cache gcc musl-dev bash python3
   script:
     - cd cli
     - go test -v -race -count=1 ./...

--- a/cli/internal/cmd/process_alive_unix.go
+++ b/cli/internal/cmd/process_alive_unix.go
@@ -2,11 +2,38 @@
 
 package cmd
 
-import "syscall"
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"syscall"
+)
 
 func isProcessAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
+	// kill(pid, 0) succeeds for zombies. Host-exec SIGKILLs a process group
+	// whose parent cannot wait on grandchildren; Docker/CI PID 1 often leaves
+	// those tasks as zombies. Treat Z/X as not running.
+	if state, ok := linuxProcState(pid); ok {
+		return state != 'Z' && state != 'X'
+	}
 	return syscall.Kill(pid, 0) == nil
+}
+
+func linuxProcState(pid int) (byte, bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0, false
+	}
+	return procStatState(data)
+}
+
+func procStatState(stat []byte) (byte, bool) {
+	i := bytes.LastIndexByte(stat, ')')
+	if i < 0 || i+2 >= len(stat) {
+		return 0, false
+	}
+	return stat[i+2], true
 }

--- a/cli/internal/cmd/process_alive_unix_test.go
+++ b/cli/internal/cmd/process_alive_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestProcStatStateReadsBusyBoxSleepZombie(t *testing.T) {
+	// Alpine CI: `4848 (sleep) Z 1 4847 1 ...`
+	stat := []byte("4848 (sleep) Z 1 4847 1 0 -1 4228108 58 0 0 0 0 0 0 0 20 0 1 0 391333 0 0\n")
+	state, ok := procStatState(stat)
+	if !ok || state != 'Z' {
+		t.Fatalf("state=%q ok=%v", state, ok)
+	}
+	running := []byte("14 (sleep) S 13 13 1 0 -1 4194304 56 0\n")
+	state, ok = procStatState(running)
+	if !ok || state != 'S' {
+		t.Fatalf("running state=%q ok=%v", state, ok)
+	}
+}
+
+func TestIsProcessAliveTreatsZombieAsDead(t *testing.T) {
+	if _, err := os.Stat("/proc/self/stat"); err != nil {
+		t.Skip("/proc is required to distinguish zombies from running tasks")
+	}
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !isProcessAlive(pid) {
+			_ = cmd.Wait()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_ = cmd.Wait()
+	t.Fatal("zombie still reported alive")
+}

--- a/cli/internal/cmd/runner_launch_test.go
+++ b/cli/internal/cmd/runner_launch_test.go
@@ -35,6 +35,13 @@ func runnerBootstrapForHost(workspace, client string) string {
 	return strings.ReplaceAll(script, "/tmp/preloop-checkpoint-client.py", strings.ReplaceAll(client, `\`, "/"))
 }
 
+func requirePython3(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is required to execute the private-runner bootstrap")
+	}
+}
+
 func TestRunnerCompletionRequiresReportAndExit(t *testing.T) {
 	for _, tc := range []struct {
 		name, output string
@@ -467,6 +474,7 @@ func TestRunnerDockerOutcomeCarriesFinalEvidenceUpload(t *testing.T) {
 }
 
 func TestRunnerBootstrapEmitsEvidenceUploadWithoutValidResult(t *testing.T) {
+	requirePython3(t)
 	for _, tc := range []struct {
 		name   string
 		result []byte
@@ -508,6 +516,7 @@ func TestRunnerBootstrapEmitsEvidenceUploadWithoutValidResult(t *testing.T) {
 }
 
 func TestRunnerBootstrapUploadBeatsForgedSandboxEnvelope(t *testing.T) {
+	requirePython3(t)
 	root := t.TempDir()
 	workspace := filepath.Join(root, "workspace")
 	if err := os.MkdirAll(workspace, 0o755); err != nil {
@@ -534,6 +543,7 @@ func TestRunnerBootstrapUploadBeatsForgedSandboxEnvelope(t *testing.T) {
 }
 
 func TestRunnerBootstrapWindowsTempPathIsPythonSafe(t *testing.T) {
+	requirePython3(t)
 	workspace := `C:\Users\Example\AppData\Local\Temp\workspace`
 	client := `C:\Users\Example\AppData\Local\Temp\preloop-checkpoint-client.py`
 	script := runnerBootstrapForHost(workspace, client)


### PR DESCRIPTION
## Summary
- Treat Linux zombies (`/proc/<pid>/stat` state `Z`/`X`) as not running so Alpine host-exec tests stop failing after process-group SIGKILL.
- Install `python3` in GitLab `test:unit:cli` so runner bootstrap evidence tests can emit the trusted result envelope.
- Skip those bootstrap tests only when `python3` is missing on the host (e.g. GitHub Windows).

## Test plan
- [x] Darwin: `go test ./internal/cmd` for host-exec, process-alive, and bootstrap tests
- [x] Alpine `golang:1.26-alpine` with `gcc musl-dev bash python3`: same tests
- [ ] GitLab `test:unit:cli` job

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Test/CI-only changes with no security surface: correct zombie detection and a `python3` dependency/skip for bootstrap tests.
>
> **Overview**
> Fixes Alpine CLI test failures by treating Linux zombie processes as not running in `isProcessAlive`, and adds `python3` to the GitLab CI image with a host-skip guard for environments where it is missing.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit e014232. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->