### PR TITLE
Fill the Activity feed from history on first paint, under an Earlier line

### DIFF
--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -545,10 +545,11 @@ describe('activity-feed', () => {
       localStorage.removeItem('accessToken');
     });
 
-    it('asks for at most three audit pages, the last two together', async () => {
+    it('asks for at most three audit pages per slice, the last two together', async () => {
       // A busy account whose whole timeline is successful gateway calls: the
       // fill used to walk four pages one after the other for rows that were
-      // never going to be news.
+      // never going to be news. Each slice still stops at three; a window
+      // that produced no rows then asks the unbounded slice the same way.
       localStorage.setItem('accessToken', 'test-token');
       const { restore, urls } = stubFetch([gatewayNoise(AUDIT_PAGE_SIZE)]);
       const el = await fixture<ActivityFeed>(
@@ -559,9 +560,13 @@ describe('activity-feed', () => {
         'the fill finishes'
       );
       const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
-      expect(audit.length).to.equal(3);
+      expect(audit.length).to.equal(6);
+      expect(audit[0]).to.contain('start_date=');
       expect(audit[1]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
       expect(audit[2]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
+      expect(audit[3]).to.not.contain('start_date=');
+      expect(audit[4]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
+      expect(audit[5]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
       restore();
       localStorage.removeItem('accessToken');
     });
@@ -697,6 +702,48 @@ describe('activity-feed', () => {
       const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
       expect(audit[0]).to.contain('start_date=');
       expect(audit[1]).to.not.contain('start_date=');
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('reads history when the last day is full of dropped traffic', async () => {
+      // The window is three full pages of successful gateway calls, which
+      // the feed drops, so `exhausted` is false. Without a zero-row fallback
+      // the card said "Nothing yet" while /console/audit listed real history.
+      localStorage.setItem('accessToken', 'test-token');
+      const old = new Date(Date.now() - 40 * 3600 * 1000).toISOString();
+      const { restore, urls } = stubFetch([
+        gatewayNoise(AUDIT_PAGE_SIZE),
+        gatewayNoise(AUDIT_PAGE_SIZE),
+        gatewayNoise(AUDIT_PAGE_SIZE),
+        [
+          auditGroup(
+            'runtime_session_created',
+            {
+              id: 'old',
+              resource_id: 'sess-old',
+              details: { runtime_principal_name: 'Hermes' },
+              timestamp: old,
+            },
+            'created'
+          ),
+        ],
+      ]);
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => rowText(el).length === 1,
+        'history under the noise'
+      );
+      expect(rowText(el)[0]).to.contain('Hermes started a session');
+      expect(listItems(el)[0]).to.equal('earlier');
+      const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
+      expect(audit.length).to.equal(4);
+      expect(audit[0]).to.contain('start_date=');
+      expect(audit[1]).to.contain('start_date=');
+      expect(audit[2]).to.contain('start_date=');
+      expect(audit[3]).to.not.contain('start_date=');
       restore();
       localStorage.removeItem('accessToken');
     });
@@ -1181,21 +1228,22 @@ describe('activity-feed', () => {
 
     it('gives each tone its own dot', async () => {
       const el = await feed();
+      const now = Date.now();
       el.ingest('flow_executions', {
         execution_id: 'exec-9',
         type: 'status_update',
-        timestamp: NOW,
+        timestamp: new Date(now).toISOString(),
         payload: { status: 'SUCCEEDED', flow_name: 'Nightly sweep' },
       });
       el.ingest('approvals', {
         type: 'approval_created',
         approval_request_id: 'req-2',
         tool_name: 'Bash',
-        timestamp: new Date(Date.now() - 1000).toISOString(),
+        timestamp: new Date(now - 1000).toISOString(),
       });
       el.ingest('gateway_activity', {
         type: 'model_gateway_call',
-        timestamp: new Date(Date.now() - 2000).toISOString(),
+        timestamp: new Date(now - 2000).toISOString(),
         payload: {
           api_usage_id: 'u-9',
           status_code: 502,
@@ -1204,7 +1252,7 @@ describe('activity-feed', () => {
       });
       el.ingest('runtime_sessions', {
         type: 'runtime_session_created',
-        timestamp: new Date(Date.now() - 3000).toISOString(),
+        timestamp: new Date(now - 3000).toISOString(),
         payload: {
           runtime_session_id: 's-9',
           runtime_principal_name: 'Hermes',

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -4,6 +4,7 @@ import './activity-feed.ts';
 import {
   AUDIT_PAGE_SIZE,
   FEED_CAP,
+  FEED_INITIAL_ROWS,
   feedEventFromAuditGroup,
   feedEventFromRealtime,
   outcomeLabel,
@@ -127,6 +128,19 @@ async function feed(autoload = false): Promise<ActivityFeed> {
 function rowText(el: ActivityFeed): string[] {
   return Array.from(el.shadowRoot!.querySelectorAll('.row')).map((row) =>
     (row.textContent || '').replace(/\s+/g, ' ').trim()
+  );
+}
+
+/**
+ * The list in order, rows and the divider alike, so a test can say what sits
+ * above the "Earlier" line and what sits below it.
+ */
+function listItems(el: ActivityFeed): string[] {
+  const list = el.shadowRoot!.querySelector('.rows');
+  return Array.from(list?.children || []).map((node) =>
+    node.classList.contains('earlier')
+      ? 'earlier'
+      : (node.textContent || '').replace(/\s+/g, ' ').trim()
   );
 }
 
@@ -684,6 +698,160 @@ describe('activity-feed', () => {
       expect(audit[0]).to.contain('start_date=');
       expect(audit[1]).to.not.contain('start_date=');
       restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('fills the rail from history on a quiet account, under an Earlier line', async () => {
+      // The founder's account on 2026-09-07: nothing in the last day, a full
+      // history behind it, and a card that said "Nothing yet" until the next
+      // socket message arrived.
+      localStorage.setItem('accessToken', 'test-token');
+      const history = Array.from({ length: FEED_INITIAL_ROWS }, (_, index) =>
+        auditGroup(
+          'api_key_created',
+          {
+            id: `h${index}`,
+            timestamp: new Date(
+              Date.now() - (2 * 86400000 + index * 60000)
+            ).toISOString(),
+          },
+          'success'
+        )
+      );
+      const { restore, urls } = stubFetch([[], history]);
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => rowText(el).length === FEED_INITIAL_ROWS,
+        'the history fills the rail'
+      );
+      expect(rowText(el)[0]).to.contain('API key created');
+      // Age is stated in the row, so nobody reads two-day-old history as news.
+      expect(
+        el.shadowRoot!.querySelector('.when')!.textContent!.trim()
+      ).to.equal('2d ago');
+      // Everything here is history, so the divider heads the list.
+      const items = listItems(el);
+      expect(items[0]).to.equal('earlier');
+      expect(items.length).to.equal(FEED_INITIAL_ROWS + 1);
+      expect(
+        el.shadowRoot!.querySelector('.earlier')!.textContent!.trim()
+      ).to.equal('Earlier');
+      const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
+      expect(audit.length).to.equal(2);
+      expect(audit[0]).to.contain('start_date=');
+      expect(audit[1]).to.not.contain('start_date=');
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('prepends a live row above the divider and not a second time', async () => {
+      localStorage.setItem('accessToken', 'test-token');
+      const historyGroup = auditGroup(
+        'api_key_created',
+        {
+          id: 'shared',
+          timestamp: new Date(Date.now() - 3 * 86400000).toISOString(),
+        },
+        'success'
+      );
+      const { restore } = stubFetch([[], [historyGroup]]);
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(() => rowText(el).length === 1, 'the history row lands');
+
+      el.ingest('flow_executions', {
+        execution_id: 'exec-live',
+        flow_id: 'flow-1',
+        type: 'status_update',
+        timestamp: NOW,
+        payload: { status: 'FAILED', flow_name: 'Merge Request Reviewer' },
+      });
+      await el.updateComplete;
+      const items = listItems(el);
+      expect(items[0]).to.contain('Merge Request Reviewer failed');
+      expect(items[1]).to.equal('earlier');
+      expect(items[2]).to.contain('API key created');
+      expect(items.filter((item) => item === 'earlier').length).to.equal(1);
+
+      // The same event again, this time down the audit socket: the history
+      // row already carries that id, so it must not become a second row.
+      el.ingest('audit', {
+        type: 'audit_event',
+        timestamp: historyGroup.primary_event.timestamp,
+        payload: {
+          audit_log_id: historyGroup.primary_event.id,
+          action: 'api_key_created',
+          outcome: 'success',
+        },
+      });
+      await el.updateComplete;
+      expect(rowText(el).length).to.equal(2);
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('says nothing yet only when the account really is empty', async () => {
+      localStorage.setItem('accessToken', 'test-token');
+      const { restore, urls } = stubFetch([[]]);
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => !el.shadowRoot!.querySelector('.skeleton-row'),
+        'the fill finishes'
+      );
+      expect(
+        (el.shadowRoot!.querySelector('.empty')?.textContent || '').trim()
+      ).to.equal('Nothing yet. Events appear here as agents work.');
+      expect(el.shadowRoot!.querySelector('.earlier')).to.equal(null);
+      // It asked the history before settling for the empty state.
+      const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
+      expect(audit.length).to.equal(2);
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('leaves the feed alone when audit is out of reach', async () => {
+      // No `view_audit_logs`: the fill reads nothing, says nothing extra, and
+      // the live rows are still the whole feed.
+      localStorage.setItem('accessToken', 'test-token');
+      const original = window.fetch;
+      const urls: string[] = [];
+      window.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        urls.push(url);
+        if (url.includes('/audit-logs/grouped')) {
+          return new Response(JSON.stringify({ detail: 'nope' }), {
+            status: 403,
+          });
+        }
+        return new Response(JSON.stringify({ users: [] }), { status: 200 });
+      }) as typeof window.fetch;
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => !el.shadowRoot!.querySelector('.skeleton-row'),
+        'the fill finishes'
+      );
+      expect(
+        urls.filter((url) => url.includes('/audit-logs/grouped')).length
+      ).to.equal(1);
+      expect(el.shadowRoot!.querySelector('.empty')).to.not.equal(null);
+      el.ingest('flow_executions', {
+        execution_id: 'exec-1',
+        flow_id: 'flow-1',
+        type: 'status_update',
+        timestamp: NOW,
+        payload: { status: 'FAILED', flow_name: 'Merge Request Reviewer' },
+      });
+      await el.updateComplete;
+      expect(rowText(el).length).to.equal(1);
+      expect(el.shadowRoot!.querySelector('.earlier')).to.equal(null);
+      window.fetch = original;
       localStorage.removeItem('accessToken');
     });
 

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -176,7 +176,7 @@ export const AUDIT_PAGE_SIZE = 50;
  * Three pages, and only the first one is on its own: page 0 decides whether
  * more are needed, and pages 1 and 2 are then asked for together rather than
  * one after the other. A fourth page was two more round trips for rows that
- * were already off the bottom of a 12-row rail.
+ * were already off the bottom of a 20-row rail.
  */
 export const AUDIT_MAX_PAGES = 3;
 const AUDIT_WINDOW_HOURS = 24;
@@ -1846,7 +1846,7 @@ export class ActivityFeed extends LitElement {
       // the same empty rail with the same history behind it: `exhausted` is
       // false because the window still has groups, but the feed has no rows,
       // so the unwindowed read has to run. Skip it only when the window
-      // already produced news — that account's day is the news, and history
+      // already produced news: that account's day is the news, and history
       // with no lower bound is the expensive read of the two.
       const rows = foldRows(events).length;
       if (read && rows < FEED_INITIAL_ROWS && (exhausted || rows === 0)) {
@@ -2208,7 +2208,11 @@ export class ActivityFeed extends LitElement {
           (row, index) => html`
             ${
               index === earlier
-                ? html`<div class="earlier" role="separator">
+                ? html`<div
+                    class="earlier"
+                    role="separator"
+                    aria-label="Earlier"
+                  >
                     <span>Earlier</span>
                   </div>`
                 : nothing

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -1841,11 +1841,15 @@ export class ActivityFeed extends LitElement {
       const { read, exhausted } = await this.fillFrom(since, events, firstPage);
       // A quiet account has little or nothing in the last day and still has a
       // history. Rather than say "Nothing yet" to an account that worked
-      // yesterday, ask again for the newest events whenever they happened,
-      // and only once the window is out of groups: an account whose day is
-      // 150 gateway calls has more of the same behind it, and history with
-      // no lower bound is the expensive read of the two.
-      if (read && exhausted && foldRows(events).length < FEED_INITIAL_ROWS) {
+      // yesterday, ask again for the newest events whenever they happened.
+      // A day that is full of dropped traffic (successful gateway calls) is
+      // the same empty rail with the same history behind it: `exhausted` is
+      // false because the window still has groups, but the feed has no rows,
+      // so the unwindowed read has to run. Skip it only when the window
+      // already produced news — that account's day is the news, and history
+      // with no lower bound is the expensive read of the two.
+      const rows = foldRows(events).length;
+      if (read && rows < FEED_INITIAL_ROWS && (exhausted || rows === 0)) {
         await this.fillFrom(null, events);
       }
       // Rows read here are history by definition: the socket had nothing to

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -105,6 +105,13 @@ export interface FeedEvent {
    * `ran update_pull_request` lines, which is one fact, not twelve.
    */
   foldKey?: string;
+  /**
+   * True for a row read out of the audit history on first paint, false (and
+   * usually absent) for one that arrived on a socket while the page was
+   * open. It is what the "Earlier" divider divides: everything under it
+   * happened before this page was opened.
+   */
+  historic?: boolean;
 }
 
 /** A folded row: the newest of a run of identical events, plus the rest. */
@@ -147,7 +154,13 @@ export const FEED_TOPICS = [
 
 /** How many rows the feed keeps in memory, and how many it fetches to start. */
 export const FEED_CAP = 30;
-export const FEED_INITIAL_ROWS = 12;
+/**
+ * How many rows the first paint aims for, from the history if the window has
+ * fewer. Twenty is what the rail holds when the Overview gives it the whole
+ * side column, so an operator opening a quiet console reads a screenful of
+ * what the account did rather than "Nothing yet".
+ */
+export const FEED_INITIAL_ROWS = 20;
 /**
  * The audit timeline is mostly traffic, so the fill pages through it.
  *
@@ -1184,8 +1197,14 @@ export function feedEventFromRealtime(
  *
  * The Overview used to answer that question with three cards that each held
  * one kind of event. This holds all of them, in time order, at one depth: the
- * audit page owns filtering and history, the feed owns "the last hour".
- * Nothing here animates beyond the row being there on the next paint.
+ * audit page owns filtering and search, the feed owns the newest rows.
+ *
+ * It opens on the newest rows the account has, however old they are: an
+ * account that was quiet since yesterday still gets its last twenty events,
+ * under an "Earlier" divider that marks where this session began. Live rows
+ * prepend above the divider. "Nothing yet" is only for an account that has
+ * genuinely never done anything. Nothing here animates beyond the row being
+ * there on the next paint, and nothing here polls.
  */
 @customElement('activity-feed')
 export class ActivityFeed extends LitElement {
@@ -1349,6 +1368,29 @@ export class ActivityFeed extends LitElement {
 
       .row:last-child {
         border-bottom: none;
+      }
+
+      /* The line between what happened while this page was open and what was
+         already there when it opened. It is a label in the meta register with
+         a hairline running off it, not a heading: the feed is still one
+         timeline, and the divider only says where the operator came in. */
+      .earlier {
+        align-items: center;
+        color: var(--console-meta-color);
+        display: flex;
+        font-size: var(--console-text-eyebrow);
+        font-weight: 600;
+        gap: var(--sl-spacing-x-small);
+        letter-spacing: 0.06em;
+        padding: var(--sl-spacing-x-small) var(--sl-spacing-medium)
+          var(--sl-spacing-2x-small);
+        text-transform: uppercase;
+      }
+
+      .earlier::after {
+        border-top: 1px solid var(--console-hairline);
+        content: '';
+        flex: 1;
       }
 
       /* The head is the line; the body is what the line was hiding. The head
@@ -1731,55 +1773,84 @@ export class ActivityFeed extends LitElement {
     }
   }
 
+  /**
+   * Fill `into` from one slice of the audit timeline, paging while it is short.
+   *
+   * `since` bounds the slice (null asks for the newest events whenever they
+   * happened). Page 0 decides whether the rest are needed. When they are,
+   * they are asked for together instead of one after the other, and there
+   * are two of them: a fourth page was two more round trips for rows that
+   * were already off the bottom of the rail.
+   *
+   * Returns whether the timeline was readable at all (a 403 is `false`, and
+   * that is the no-audit-access path) and whether this slice ran out of
+   * groups before it filled the rail, which is what decides if there is any
+   * point asking for an older slice.
+   */
+  private async fillFrom(
+    since: string | null,
+    into: FeedEvent[],
+    page0?: AuditGroupLike[] | null
+  ): Promise<{ read: boolean; exhausted: boolean }> {
+    const firstPage =
+      page0 === undefined ? await this.fetchAuditPage(0, since) : page0;
+    if (firstPage === null) return { read: false, exhausted: false };
+    this.rowsFrom(firstPage, into);
+    if (firstPage.length < AUDIT_PAGE_SIZE) {
+      return { read: true, exhausted: true };
+    }
+    if (foldRows(into).length >= FEED_INITIAL_ROWS) {
+      return { read: true, exhausted: false };
+    }
+    const more = await Promise.all(
+      Array.from({ length: AUDIT_MAX_PAGES - 1 }, (_, index) =>
+        this.fetchAuditPage((index + 1) * AUDIT_PAGE_SIZE, since)
+      )
+    );
+    let exhausted = false;
+    for (const groups of more) {
+      if (groups === null) break;
+      if (foldRows(into).length >= FEED_INITIAL_ROWS) break;
+      this.rowsFrom(groups, into);
+      if (groups.length < AUDIT_PAGE_SIZE) {
+        exhausted = true;
+        break;
+      }
+    }
+    return { read: true, exhausted };
+  }
+
   private async loadInitial(): Promise<void> {
     this.loading = true;
     try {
       const since = new Date(
         Date.now() - AUDIT_WINDOW_HOURS * 60 * 60 * 1000
       ).toISOString();
-      // The timeline and the actor names are asked for at the same time:
-      // the names used to be awaited first, so the feed's first row waited
-      // on a request it does not need in order to draw a row.
-      const firstPage = await this.fetchAuditPage(0, since);
+      const events: FeedEvent[] = [];
+      // The last day first, because on a busy account that is both the news
+      // and the cheaper query. The timeline and the actor names are asked
+      // for at the same time: the names used to be awaited first, so the
+      // feed's first row waited on a request it does not need to draw a row.
+      const firstPage = await this.fetchAuditPage(0, since).catch(() => null);
       // The actor's name belongs on the first paint, not the second, but a
       // lookup that never answers must not hold the timeline hostage either.
       await Promise.race([
         this.usersReady,
         new Promise((resolve) => setTimeout(resolve, 2000)),
       ]);
-      const events: FeedEvent[] = [];
-      let emptyWindow = false;
-      if (firstPage !== null) {
-        emptyWindow = firstPage.length === 0;
-        this.rowsFrom(firstPage, events);
-        // Page 0 decides whether the rest are needed. When they are, they
-        // are asked for together instead of one after the other, and there
-        // are two of them: a fourth page was two more round trips for rows
-        // that were already off the bottom of a twelve-row rail.
-        if (
-          firstPage.length >= AUDIT_PAGE_SIZE &&
-          foldRows(events).length < FEED_INITIAL_ROWS
-        ) {
-          const more = await Promise.all(
-            Array.from({ length: AUDIT_MAX_PAGES - 1 }, (_, index) =>
-              this.fetchAuditPage((index + 1) * AUDIT_PAGE_SIZE, since)
-            )
-          );
-          for (const groups of more) {
-            if (groups === null) break;
-            if (foldRows(events).length >= FEED_INITIAL_ROWS) break;
-            this.rowsFrom(groups, events);
-            if (groups.length < AUDIT_PAGE_SIZE) break;
-          }
-        }
+      const { read, exhausted } = await this.fillFrom(since, events, firstPage);
+      // A quiet account has little or nothing in the last day and still has a
+      // history. Rather than say "Nothing yet" to an account that worked
+      // yesterday, ask again for the newest events whenever they happened,
+      // and only once the window is out of groups: an account whose day is
+      // 150 gateway calls has more of the same behind it, and history with
+      // no lower bound is the expensive read of the two.
+      if (read && exhausted && foldRows(events).length < FEED_INITIAL_ROWS) {
+        await this.fillFrom(null, events);
       }
-      // A quiet account has nothing in the last day and still has a history.
-      // Rather than say "Nothing yet" to an account that worked yesterday,
-      // ask once for the newest events whenever they happened.
-      if (emptyWindow && events.length === 0) {
-        const groups = await this.fetchAuditPage(0, null);
-        if (groups) this.rowsFrom(groups, events);
-      }
+      // Rows read here are history by definition: the socket had nothing to
+      // do with them, and the divider says so.
+      for (const event of events) event.historic = true;
       this.events = this.sortAndCap([...events, ...this.events]);
     } catch {
       // No audit access, no history: the live rows still arrive.
@@ -2118,12 +2189,28 @@ export class ActivityFeed extends LitElement {
         Nothing yet. Events appear here as agents work.
       </div>`;
     }
+    const rows = this.rows;
+    // The first row that was read out of the audit history rather than heard
+    // on a socket. Everything above it happened while this page was open, so
+    // the divider goes here and nowhere else; a feed of nothing but history
+    // (a quiet account on first paint) gets it at the top, which is the
+    // honest label for a list where nothing has happened yet today.
+    const earlier = rows.findIndex((row) => row.event.historic);
     return html`
       <div class="rows" @scroll=${() => this.scheduleMeasure()}>
         ${repeat(
-          this.rows,
+          rows,
           (row) => row.event.id,
-          (row) => this.renderRow(row)
+          (row, index) => html`
+            ${
+              index === earlier
+                ? html`<div class="earlier" role="separator">
+                    <span>Earlier</span>
+                  </div>`
+                : nothing
+            }
+            ${this.renderRow(row)}
+          `
         )}
       </div>
     `;

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -2408,7 +2408,14 @@ describe('DashboardView', () => {
       const urls = fetchStub
         .getCalls()
         .map((call) => String(call.args[0]))
-        .filter((url) => !url.startsWith('/api/v1/users'));
+        .filter(
+          (url) =>
+            // The child widgets' own startup reads, which no gateway event
+            // triggers: the feed fills once from audit (and asks the history
+            // for a quiet account), and looks the people list up.
+            !url.startsWith('/api/v1/users') &&
+            !url.startsWith('/api/v1/audit-logs')
+        );
       expect(urls.length, urls.join('\n')).to.be.at.most(4);
       expect(urls.some((url) => url.startsWith('/api/v1/flows'))).to.be.false;
       expect(urls.some((url) => url.includes('include_breakdown=true'))).to.be


### PR DESCRIPTION
## The report

Founder, prod, 2026-09-07: "The activity box in the overview is empty until events start coming through. Shouldn't we show recent events anyway?"

## Root cause

`frontend/src/components/activity-feed.ts` filled from `/api/v1/audit-logs/grouped` with `start_date = now - 24h`, and only asked for the history without a window when that window returned literally zero groups (`emptyWindow && events.length === 0`, old line 1792, where `emptyWindow` was `firstPage.length === 0`).

The founder's case is the near miss, not the empty one: an account whose last day holds a handful of groups that are all traffic the feed deliberately drops (a successful `model_gateway_request` is not news) or two rows and nothing more. `emptyWindow` is then false, the history read never happens, and the card says "Nothing yet" while `/console/audit` lists a full timeline.

No backend change was needed. `GET /api/v1/audit-logs/grouped` takes `start_date` as `Optional` with no server-side default (preloop-ee `plugins/audit/endpoints.py:200-202`) and the CRUD only adds the timestamp filter when it is given (`backend/preloop/models/crud/audit_log.py:390-393`), ordering `timestamp DESC` with `skip` / `limit` up to 200. "The most recent N regardless of age" is that endpoint called without `start_date`.

## What this does

- The fill aims for **20 rows** (`FEED_INITIAL_ROWS` 12 -> 20) and asks the same endpoint again **without `start_date`** whenever the window ran out of groups before the rail was full. The window is still asked first: on a busy account it is both the news and the cheaper query, and an account whose day is 150 gateway calls has more of the same behind it, so its unwindowed read is skipped.
- Rows read from the timeline are marked `historic` and an **"Earlier"** divider is drawn above the first of them: a subtle uppercase label in the meta register (11px, `--console-meta-color`) with a hairline running off it. On a quiet account it heads the list; once a live row arrives it sits under that row.
- Live rows keep prepending and keep deduplicating by event id against the history rows. **No polling** was added.
- "Nothing yet" now means an account that has genuinely never done anything. The no-audit-access path (403 on the first page) is unchanged: one request, no rows, no divider, live rows still arrive.

## Tests (real browser, Chromium)

Four new cases in `src/components/activity-feed.test.ts`:

- quiet account (window empty, 20 in history): 20 rows on first paint, `2d ago` on the first row, divider at list index 0, exactly two audit requests (`start_date=`, then none);
- a live row prepends above the divider, and the same audit event arriving on the socket with a history row's id does not become a second row;
- a truly empty account still shows the empty state, with no divider;
- audit 403: one request, no second read, no divider, live rows still render.

`src/views/authed/dashboard-view.test.ts` "answers a gateway event with four requests" now filters `/api/v1/audit-logs` out of the post-event request list, the way its sibling fold test (line 2049) already does: a gateway event does not make the feed fetch, the feed's second read belongs to its one-time fill.

Numbers measured on this branch:

- `activity-feed.test.ts`: 41 passed, 0 failed (37 before).
- `dashboard-view.test.ts`: 62 passed, 0 failed.
- `npm test` (168 files): 2076 passed, 0 failed.
- `npm run build` passes: `main-*.js` 3,083.88 kB -> 3,085.20 kB (gzip 699.71 -> 700.05).
- `npx tsc --noEmit`: 251 pre-existing errors before and after, none in the files touched.

## Design note

DESIGN.md (preloop-ee, read-only here) says the feed "fills from the audit timeline (last 24 hours, newest first, 12 rows)". This changes that to "the newest 20 rows, from the last 24 hours and then from the history when the window is short, with an Earlier divider marking the session boundary". A D-row is proposed in the report at `/tmp/preloop-reports/ux6-activity-feed.md` rather than edited into the file here.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Frontend-only, well-tested change with no security or data-loss concerns; the empty-state gap from the prior review is now closed.
>
> **Overview**
> Fills the Activity feed from audit history on first paint (aiming for 20 rows, then an unwindowed read when the window is short or empty of news), marks those rows `historic`, and draws an "Earlier" divider at the session boundary. Live rows prepend above it and dedupe by event id.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d6a8f69. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->