### PR TITLE
Console polish: agents page geometry, one token total in the lists, bell at the header's optical size

### DIFF
--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -15,6 +15,7 @@ import {
 import './console-header.ts';
 import type { ConsoleHeader } from './console-header.ts';
 import { publishAttentionSummary } from '../utils/attention-summary';
+import { loadShoelaceTokens } from '../utils/test-shoelace-theme';
 import { Router } from '@vaadin/router';
 
 const USER = {
@@ -115,6 +116,88 @@ describe('console-header user menu trigger', () => {
  * the empty state names what is empty and repeats the attention counts the
  * Overview or the Attention page published.
  */
+describe('console-header notification button', () => {
+  let restoreFetch: () => void;
+  let el: ConsoleHeader;
+
+  beforeEach(async () => {
+    await loadShoelaceTokens();
+    localStorage.setItem('accessToken', 'test-token');
+    restoreFetch = stubFetch();
+    el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    localStorage.removeItem('accessToken');
+  });
+
+  it('sits at the optical size of the header icons around it', async () => {
+    const bell = el.shadowRoot!.querySelector<HTMLElement>(
+      '.notification-button sl-icon-button'
+    )!;
+    expect(bell.getAttribute('name'), 'the plain bell glyph').to.equal('bell');
+    // 1.375rem. The size is set on the button, not baked into a special
+    // icon, and it is below the 1.5rem nav toggle because a bell's ink fills
+    // its box where a hamburger's does not. At 1.8rem the glyph was 28.8px
+    // in a 45px box, taller than the 32px avatar beside it.
+    const fontSize = parseFloat(getComputedStyle(bell).fontSize);
+    expect(fontSize, 'bell glyph size').to.equal(22);
+    const box = bell.getBoundingClientRect();
+    expect(box.height, 'bell button height').to.be.at.most(40);
+    expect(
+      box.height,
+      'bell button is still a comfortable target'
+    ).to.be.at.least(32);
+
+    const avatar = el
+      .shadowRoot!.querySelector('button.user-menu-trigger')!
+      .getBoundingClientRect();
+    expect(
+      box.height,
+      'bell is no louder than the avatar beside it'
+    ).to.be.at.most(avatar.height + 8);
+  });
+
+  it('keeps the badge on the corner of the smaller button', async () => {
+    // A pending approval is what puts a count on the bell.
+    restoreFetch();
+    restoreFetch = stubFetch(() => [
+      {
+        id: 'ar-1',
+        tool_name: 'write_file',
+        tool_args: {},
+        status: 'pending',
+        requested_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        execution_id: 'exec-1',
+      },
+    ]);
+    el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
+    await el.updateComplete;
+    await waitUntil(
+      () => !!el.shadowRoot?.querySelector('.notification-badge'),
+      'badge never appeared'
+    );
+
+    const wrapper = el
+      .shadowRoot!.querySelector('.notification-button')!
+      .getBoundingClientRect();
+    const badge = el
+      .shadowRoot!.querySelector('.notification-badge')!
+      .getBoundingClientRect();
+    // Anchored to the button's own top-right corner, so the smaller button
+    // did not leave it floating in the header.
+    expect(
+      Math.abs(badge.right - (wrapper.right + 4)),
+      'badge x'
+    ).to.be.at.most(1);
+    expect(Math.abs(badge.top - (wrapper.top - 4)), 'badge y').to.be.at.most(1);
+    expect(badge.width, 'badge is drawn').to.be.greaterThan(0);
+  });
+});
+
 describe('console-header bell empty state', () => {
   let restoreFetch: () => void;
 

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -184,8 +184,17 @@ export class ConsoleHeader extends LitElement {
       align-items: center;
       gap: 0.5rem;
     }
+    /* The bell is the only icon button in this row, and at 1.8rem it drew a
+       28.8px glyph in a 45px box: larger than the 24px nav toggle beside it
+       and taller than the 32px avatar, so it read as the loudest thing in a
+       header that is mostly quiet. A bell is a tall glyph (its ink fills the
+       Bootstrap Icons box, unlike the hamburger's three short rules), so
+       optical parity is a smaller size than the nav toggle's, not the same
+       one: 1.375rem is 22px of glyph in a 38px box. The size lives here
+       rather than in a one-off icon, so the glyph stays the plain bell
+       every product uses for notifications. */
     .user-menu sl-icon-button {
-      font-size: 1.8rem;
+      font-size: 1.375rem;
     }
     .theme-switcher-container {
       padding: 0.5rem 1rem;

--- a/frontend/src/components/token-figures.test.ts
+++ b/frontend/src/components/token-figures.test.ts
@@ -14,6 +14,7 @@ import {
   formatTokenCount,
   sumTokenUsage,
   tokenFiguresTitle,
+  totalTokensOf,
 } from './token-figures';
 import type { GatewayTokenUsage } from '../types';
 
@@ -215,5 +216,40 @@ describe('token-figures', () => {
     );
     expect(text(el)).to.contain('12.4K in');
     expect(text(el)).to.not.contain('cache');
+  });
+
+  it('states the total alone in total-only, with the breakdown still in the tooltip', async () => {
+    const el = await fixture<TokenFigures>(
+      html`<token-figures .usage=${USAGE} total-only></token-figures>`
+    );
+    // One figure, no direction words and no cache suffix to clip.
+    expect(text(el)).to.equal('15.5K');
+    expect(text(el)).to.not.contain('in');
+    expect(text(el)).to.not.contain('out');
+    expect(text(el)).to.not.contain('cache');
+
+    const expected = tokenFiguresTitle(USAGE);
+    expect(
+      el.shadowRoot?.querySelector('sl-tooltip')?.getAttribute('content')
+    ).to.equal(expected);
+    expect(
+      el.shadowRoot?.querySelector('.figures')?.getAttribute('title')
+    ).to.equal(expected);
+    expect(expected).to.contain('15,500 total');
+  });
+
+  it('says nothing in total-only for a row with no usage', async () => {
+    const el = await fixture<TokenFigures>(
+      html`<token-figures total-only></token-figures>`
+    );
+    expect(text(el)).to.equal('-');
+  });
+
+  it('adds the directions up where the endpoint reported no total', () => {
+    expect(totalTokensOf({ input_tokens: 400, output_tokens: 100 })).to.equal(
+      500
+    );
+    expect(totalTokensOf(USAGE)).to.equal(15500);
+    expect(totalTokensOf(null)).to.equal(0);
   });
 });

--- a/frontend/src/components/token-figures.ts
+++ b/frontend/src/components/token-figures.ts
@@ -91,6 +91,21 @@ export function outputTokensOf(
 }
 
 /**
+ * Every token an aggregate accounts for.
+ *
+ * The endpoints that report a total are believed; the ones that report only
+ * the two directions are added up, so a list column never reads "-" over
+ * traffic that has counts.
+ */
+export function totalTokensOf(
+  usage: GatewayTokenUsage | null | undefined
+): number {
+  const total = Number(usage?.total_tokens || 0);
+  if (total > 0) return total;
+  return inputTokensOf(usage) + outputTokensOf(usage);
+}
+
+/**
  * Add up several aggregates into one.
  *
  * Counts add; a rate does not, so the combined hit rate is recomputed from
@@ -150,7 +165,7 @@ export function tokenFiguresTitle(
   if (!usage) return 'No token usage recorded';
   const input = inputTokensOf(usage);
   const output = outputTokensOf(usage);
-  const total = Number(usage.total_tokens || input + output);
+  const total = totalTokensOf(usage);
   const parts = [
     `${formatExactTokenCount(input)} input tokens`,
     `${formatExactTokenCount(output)} output tokens`,
@@ -179,6 +194,12 @@ export function tokenFiguresTitle(
  * Renders "12.4K in - 3.1K out" with an optional cache segment, either
  * "cache 68% hit" (default) or "8.2K hit - 3.9K miss" when `expanded` is set,
  * which is what the cost tables and the usage card want.
+ *
+ * `total-only` states one number instead, for the default list views: the
+ * three-part breakdown needs more width than a list column has, and on a long
+ * figure the cache suffix was clipped mid-word. The breakdown is still one
+ * hover (or one screen reader stop) away in the tooltip and `title`, and the
+ * detail views keep it on the surface.
  */
 @customElement('token-figures')
 export class TokenFigures extends LitElement {
@@ -193,6 +214,10 @@ export class TokenFigures extends LitElement {
   /** Drop the cache segment entirely, for the narrowest columns. */
   @property({ type: Boolean, attribute: 'hide-cache' })
   hideCache = false;
+
+  /** State the total alone, for a list column too narrow for the breakdown. */
+  @property({ type: Boolean, attribute: 'total-only' })
+  totalOnly = false;
 
   /** What to render when there is no usage at all. */
   @property({ type: String })
@@ -247,6 +272,15 @@ export class TokenFigures extends LitElement {
       >`;
     }
     const description = tokenFiguresTitle(usage);
+    if (this.totalOnly) {
+      return html`<sl-tooltip content=${description} hoist>
+        <span class="figures" title=${description}>
+          <span class="direction"
+            >${formatTokenCount(totalTokensOf(usage))}</span
+          >
+        </span>
+      </sl-tooltip>`;
+    }
     return html`<sl-tooltip content=${description} hoist>
       <span class="figures" title=${description}>
         <span class="direction"

--- a/frontend/src/views/authed/agents-page-geometry.test.ts
+++ b/frontend/src/views/authed/agents-page-geometry.test.ts
@@ -1,0 +1,174 @@
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import '../../components/view-header.ts';
+import './agents-view.ts';
+import './flows-view.ts';
+import { invalidateApiCaches } from '../../api';
+import { loadShoelaceTokens } from '../../utils/test-shoelace-theme';
+
+/**
+ * Agents sits in the same page box as the rest of the console.
+ *
+ * The shell centres one column and pays the side inset, so a view adds none
+ * of its own (styles/console-styles.css, "The page box"). Agents used to
+ * carry `.console-page` in every mode, which is right only for the canvas:
+ * the canvas takes the whole window and has no shell padding to inherit. In
+ * the default list it meant a second 2rem inset and a page 64px narrower
+ * than Flows.
+ */
+/** One row each, so both pages draw a real list card rather than an empty state. */
+const AGENT = {
+  id: 'agent-1',
+  runtime_session_id: 'runtime-session-agent-1',
+  display_name: 'Claude Code Workspace',
+  agent_kind: 'claude_code',
+  session_source_type: 'claude_code',
+  session_source_id: 'workspace-1',
+  session_reference: 'session-1',
+  lifecycle_state: 'active',
+  activity_status: 'active_now',
+  is_active_now: true,
+  last_seen_at: '2026-09-06T10:00:00Z',
+  total_requests: 3,
+  estimated_cost: 0.42,
+  latest_model_alias: 'openai/gpt-5',
+};
+
+const FLOW = {
+  id: 'flow-1',
+  name: 'Nightly sweep',
+  is_enabled: true,
+};
+
+describe('Agents page geometry', () => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    await loadShoelaceTokens();
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    fetchStub = sinon.stub(window, 'fetch').callsFake(async (input) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      let body: unknown = [];
+      if (url.startsWith('/api/v1/agents')) {
+        body = { items: [AGENT], total: 1, limit: 50, offset: 0 };
+      } else if (url.includes('/api/v1/flows/presets')) {
+        body = [];
+      } else if (url.includes('/api/v1/flows/executions')) {
+        body = [];
+      } else if (url.startsWith('/api/v1/flows')) {
+        body = [FLOW];
+      } else if (url.includes('gateway-usage/summary')) {
+        body = {
+          token_usage: { total_tokens: 0, input_tokens: 0, output_tokens: 0 },
+          estimated_cost: 0,
+          total_requests: 0,
+          requests_by_day: [],
+          top_models: [],
+          top_agents: [],
+          top_flows: [],
+        };
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  });
+
+  afterEach(() => {
+    fetchStub?.restore();
+    localStorage.clear();
+    invalidateApiCaches();
+  });
+
+  /**
+   * Mounts a view in a column of the given width and reports where its title
+   * and its list card sit relative to the view's own left edge.
+   */
+  async function pageBox(
+    tag: 'agents-view' | 'flows-view',
+    width: number
+  ): Promise<{ titleLeft: number; cardLeft: number; cardWidth: number }> {
+    const wrapper = (await fixture(html`
+      <div style="width: ${width}px; display: flex; flex-direction: column">
+        ${document.createElement(tag)}
+      </div>
+    `)) as HTMLElement;
+    const view = wrapper.firstElementChild as HTMLElement & {
+      updateComplete?: Promise<unknown>;
+    };
+    view.style.width = '100%';
+    await view.updateComplete;
+
+    let title: HTMLElement | null = null;
+    let card: HTMLElement | null = null;
+    await waitUntil(() => {
+      title =
+        (view.shadowRoot
+          ?.querySelector('view-header')
+          ?.shadowRoot?.querySelector('h1') as HTMLElement | null) ?? null;
+      card = view.shadowRoot?.querySelector(
+        'sl-card.table-card'
+      ) as HTMLElement | null;
+      return title !== null && card !== null;
+    }, `${tag} never drew its title and list card`);
+
+    const origin = view.getBoundingClientRect().left;
+    const titleBox = (title as unknown as HTMLElement).getBoundingClientRect();
+    const cardBox = (card as unknown as HTMLElement).getBoundingClientRect();
+    return {
+      titleLeft: titleBox.left - origin,
+      cardLeft: cardBox.left - origin,
+      cardWidth: cardBox.width,
+    };
+  }
+
+  it('keeps the page box on the canvas, which the shell hands the full window', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'canvas');
+    const wrapper = (await fixture(html`
+      <div style="width: 1440px; display: flex; flex-direction: column">
+        <agents-view></agents-view>
+      </div>
+    `)) as HTMLElement;
+    const view = wrapper.firstElementChild as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    await view.updateComplete;
+    const band = view.shadowRoot!.querySelector('.content-bounds')!;
+    // Full bleed means no shell padding to inherit, so the canvas page draws
+    // the box itself: the 1280px column centred in 1440 (80px each side)
+    // plus the 2rem side inset.
+    expect(band.classList.contains('console-page')).to.equal(true);
+    const header = band.querySelector('view-header')!;
+    expect(
+      Math.round(
+        header.getBoundingClientRect().left - view.getBoundingClientRect().left
+      ),
+      'canvas header inset'
+    ).to.equal(112);
+  });
+
+  for (const width of [1440, 1280]) {
+    it(`puts the agents header and list on the same x and width as flows at ${width}`, async () => {
+      const flows = await pageBox('flows-view', width);
+      const agents = await pageBox('agents-view', width);
+
+      expect(
+        Math.abs(agents.titleLeft - flows.titleLeft),
+        `title x: agents ${agents.titleLeft}, flows ${flows.titleLeft}`
+      ).to.be.at.most(1);
+      expect(
+        Math.abs(agents.cardLeft - flows.cardLeft),
+        `list card x: agents ${agents.cardLeft}, flows ${flows.cardLeft}`
+      ).to.be.at.most(1);
+      expect(
+        Math.abs(agents.cardWidth - flows.cardWidth),
+        `list card width: agents ${agents.cardWidth}, flows ${flows.cardWidth}`
+      ).to.be.at.most(1);
+      // The shell pays the inset, so a view adds none of its own.
+      expect(agents.titleLeft, 'agents adds no inset of its own').to.equal(0);
+    });
+  }
+});

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -318,16 +318,30 @@ describe('AgentsView', () => {
     expect(cardLink?.getAttribute('href')).to.equal('/console/agents/agent-1');
   });
 
-  it('pays the page box with .console-page on the full-bleed canvas', async () => {
-    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitForAgents(el);
-
+  it('pays the page box with .console-page only on the full-bleed canvas', async () => {
+    // List and cards are ordinary shell pages: the shell centres the column
+    // and pays the side inset, so paying it here too moved the header 2rem
+    // in from the Flows header and made the list 64px narrower.
+    const list = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(list);
     expect(
-      el.shadowRoot?.querySelector('.content-bounds.console-page'),
-      'header band'
+      list.shadowRoot?.querySelector('.content-bounds.console-page'),
+      'header band on the list'
+    ).to.not.exist;
+    expect(
+      list.shadowRoot?.querySelector('.list-bounds.console-page'),
+      'list card'
+    ).to.not.exist;
+
+    // The canvas asks the shell for the whole window, so there it draws the
+    // box itself.
+    localStorage.setItem('preloop.agents.view_mode', 'canvas');
+    const canvas = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await canvas.updateComplete;
+    expect(
+      canvas.shadowRoot?.querySelector('.content-bounds.console-page'),
+      'header band on the canvas'
     ).to.exist;
-    expect(el.shadowRoot?.querySelector('.list-bounds.console-page'), 'list').to
-      .exist;
   });
 
   it('gives every column a sortable header with aria-sort', async () => {

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -1376,7 +1376,8 @@ describe('sortAgentListRows', () => {
   it('sorts tokens by the total the cell states', () => {
     // The cell shows the total and nothing else, so the column sorts by the
     // total: a row whose header says 900K outranks one that says 15.5K,
-    // whatever the in/out split behind them.
+    // whatever the in/out split behind them. When the payload has directions
+    // and no total, the cell adds them up, and so does the sort.
     const tokenRows = [
       makeRow({
         id: 'small',
@@ -1388,14 +1389,23 @@ describe('sortAgentListRows', () => {
         name: 'Large',
         tokenUsage: { total_tokens: 900000, input_tokens: 100 },
       }),
+      makeRow({
+        id: 'split',
+        name: 'Split',
+        tokenUsage: {
+          input_tokens: 400,
+          output_tokens: 100,
+          total_tokens: 0,
+        } as AgentListRow['tokenUsage'],
+      }),
       makeRow({ id: 'none', name: 'None', tokenUsage: null }),
     ];
     expect(
       sortAgentListRows(tokenRows, 'tokens', 'desc').map((row) => row.id)
-    ).to.deep.equal(['large', 'small', 'none']);
+    ).to.deep.equal(['large', 'small', 'split', 'none']);
     expect(
       sortAgentListRows(tokenRows, 'tokens', 'asc').map((row) => row.id)
-    ).to.deep.equal(['none', 'small', 'large']);
+    ).to.deep.equal(['none', 'split', 'small', 'large']);
   });
 
   it('sorts last seen newest first and keeps never-seen agents last', () => {

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -205,6 +205,37 @@ describe('AgentsView', () => {
     );
   });
 
+  it('fits a large token figure inside the tokens column', async () => {
+    await loadShoelaceTokens();
+    agentItems = [
+      {
+        ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
+        token_usage: {
+          input_tokens: 780000000,
+          output_tokens: 207654321,
+          total_tokens: 987654321,
+          cache_read_tokens: 500000000,
+          uncached_input_tokens: 280000000,
+          cache_hit_ratio: 0.64,
+        },
+      },
+    ];
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const cell = el.shadowRoot!.querySelector('tbody td.numeric + td.numeric')!;
+    const figures = cell.querySelector('token-figures')!;
+    await (figures as unknown as { updateComplete: Promise<unknown> })
+      .updateComplete;
+    expect((figures.shadowRoot?.textContent || '').trim()).to.equal('987.7M');
+    // The breakdown used to overrun this column and lose the end of the
+    // cache segment to the cell's own ellipsis. One total fits.
+    expect(
+      figures.getBoundingClientRect().right,
+      'token figure ends inside its cell'
+    ).to.be.at.most(cell.getBoundingClientRect().right + 1);
+  });
+
   it('puts the select-all box on the same x as the row boxes', async () => {
     await loadShoelaceTokens();
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
@@ -372,9 +403,11 @@ describe('AgentsView', () => {
     const spendButton = headers[7].querySelector('.sort-button');
     expect(spendButton?.getAttribute('aria-label')).to.equal('Estimated spend');
     expect(spendButton?.getAttribute('title')).to.equal('Estimated spend');
+    // The cell states one total, so the header names that rather than the
+    // split it no longer shows.
     const tokensButton = headers[6].querySelector('.sort-button');
     expect(tokensButton?.getAttribute('aria-label')).to.equal(
-      'Tokens, input and output'
+      'Total tokens, input plus output'
     );
 
     const lastSeen = headers[8];
@@ -423,7 +456,7 @@ describe('AgentsView', () => {
     expect(numeric?.[0].textContent?.trim()).to.equal((1234).toLocaleString());
   });
 
-  it('states tokens before cost, split in and out with the cache rate', async () => {
+  it('states the token total before cost, with the split in the tooltip', async () => {
     agentItems = [
       {
         ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
@@ -460,12 +493,18 @@ describe('AgentsView', () => {
     const figures = cells[tokenIndex].querySelector('token-figures')!;
     await (figures as unknown as { updateComplete: Promise<unknown> })
       .updateComplete;
-    const text = (figures.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
-    expect(text).to.contain('12.4K in');
-    expect(text).to.contain('3.1K out');
-    expect(text).to.contain('cache 68% hit');
+    // The default list states one number. The in/out/cache breakdown needed
+    // more width than the column has and was clipped mid-word, so it lives
+    // in the tooltip and on the agent's own page.
+    const text = (figures.shadowRoot?.textContent || '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    expect(text).to.equal('15.5K');
+    expect(text).to.not.contain('in');
+    expect(text).to.not.contain('cache');
     const exact = figures.shadowRoot?.querySelector('.figures');
     expect(exact?.getAttribute('title')).to.contain('12,400 input tokens');
+    expect(exact?.getAttribute('title')).to.contain('15,500 total');
   });
 
   it('states lifetime tokens on a flow row, beside its lifetime spend', async () => {
@@ -511,10 +550,13 @@ describe('AgentsView', () => {
     const figures = row?.querySelector('token-figures')!;
     await (figures as unknown as { updateComplete: Promise<unknown> })
       .updateComplete;
-    const text = (figures.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
-    expect(text).to.contain('9K in');
-    expect(text).to.contain('1.2K out');
-    expect(text).to.contain('cache 67% hit');
+    const text = (figures.shadowRoot?.textContent || '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    expect(text).to.equal('10.2K');
+    expect(
+      figures.shadowRoot?.querySelector('.figures')?.getAttribute('title')
+    ).to.contain('9,000 input tokens');
   });
 
   it('shows a relative last seen with the absolute time on hover', async () => {
@@ -1329,6 +1371,31 @@ describe('sortAgentListRows', () => {
   it('sorts numeric columns by value, not by their formatted text', () => {
     expect(ids('requests', 'desc')).to.deep.equal(['c', 'b', 'a']);
     expect(ids('spend', 'desc')).to.deep.equal(['a', 'c', 'b']);
+  });
+
+  it('sorts tokens by the total the cell states', () => {
+    // The cell shows the total and nothing else, so the column sorts by the
+    // total: a row whose header says 900K outranks one that says 15.5K,
+    // whatever the in/out split behind them.
+    const tokenRows = [
+      makeRow({
+        id: 'small',
+        name: 'Small',
+        tokenUsage: { total_tokens: 15500, input_tokens: 12400 },
+      }),
+      makeRow({
+        id: 'large',
+        name: 'Large',
+        tokenUsage: { total_tokens: 900000, input_tokens: 100 },
+      }),
+      makeRow({ id: 'none', name: 'None', tokenUsage: null }),
+    ];
+    expect(
+      sortAgentListRows(tokenRows, 'tokens', 'desc').map((row) => row.id)
+    ).to.deep.equal(['large', 'small', 'none']);
+    expect(
+      sortAgentListRows(tokenRows, 'tokens', 'asc').map((row) => row.id)
+    ).to.deep.equal(['none', 'small', 'large']);
   });
 
   it('sorts last seen newest first and keeps never-seen agents last', () => {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -26,7 +26,7 @@ import '../../components/resource-actions.ts';
 import '../../components/list-selection.ts';
 import '../../components/talk-button.ts';
 import '../../components/confirm-dialog.ts';
-import '../../components/token-figures.ts';
+import { totalTokensOf } from '../../components/token-figures';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
 import {
@@ -229,9 +229,9 @@ export interface AgentListRow {
   source: any;
 }
 
-/** Total tokens for sorting; an unmeasured row sorts as zero, not as noise. */
+/** Total tokens for sorting; matches the figure the cell states. */
 function tokenTotal(usage: GatewayTokenUsage | null): number {
-  return Number(usage?.total_tokens || 0);
+  return totalTokensOf(usage);
 }
 
 function timestampValue(value: string | null): number {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -531,17 +531,18 @@ export class AgentsView extends LitElement {
         width: 100%;
         /* Below this the columns cannot hold their content, so the card
            scrolls sideways instead of hiding anything. The number is derived,
-           not guessed: the pixel columns sum to 800px (select 40, status 150,
-           requests 110, tokens 190, spend 110, last seen 128, actions 72) and
+           not guessed: the pixel columns sum to 720px (select 40, status 150,
+           requests 110, tokens 110, spend 110, last seen 128, actions 72) and
            owner + model take 24%, so the auto Agent column gets
-           0.76 x width - 800. At 1340px that is 218px: 32px of cell padding
+           0.76 x width - 720. At 1260px that is 238px: 32px of cell padding
            and the 180px .agent-identity (20px icon, 12px gap, ~150px of
-           name). The old 1096px left Agent with nothing: a
-           fixed-layout auto column collapses to zero once the others overrun
-           the table, which is how the name column vanished (and "Agent"
-           became "AGE") at zoomed or laptop widths. The list falls back to
-           cards under 640px. */
-        min-width: 1340px;
+           name), with room to spare. The old 1096px left Agent with nothing:
+           a fixed-layout auto column collapses to zero once the others
+           overrun the table, which is how the name column vanished (and
+           "Agent" became "AGE") at zoomed or laptop widths. 1340px was the
+           same arithmetic while tokens still spent 190px on a breakdown.
+           The list falls back to cards under 640px. */
+        min-width: 1260px;
       }
       .table-scroll {
         overflow-x: auto;
@@ -610,10 +611,12 @@ export class AgentsView extends LitElement {
       .col-requests {
         width: 110px;
       }
-      /* Tokens read before cost, so the pair sits together and the wider of
-         the two gets the room. */
+      /* Tokens read before cost, so the pair sits together. The column
+         holds one compact total ("12.4M"), not the in/out/cache breakdown
+         that used to be clipped mid-word here, so it needs no more room
+         than the requests count beside it. */
       .col-tokens {
-        width: 190px;
+        width: 110px;
       }
       .col-spend {
         width: 110px;
@@ -3554,8 +3557,10 @@ export class AgentsView extends LitElement {
           }
         </td>
         <td class="numeric">${(row.requests || 0).toLocaleString()}</td>
+        <!-- The list states the total; in, out and the cache split are in
+             the tooltip and on the agent's own page. -->
         <td class="numeric">
-          <token-figures .usage=${row.tokenUsage}></token-figures>
+          <token-figures total-only .usage=${row.tokenUsage}></token-figures>
         </td>
         <td class="numeric">${this.formatMoney(row.spend)}</td>
         <td
@@ -3686,7 +3691,7 @@ export class AgentsView extends LitElement {
                     'tokens',
                     'Tokens',
                     true,
-                    'Tokens, input and output'
+                    'Total tokens, input plus output'
                   )}
                   ${this.renderSortableHeader(
                     'spend',

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -507,23 +507,21 @@ export class AgentsView extends LitElement {
            stretch into two half-screen banners. */
         grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
         gap: var(--sl-spacing-large);
-        /* Same side inset as the header band above it. */
-        padding: 1rem var(--console-page-padding-x) 0;
+        /* No side inset of its own: the header band above it has none
+           either, because outside the canvas the shell pays it. */
+        padding: 1rem 0 0;
       }
       /* --- List view --- */
-      /* The canvas is full bleed, so this page pays its own side inset with
-         .console-page (styles/console-styles.css, "The page box"). Extra
-         block padding is all these wrappers add. */
+      /* Side insets are the shell's (styles/console-styles.css, "The page
+         box"), so these wrappers add block padding and nothing else. Only
+         the canvas is full bleed, and only there does the header band add
+         .console-page for itself: carrying it in every mode paid the inset
+         twice and left the list 64px narrower than Flows. */
       .list-bounds {
         padding-block: 0 2rem;
       }
       .content-bounds {
         padding-block: 1rem 0;
-      }
-      @media (max-width: 768px) {
-        .cards {
-          padding-inline: var(--console-page-padding-x-compact);
-        }
       }
       /* The table sizes itself from the colgroup, not from its content: an
          agent named after a container hash used to push the kebab column past
@@ -1320,6 +1318,19 @@ export class AgentsView extends LitElement {
       return 'cards';
     }
     return this.currentView;
+  }
+
+  /**
+   * The page box, but only where the shell is not already drawing it.
+   *
+   * The canvas asks the shell for the whole window (`request-full-bleed`),
+   * which turns off the shell's centred column and its side padding, so on
+   * canvas this page reproduces the box itself. In list and cards the shell
+   * pays, and adding .console-page here inset the header a second 2rem and
+   * capped the page 64px short of Flows.
+   */
+  private get pageBoxClass(): string {
+    return this.effectiveView === 'canvas' ? 'console-page' : '';
   }
 
   disconnectedCallback(): void {
@@ -3621,7 +3632,7 @@ export class AgentsView extends LitElement {
 
     if (rows.length === 0) {
       return html`
-        <div class="list-bounds console-page">
+        <div class="list-bounds">
           <div class="empty-state">
             ${
               this.loading
@@ -3634,7 +3645,7 @@ export class AgentsView extends LitElement {
     }
 
     return html`
-      <div class="list-bounds console-page">
+      <div class="list-bounds">
         <sl-card class="table-card">
           <div class="table-scroll">
             <table
@@ -4699,7 +4710,7 @@ export class AgentsView extends LitElement {
           ></preloop-agent-deployer>
         </sl-dialog>
 
-        <div class="content-bounds console-page">
+        <div class="content-bounds ${this.pageBoxClass}">
           <view-header
             headerText="Agents"
             description="Agents connected to Preloop: their gateway credentials, MCP access, and live status. Onboard agents you already run with the CLI, or deploy new ones."

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -1171,7 +1171,8 @@ describe('FlowsView', () => {
     });
 
     it('sorts tokens by the total the cell states', () => {
-      // The list cell shows one total, and the column sorts by it.
+      // The list cell shows one total, and the column sorts by it — including
+      // the in+out fallback when the payload has directions and no total.
       const rows = [
         makeRow({
           id: 'b',
@@ -1183,14 +1184,23 @@ describe('FlowsView', () => {
           name: 'Gamma',
           tokenUsage: { total_tokens: 900000, input_tokens: 100 } as any,
         }),
+        makeRow({
+          id: 'd',
+          name: 'Delta',
+          tokenUsage: {
+            input_tokens: 400,
+            output_tokens: 100,
+            total_tokens: 0,
+          } as any,
+        }),
         makeRow({ id: 'a', name: 'Alpha', tokenUsage: null }),
       ];
       expect(
         sortFlowListRows(rows, 'tokens', 'desc').map((row) => row.name)
-      ).to.deep.equal(['Gamma', 'Beta', 'Alpha']);
+      ).to.deep.equal(['Gamma', 'Beta', 'Delta', 'Alpha']);
       expect(
         sortFlowListRows(rows, 'tokens', 'asc').map((row) => row.name)
-      ).to.deep.equal(['Alpha', 'Beta', 'Gamma']);
+      ).to.deep.equal(['Alpha', 'Delta', 'Beta', 'Gamma']);
     });
 
     it('matches the search against everything the row shows', () => {

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -866,9 +866,15 @@ describe('FlowsView', () => {
       const figures = cells[tokenIndex].querySelector('token-figures')!;
       await (figures as unknown as { updateComplete: Promise<unknown> })
         .updateComplete;
-      const text = (figures.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
-      expect(text).to.contain('12.4K in');
-      expect(text).to.contain('3.1K out');
+      // One total in the list; the breakdown is a hover away and on the
+      // flow's own page.
+      const text = (figures.shadowRoot?.textContent || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      expect(text).to.equal('15.5K');
+      expect(
+        figures.shadowRoot?.querySelector('.figures')?.getAttribute('title')
+      ).to.contain('12,400 input tokens');
     });
 
     it('states no tokens beside a flow with no run in the range', async () => {
@@ -1161,6 +1167,29 @@ describe('FlowsView', () => {
       ).to.deep.equal(['Gamma', 'Alpha', 'Beta']);
       expect(
         sortFlowListRows(rows, 'flow', 'asc').map((row) => row.name)
+      ).to.deep.equal(['Alpha', 'Beta', 'Gamma']);
+    });
+
+    it('sorts tokens by the total the cell states', () => {
+      // The list cell shows one total, and the column sorts by it.
+      const rows = [
+        makeRow({
+          id: 'b',
+          name: 'Beta',
+          tokenUsage: { total_tokens: 15500, input_tokens: 12400 } as any,
+        }),
+        makeRow({
+          id: 'c',
+          name: 'Gamma',
+          tokenUsage: { total_tokens: 900000, input_tokens: 100 } as any,
+        }),
+        makeRow({ id: 'a', name: 'Alpha', tokenUsage: null }),
+      ];
+      expect(
+        sortFlowListRows(rows, 'tokens', 'desc').map((row) => row.name)
+      ).to.deep.equal(['Gamma', 'Beta', 'Alpha']);
+      expect(
+        sortFlowListRows(rows, 'tokens', 'asc').map((row) => row.name)
       ).to.deep.equal(['Alpha', 'Beta', 'Gamma']);
     });
 

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -13,7 +13,7 @@ import '../../components/list-toolbar.ts';
 import '../../components/resource-actions.ts';
 import '../../components/list-selection.ts';
 import '../../components/time-range-select.ts';
-import '../../components/token-figures.ts';
+import { totalTokensOf } from '../../components/token-figures';
 import { router } from '../../router';
 import { Router } from '@vaadin/router';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
@@ -222,10 +222,7 @@ function compareFlowRowsByKey(
     case 'failed':
       return a.failed - b.failed;
     case 'tokens':
-      return (
-        Number(a.tokenUsage?.total_tokens || 0) -
-        Number(b.tokenUsage?.total_tokens || 0)
-      );
+      return totalTokensOf(a.tokenUsage) - totalTokensOf(b.tokenUsage);
     case 'cost':
       return a.cost - b.cost;
     case 'last_run':

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -378,9 +378,11 @@ export class FlowsView extends LitElement {
       .col-failed {
         width: 84px;
       }
-      /* Tokens lead the pair, and need room for "12.4K in - 3.1K out". */
+      /* One compact total ("12.4M"), the same width as the cost beside it.
+         The in/out/cache breakdown that used to need 170px here is in the
+         tooltip and on the flow's own page. */
       .col-tokens {
-        width: 170px;
+        width: 96px;
       }
       .col-cost {
         width: 96px;
@@ -1829,7 +1831,7 @@ export class FlowsView extends LitElement {
         <!-- Tokens before cost, over the same window, and silent for the
              same reason the cost is. -->
         <td class="numeric" title=${`Tokens, last ${this.rangeLabel}`}>
-          <token-figures .usage=${row.tokenUsage}></token-figures>
+          <token-figures total-only .usage=${row.tokenUsage}></token-figures>
         </td>
         <!-- Only a server that measured this window can state a spend for
              it. Without stats_since the cost is unknown, and "-" says that;

--- a/frontend/src/views/authed/page-width.test.ts
+++ b/frontend/src/views/authed/page-width.test.ts
@@ -2,6 +2,7 @@ import { html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 
 import '../../components/view-header.ts';
+import './agents-view';
 import './flows-view';
 import './approvals-view';
 import './settings/account-view';
@@ -25,9 +26,10 @@ import { unifiedWebSocketManager } from '../../services/unified-websocket-manage
  *
  * The list is deliberately mixed: Flows, Approvals and Settings account were
  * already flush with the shell, Audit (`:host { padding: 1.5rem; max-width:
- * 1200px }`) and Users (`:host { padding: 2rem }`) were not. Without a
- * repaired page in here the test passes on a tree where every override is
- * back, which is the only failure it exists to catch.
+ * 1200px }`), Users (`:host { padding: 2rem }`) and Agents (`.console-page`
+ * on the header band in every mode, not just on the full-bleed canvas) were
+ * not. Without a repaired page in here the test passes on a tree where every
+ * override is back, which is the only failure it exists to catch.
  */
 describe('Console page width', () => {
   let fetchStub: sinon.SinonStub;
@@ -35,6 +37,7 @@ describe('Console page width', () => {
   let wsConnectStub: sinon.SinonStub;
 
   const PAGES = [
+    'agents-view',
     'flows-view',
     'approvals-view',
     'account-view',


### PR DESCRIPTION
Three console polish items from the 2026-09-07 founder review, all in the frontend.

## 1. The agents page sits in the same box as the rest of the console

`agents-view` carried `.console-page` (the shared page box: 80rem, centred, 2rem
side inset) on its header band, its list wrapper and its cards grid, in every
mode. That is right only on the canvas, which asks the shell for the whole window
(`request-full-bleed`) and so has no shell padding to inherit. In the default list
the shell was already centring the column and paying the inset, so the page paid
it twice.

Measured in a browser (web-test-runner, real Shoelace tokens, `getBoundingClientRect`),
inset from the view's own left edge to its title:

| viewport column | agents before | agents after | flows | tools | approvals |
| --- | --- | --- | --- | --- | --- |
| 1440 | 112px | 0px | 0px | 0px | 0px |
| 1280 | 32px | 0px | 0px | 0px | 0px |

Inside the shell the doubled part is the 2rem, so the agents list card also came
out 64px narrower than the Flows one. The fix removes the divergence rather than
adding an override: a `pageBoxClass` getter applies `.console-page` only on the
canvas. Agents joins the shared `page-width.test.ts`, and a new
`agents-page-geometry.test.ts` pins the agents header and list card to the Flows
ones within 1px at 1440 and 1280, and pins the canvas keeping its own box.

## 2. The default lists state one token total

The lists carried the full breakdown ("12.4K in / 3.1K out / cache 68% hit"). It
does not fit a list column: at the agents table's 190px tokens column a long
figure lost the end of the cache segment to the cell's ellipsis.

`token-figures` gets a `total-only` mode: one compact figure, with the same
breakdown sentence still in the tooltip and in `title`. Detail views, cost tables,
the usage card and the session panel keep the breakdown on the surface. Sorting is
by the total, which is what the cell now states.

Widths that follow: agents tokens column 190px to 110px, flows 170px to 96px, and
the agents table `min-width` 1340px to 1260px on the same PR #479 arithmetic
(pixel columns now sum to 720px, owner + model still 24%, so the auto Agent column
is `0.76 x width - 720` = 238px at 1260, above the 212px it needs). The #479 test
passes unchanged.

Configurable columns and composite columns with per-part sorting are not in here.

## 3. The notification bell is at the optical size of the header icons

The header row is the nav toggle (a 24px glyph), the bell and a 32px avatar. The
bell was `font-size: 1.8rem`: a 28.8px glyph in a 45px box, the loudest thing in a
quiet header.

Candidates (bell, bell-fill, inbox, app-indicator, at 1.25 / 1.375 / 1.5rem) were
rendered side by side with real Shoelace icons and measured. The glyph stays the
plain `bell` (bell-fill reads as a ringing state and competes with the red badge,
inbox reads as mail, app-indicator is illegible at these sizes and duplicates the
badge's dot); only the size changes, and it changes on the icon button rather than
becoming a one-off icon. 1.375rem is 22px of glyph in a 38px box beside a 32px
avatar. A bell fills its Bootstrap Icons box where a hamburger's three short rules
do not, so optical parity is below the nav toggle's size, not equal to it.

Badge placement survives: it is still positioned on `.notification-button`, and a
test pins it to the button's top-right corner.

## Tests

- Full frontend suite: 169 files, 2083 passed, 0 failed.
- New/changed: `agents-page-geometry.test.ts` (3), `page-width.test.ts` (+agents),
  `agents-view.test.ts` 43 passed, `flows-view.test.ts` 49 passed,
  `token-figures.test.ts` 18 passed, `console-header.test.ts` 35 passed.
- `npm run build` passes. Bundle 3,083.88 kB to 3,085.57 kB (gzip 699.71 to 700.44 kB).
- `npx tsc --noEmit`: 251 pre-existing errors on the base commit, 251 on this
  branch (no change; none in the files touched here).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Frontend-only console polish (agents page geometry, one token total in the lists, bell sizing); no security or API surface changes and well covered by browser-measured tests.
>
> **Overview**
> Three founder-review polish items: agents page geometry is brought in line with the shared shell box (removing a doubled `.console-page` inset), the default agent/flow lists state a single token total (breakdown moves to tooltip/`title`), and the notification bell is resized to optical parity with its header neighbours. The token-column sort now uses the same `totalTokensOf` helper the cell renders, resolving the one prior MEDIUM suggestion. All changes are frontend, with new geometry and total-only tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit dfc67157. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->