### PR TITLE
Deploy new agent dialog (and the onboarding path): rebuild on the console idiom

### DIFF
--- a/frontend/src/components/preloop-agent-deployer.test.ts
+++ b/frontend/src/components/preloop-agent-deployer.test.ts
@@ -1,0 +1,280 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import './preloop-agent-deployer';
+import type { PreloopAgentDeployer } from './preloop-agent-deployer';
+
+/**
+ * The deployer is the body of the "Deploy Governed Agent" dialog and of the
+ * deploy path inside the onboarding wizard. It had no tests at all, so this
+ * file pins what the redesign relies on: the step counter (including the
+ * offset the wizard hands it), one primary action per step, the review block
+ * before an irreversible action, the back routing between substeps, and the
+ * phone layout.
+ */
+describe('PreloopAgentDeployer', () => {
+  let fetchStub: sinon.SinonStub;
+
+  const MODELS = [
+    {
+      id: 'm1',
+      name: 'GPT-4o',
+      provider_name: 'openai',
+      model_kind: 'llm',
+      model_identifier: 'gpt-4o',
+    },
+    {
+      id: 'm2',
+      name: 'Claude Sonnet',
+      provider_name: 'anthropic',
+      model_kind: 'llm',
+      model_identifier: 'claude-sonnet',
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify(MODELS), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  const PHONE_WIDTH = 390;
+
+  async function mount(
+    attrs: { hideBack?: boolean; stepOffset?: number; width?: number } = {}
+  ): Promise<PreloopAgentDeployer> {
+    const host = (await fixture(html`
+      <div style="width: ${attrs.width || 900}px;">
+        <preloop-agent-deployer
+          ?hide-back-button=${attrs.hideBack ?? false}
+          .stepOffset=${attrs.stepOffset ?? 0}
+          .aiModels=${MODELS}
+          .isEnterprise=${true}
+          .isAdmin=${true}
+        ></preloop-agent-deployer>
+      </div>
+    `)) as HTMLElement;
+    const el = host.querySelector(
+      'preloop-agent-deployer'
+    ) as PreloopAgentDeployer;
+    await el.updateComplete;
+    return el;
+  }
+
+  function stepText(el: PreloopAgentDeployer): string {
+    return (
+      el.shadowRoot?.querySelector('.wizard-step-count')?.textContent || ''
+    )
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function cardByText(
+    el: PreloopAgentDeployer,
+    text: string
+  ): HTMLElement | undefined {
+    return (
+      Array.from(
+        el.shadowRoot?.querySelectorAll('.wizard-option-button') || []
+      ) as HTMLElement[]
+    ).find((b) => b.textContent?.includes(text));
+  }
+
+  async function goTo(
+    el: PreloopAgentDeployer,
+    step: string
+  ): Promise<PreloopAgentDeployer> {
+    (el as any).deploySubStep = step;
+    el.requestUpdate();
+    await el.updateComplete;
+    return el;
+  }
+
+  it('numbers its own steps and draws a rail only where the total is known', async () => {
+    const el = await mount({ hideBack: true });
+    expect(stepText(el)).to.equal('Step 1');
+    expect(el.shadowRoot?.querySelector('.wizard-step-rail')).to.equal(null);
+
+    cardByText(el, 'Deploy on an existing host')!.click();
+    await el.updateComplete;
+    expect((el as any).deploySubStep).to.equal('existing-host-method');
+    expect(stepText(el)).to.equal('Step 2');
+
+    cardByText(el, 'SSH access')!.click();
+    await el.updateComplete;
+    expect((el as any).deploySubStep).to.equal('ssh-config');
+    expect(stepText(el)).to.contain('Step 3 of 3');
+    const rail = el.shadowRoot?.querySelector(
+      '.wizard-step-rail'
+    ) as HTMLElement;
+    expect(rail.children.length).to.equal(3);
+    expect(rail.querySelectorAll('.done').length).to.equal(3);
+  });
+
+  it('continues the wizard count when the wizard hands over mid-path', async () => {
+    // The wizard reaches the deployer after choose + deploy-type, so the first
+    // deployer screen is step 3, not step 1 all over again.
+    const el = await mount({ stepOffset: 2 });
+    expect(stepText(el)).to.equal('Step 3');
+    await goTo(el, 'ssh-config');
+    expect(stepText(el)).to.contain('Step 5 of 5');
+  });
+
+  it('hides Back on the first step when the host owns the exit', async () => {
+    const hidden = await mount({ hideBack: true });
+    expect(hidden.shadowRoot?.querySelector('.wizard-back')).to.equal(null);
+
+    const shown = await mount({ hideBack: false });
+    expect(shown.shadowRoot?.querySelector('.wizard-back')).to.exist;
+
+    let cancelled = false;
+    shown.addEventListener('deploy-cancel', () => (cancelled = true));
+    (shown.shadowRoot?.querySelector('.wizard-back') as HTMLElement).click();
+    await shown.updateComplete;
+    expect(cancelled, 'first-step Back cancels').to.equal(true);
+  });
+
+  it('routes Back from a leaf step to the branch above it', async () => {
+    const el = await mount({ hideBack: true });
+    await goTo(el, 'ssh-config');
+    (el.shadowRoot?.querySelector('.wizard-back') as HTMLElement).click();
+    await el.updateComplete;
+    expect((el as any).deploySubStep).to.equal('existing-host-method');
+
+    await goTo(el, 'cli-install');
+    (el.shadowRoot?.querySelector('.wizard-back') as HTMLElement).click();
+    await el.updateComplete;
+    expect((el as any).deploySubStep).to.equal('existing-host-method');
+
+    await goTo(el, 'fresh-vm-premium');
+    (el.shadowRoot?.querySelector('.wizard-back') as HTMLElement).click();
+    await el.updateComplete;
+    expect((el as any).deploySubStep).to.equal('agent-host');
+  });
+
+  it('keeps one primary action per step and blocks deploy until SSH is complete', async () => {
+    const el = await mount({ hideBack: true });
+    await goTo(el, 'ssh-config');
+
+    const actions = el.shadowRoot?.querySelector(
+      '.wizard-actions'
+    ) as HTMLElement;
+    const primaries = actions.querySelectorAll('sl-button[variant="primary"]');
+    expect(primaries.length).to.equal(1);
+    expect(primaries[0].textContent?.trim()).to.equal('Deploy agent');
+    expect(
+      (primaries[0] as HTMLElement & { disabled: boolean }).disabled
+    ).to.equal(true);
+
+    (el as any).sshHost = '192.168.1.100';
+    (el as any).sshUsername = 'ubuntu';
+    (el as any).sshPassword = 'secret';
+    el.requestUpdate();
+    await el.updateComplete;
+    const enabled = el.shadowRoot?.querySelector(
+      '.wizard-actions sl-button[variant="primary"]'
+    ) as HTMLElement & { disabled: boolean };
+    expect(enabled.disabled).to.equal(false);
+  });
+
+  it('summarises the deployment before the button that starts it', async () => {
+    const el = await mount({ hideBack: true });
+    (el as any).sshHost = '192.168.1.100';
+    (el as any).sshUsername = 'ubuntu';
+    (el as any).deployModel = 'm1';
+    await goTo(el, 'ssh-config');
+
+    const summary = (
+      el.shadowRoot?.querySelector('.wizard-summary')?.textContent || ''
+    ).replace(/\s+/g, ' ');
+    expect(summary).to.contain('ubuntu@192.168.1.100:22');
+    expect(summary).to.contain('GPT-4o');
+    expect(summary).to.contain('Password');
+
+    await goTo(el, 'fresh-vm-premium');
+    const vmSummary = (
+      el.shadowRoot?.querySelector('.wizard-summary')?.textContent || ''
+    ).replace(/\s+/g, ' ');
+    expect(vmSummary).to.contain('Standard (2 vCPU, 4GB RAM)');
+    expect(vmSummary).to.contain('VNC');
+  });
+
+  it('renders the provisioning log from theme tokens and finishes with one action', async () => {
+    const el = await mount({ hideBack: true });
+    (el as any).isBooting = true;
+    (el as any).bootLogs = [
+      '[ssh] Connecting to target host...',
+      'SUCCESS: Persistent governed agent node successfully activated via SSH!',
+    ];
+    el.requestUpdate();
+    await el.updateComplete;
+
+    const log = el.shadowRoot?.querySelector('.boot-log') as HTMLElement;
+    expect(log, 'log block').to.exist;
+    expect(log.getAttribute('role')).to.equal('log');
+    expect(log.querySelectorAll('.boot-log-line').length).to.equal(2);
+    expect(log.querySelectorAll('.boot-log-line.success').length).to.equal(1);
+    // No inline colour literals survive on the log or its lines.
+    expect(log.getAttribute('style')).to.equal(null);
+
+    let done = false;
+    el.addEventListener('deploy-wizard-done', () => (done = true));
+    const finish = el.shadowRoot?.querySelector(
+      '.wizard-actions sl-button[variant="primary"]'
+    ) as HTMLElement;
+    expect(finish.textContent?.trim()).to.equal('View the connected agent');
+    finish.click();
+    await el.updateComplete;
+    expect(done).to.equal(true);
+  });
+
+  it('does not overflow horizontally at 390px on any step', async () => {
+    const steps = [
+      'agent-host',
+      'existing-host-method',
+      'cli-install',
+      'ssh-config',
+      'fresh-vm-premium',
+    ];
+    for (const step of steps) {
+      const el = await mount({ hideBack: true, width: PHONE_WIDTH });
+      await goTo(el, step);
+      const shell = el.shadowRoot?.querySelector(
+        '.wizard-shell'
+      ) as HTMLElement;
+      expect(shell.scrollWidth, `${step}: shell`).to.be.at.most(
+        PHONE_WIDTH + 1
+      );
+      const right = el.getBoundingClientRect().right;
+      Array.from(el.shadowRoot?.querySelectorAll('*') || []).forEach((node) => {
+        const rect = (node as HTMLElement).getBoundingClientRect();
+        if (rect.width === 0) {
+          return;
+        }
+        expect(
+          Math.round(rect.right),
+          `${step}: ${(node as HTMLElement).className || node.tagName}`
+        ).to.be.at.most(Math.round(right) + 1);
+      });
+      Array.from(
+        el.shadowRoot?.querySelectorAll('.command-code') || []
+      ).forEach((code) => {
+        const box = code as HTMLElement;
+        expect(box.scrollWidth, `${step}: command block`).to.be.at.most(
+          box.clientWidth + 1
+        );
+      });
+    }
+  });
+});

--- a/frontend/src/components/preloop-agent-deployer.ts
+++ b/frontend/src/components/preloop-agent-deployer.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, css, nothing, unsafeCSS } from 'lit';
+import type { TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -13,197 +14,79 @@ import {
 } from '../utils/ai-model-selection';
 import './add-ai-model-modal';
 import { consoleDialogStyles } from '../styles/console-dialog';
+import consoleStyles from '../styles/console-styles.css?inline';
+import { deployWizardStyles } from '../styles/deploy-wizard';
 
 @customElement('preloop-agent-deployer')
 export class PreloopAgentDeployer extends LitElement {
   static styles = [
+    unsafeCSS(consoleStyles),
     consoleDialogStyles,
+    deployWizardStyles,
     css`
-      :host {
-        display: block;
-        width: 100%;
-      }
-
-      .deploy-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: var(--sl-spacing-large);
-      }
-
-      .inner-deploy-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-        gap: var(--sl-spacing-medium);
-      }
-
-      @media (max-width: 768px) {
-        .deploy-grid,
-        .inner-deploy-grid {
-          grid-template-columns: 1fr;
-        }
-      }
-
-      .wizard-shell {
-        width: 100%;
-        max-width: 920px;
-        margin: 0 auto;
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-large);
-        color: var(--sl-color-neutral-800);
-      }
-
-      .wizard-header {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-2x-small);
-      }
-
-      .wizard-title {
-        color: var(--sl-color-neutral-900);
-        font-size: var(--sl-font-size-large);
-        font-weight: var(--sl-font-weight-semibold);
-        line-height: 1.25;
-        margin: 0;
-      }
-
-      .wizard-copy {
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-medium);
-        line-height: 1.55;
-        margin: 0;
-      }
-
-      .wizard-card-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: var(--sl-spacing-large);
-        width: 100%;
-      }
-
-      .wizard-option-button {
-        display: block;
-        width: 100%;
-        height: 100%;
-      }
-
-      .wizard-option-button::part(base) {
-        width: 100%;
-        height: auto;
-        min-height: 132px;
-        padding: var(--sl-spacing-large);
-        justify-content: flex-start;
-        text-align: left;
-        align-items: center;
-        text-wrap: wrap;
-      }
-
-      .wizard-option-body {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--sl-spacing-medium);
-      }
-
-      .wizard-option-icon {
-        width: 44px;
-        height: 44px;
-        border-radius: var(--sl-border-radius-large);
-        color: var(--sl-color-primary-600);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        flex: 0 0 auto;
-      }
-
-      .wizard-option-icon sl-icon {
-        font-size: 1.35rem;
-      }
-
-      .wizard-option-copy {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-2x-small);
-        min-width: 0;
-      }
-
-      .wizard-option-title {
-        color: var(--sl-color-neutral-900);
-        font-size: var(--sl-font-size-medium);
-        font-weight: var(--sl-font-weight-semibold);
-        line-height: 1.3;
-      }
-
-      .wizard-option-description {
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
-        line-height: 1.45;
-      }
-
-      .wizard-panel {
-        width: 100%;
-        border: 1px solid var(--sl-color-neutral-200);
-        border-radius: var(--sl-border-radius-large);
-        background: var(--sl-color-neutral-0);
-        box-shadow: var(--sl-shadow-small);
-        padding: var(--sl-spacing-large);
-        box-sizing: border-box;
-      }
-
-      .wizard-back {
-        align-self: flex-start;
-        margin-left: calc(-1 * var(--sl-spacing-small));
-      }
-
-      .wizard-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--sl-spacing-medium);
-        margin-top: var(--sl-spacing-large);
-      }
-
-      .command-steps {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-large);
-      }
-
-      .command-step {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-2x-small);
-      }
-
-      .command-label {
-        color: var(--sl-color-neutral-800);
-        font-weight: var(--sl-font-weight-semibold);
-      }
-
-      .command-row {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-small);
-      }
-
-      .command-code {
-        flex: 1;
-        min-width: 0;
-        background: var(--sl-color-neutral-100);
-        border: 1px solid var(--sl-color-neutral-200);
+      /* The provisioning log is the one dark-on-light block in the flow: a
+         stream of machine output the operator reads, not a surface of the
+         console. It takes the page tone (the same exception the design makes
+         for a copyable command block) instead of the hard-coded slate and
+         cyan hexes this used to inline, so it follows the theme. */
+      .boot-log {
+        background: var(--console-page);
         border-radius: var(--sl-border-radius-medium);
-        color: var(--sl-color-neutral-800);
+        box-sizing: border-box;
+        color: var(--sl-color-neutral-700);
         font-family: var(--sl-font-mono);
-        font-size: var(--sl-font-size-small);
-        padding: var(--sl-spacing-small) var(--sl-spacing-medium);
-        overflow-x: auto;
-        white-space: nowrap;
+        font-size: var(--console-text-meta);
+        line-height: 1.5;
+        max-height: 17rem;
+        overflow-wrap: anywhere;
+        overflow-y: auto;
+        padding: var(--sl-spacing-medium);
+        width: 100%;
       }
 
-      @media (max-width: 640px) {
-        .wizard-option-body,
-        .command-row {
-          flex-direction: column;
-          align-items: stretch;
-        }
+      .boot-log-line.success {
+        color: var(--sl-color-success-700);
+        font-weight: 600;
+      }
+
+      .boot-title {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-x-small);
+      }
+
+      .boot-title sl-spinner {
+        font-size: 0.875rem;
+      }
+
+      .dialog-copy {
+        color: var(--sl-color-neutral-700);
+        font-size: var(--console-text-body);
+        line-height: 1.5;
+        margin: 0 0 var(--sl-spacing-small);
+      }
+
+      .dialog-copy:last-child {
+        margin-bottom: 0;
+      }
+
+      .promo {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+        text-align: center;
+      }
+
+      .promo sl-icon {
+        color: var(--sl-color-primary-600);
+        font-size: 1.75rem;
+      }
+
+      .promo-title {
+        font-size: var(--console-text-card-title);
+        font-weight: 600;
+        margin: 0;
       }
     `,
   ];
@@ -222,6 +105,14 @@ export class PreloopAgentDeployer extends LitElement {
 
   @property({ type: Boolean, attribute: 'hide-back-button' })
   hideBackButton = false;
+
+  /**
+   * Steps the host already walked before this component took over the screen,
+   * so "Step 3 of 3" keeps counting from where the deploy wizard left off.
+   * Zero when the deployer is opened on its own (the agents-view dialog).
+   */
+  @property({ type: Number, attribute: 'step-offset' })
+  stepOffset = 0;
 
   @state()
   private deploySubStep:
@@ -484,6 +375,174 @@ export class PreloopAgentDeployer extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * Where this screen sits, counting from the step the host handed over on.
+   * `total` is null on a screen that branches, because the path length is not
+   * decided yet.
+   */
+  private stepPosition(): { index: number; total: number | null } {
+    const base = this.stepOffset;
+    switch (this.deploySubStep) {
+      case 'agent-host':
+        return { index: base + 1, total: null };
+      case 'existing-host-method':
+        return { index: base + 2, total: null };
+      case 'fresh-vm-premium':
+        return { index: base + 2, total: base + 2 };
+      default:
+        return { index: base + 3, total: base + 3 };
+    }
+  }
+
+  private renderStepHeader(title: string, copy?: string) {
+    const { index, total } = this.stepPosition();
+    return html`
+      <div class="wizard-header">
+        <div class="wizard-step-count">
+          <span
+            >${total === null ? `Step ${index}` : `Step ${index} of ${total}`}</span
+          >
+          ${
+            total === null
+              ? nothing
+              : html`
+                  <span class="wizard-step-rail" aria-hidden="true">
+                    ${Array.from(
+                      { length: total },
+                      (_unused, i) =>
+                        html`<span class=${i < index ? 'done' : ''}></span>`
+                    )}
+                  </span>
+                `
+          }
+        </div>
+        <h3 class="wizard-title">${title}</h3>
+        ${copy ? html`<p class="wizard-copy">${copy}</p>` : nothing}
+      </div>
+    `;
+  }
+
+  /**
+   * One action bar per step: Back as a text button on the left, the single
+   * primary action on the right.
+   */
+  private renderActions(showBack: boolean, primary: unknown = nothing) {
+    if (!showBack && primary === nothing) {
+      return nothing;
+    }
+    return html`
+      <div class="wizard-actions">
+        ${
+          showBack
+            ? html`
+                <sl-button
+                  class="wizard-back"
+                  variant="text"
+                  size="small"
+                  @click=${this.handleBack}
+                >
+                  <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
+                </sl-button>
+              `
+            : nothing
+        }
+        ${primary}
+      </div>
+    `;
+  }
+
+  private renderOptionCard(
+    icon: string,
+    title: string,
+    description: string,
+    onClick: () => void
+  ): TemplateResult {
+    return html`
+      <button type="button" class="wizard-option-button" @click=${onClick}>
+        <sl-icon class="wizard-option-icon" name=${icon}></sl-icon>
+        <span class="wizard-option-copy">
+          <span class="wizard-option-title">${title}</span>
+          <span class="wizard-option-description">${description}</span>
+        </span>
+        <sl-icon class="wizard-option-arrow" name="chevron-right"></sl-icon>
+      </button>
+    `;
+  }
+
+  private renderCommandStep(
+    label: string,
+    command: string,
+    index?: number
+  ): TemplateResult {
+    return html`
+      <div class="command-step">
+        <div class="command-label">
+          ${index ? html`<span class="command-index">${index}</span>` : nothing}
+          <span>${label}</span>
+        </div>
+        <div class="command-row">
+          <code class="command-code">${command}</code>
+          <sl-copy-button .value=${command}></sl-copy-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSummaryRow(key: string, value: string) {
+    return html`
+      <div class="wizard-summary-row">
+        <span class="wizard-summary-key">${key}</span>
+        <span class="wizard-summary-value">${value}</span>
+      </div>
+    `;
+  }
+
+  private selectedModelName(): string {
+    const model = this.aiModels.find((m) => m.id === this.deployModel);
+    return model?.name || 'Not set';
+  }
+
+  private renderModelField() {
+    return html`
+      <div class="wizard-field">
+        <sl-select
+          label="AI model"
+          value=${this.deployModel}
+          @sl-change=${(e: any) => (this.deployModel = e.target.value)}
+        >
+          ${this.aiModels
+            .filter((m) => m.model_kind !== 'stt' && m.model_kind !== 'tts')
+            .map((m) => html`<sl-option .value=${m.id}>${m.name}</sl-option>`)}
+        </sl-select>
+        <sl-button
+          class="field-link"
+          size="small"
+          variant="text"
+          @click=${() => (this.isAddingAIModel = true)}
+        >
+          <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add an AI model
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderRuntimeField() {
+    return html`
+      <sl-select
+        label="Agent runtime"
+        value=${this.deployAgentType}
+        help-text="Hermes is the Preloop runtime; OpenClaw is the open source alternative."
+        @sl-change=${(e: any) => {
+          this.deployAgentType = e.target.value;
+          this.requestUpdate();
+        }}
+      >
+        <sl-option value="hermes">Hermes</sl-option>
+        <sl-option value="openclaw">OpenClaw</sl-option>
+      </sl-select>
+    `;
+  }
+
   render() {
     if (this.isBooting) {
       return this.renderSimulatedBoot();
@@ -493,545 +552,34 @@ export class PreloopAgentDeployer extends LitElement {
       <div style="width: 100%;">
         <div class="wizard-shell">
           ${
-            !this.hideBackButton
-              ? html`
-                  <sl-button
-                    class="wizard-back"
-                    variant="text"
-                    size="small"
-                    @click=${this.handleBack}
-                  >
-                    <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
-                  </sl-button>
-                `
-              : nothing
-          }
-          ${
             this.deploySubStep === 'agent-host'
-              ? html`
-                  <div class="wizard-header">
-                    <h3 class="wizard-title">Choose Agent Hosting Target</h3>
-                    <p class="wizard-copy">
-                      Where would you like to host this persistent agent?
-                    </p>
-                  </div>
-
-                  <div class="wizard-card-grid">
-                    <sl-button
-                      class="wizard-option-button"
-                      variant="default"
-                      @click=${() => {
-                        this.deploySubStep = 'existing-host-method';
-                        this.requestUpdate();
-                      }}
-                    >
-                      <div class="wizard-option-body">
-                        <span class="wizard-option-icon">
-                          <sl-icon name="hdd-network"></sl-icon>
-                        </span>
-                        <span class="wizard-option-copy">
-                          <span class="wizard-option-title">
-                            Deploy on Existing Host
-                          </span>
-                          <span class="wizard-option-description">
-                            Install a Hermes or OpenClaw agent on a machine you
-                            control using SSH or the Preloop CLI.
-                          </span>
-                        </span>
-                      </div>
-                    </sl-button>
-
-                    ${
-                      this.isEnterprise
-                        ? html`
-                            <sl-button
-                              class="wizard-option-button"
-                              variant="default"
-                              @click=${this.handleFreshVmSelection}
-                            >
-                              <div class="wizard-option-body">
-                                <span class="wizard-option-icon">
-                                  <sl-icon name="cpu"></sl-icon>
-                                </span>
-                                <span class="wizard-option-copy">
-                                  <span class="wizard-option-title">
-                                    Deploy on Fresh VM (Cloud)
-                                  </span>
-                                  <span class="wizard-option-description">
-                                    Provision a brand new isolated VM instance
-                                    managed by Preloop compute backends.
-                                  </span>
-                                </span>
-                              </div>
-                            </sl-button>
-                          `
-                        : nothing
-                    }
-                  </div>
-                `
-              : nothing
-          }
-          ${
-            this.deploySubStep === 'existing-host-method'
-              ? html`
-                  <div class="wizard-header">
-                    <h3 class="wizard-title">Deploy on Existing Host</h3>
-                    <p class="wizard-copy">
-                      Choose how Preloop should reach the host where the agent
-                      will run.
-                    </p>
-                  </div>
-
-                  <div class="wizard-card-grid">
-                    <sl-button
-                      class="wizard-option-button"
-                      variant="default"
-                      @click=${() => {
-                        this.deploySubStep = 'ssh-config';
-                        this.requestUpdate();
-                      }}
-                    >
-                      <div class="wizard-option-body">
-                        <span class="wizard-option-icon">
-                          <sl-icon name="key"></sl-icon>
-                        </span>
-                        <span class="wizard-option-copy">
-                          <span class="wizard-option-title">SSH Access</span>
-                          <span class="wizard-option-description">
-                            Preloop connects to the host over SSH and deploys
-                            the agent. Requires a public IP or routable address
-                            from your Preloop instance.
-                          </span>
-                        </span>
-                      </div>
-                    </sl-button>
-
-                    <sl-button
-                      class="wizard-option-button"
-                      variant="default"
-                      @click=${() => {
-                        this.deploySubStep = 'cli-install';
-                        this.requestUpdate();
-                      }}
-                    >
-                      <div class="wizard-option-body">
-                        <span class="wizard-option-icon">
-                          <sl-icon name="terminal"></sl-icon>
-                        </span>
-                        <span class="wizard-option-copy">
-                          <span class="wizard-option-title">
-                            Install with Preloop CLI
-                          </span>
-                          <span class="wizard-option-description">
-                            Run commands on the host to install Hermes or
-                            OpenClaw and onboard through Preloop. Works when the
-                            host only has outbound access to Preloop.
-                          </span>
-                        </span>
-                      </div>
-                    </sl-button>
-                  </div>
-                `
-              : nothing
-          }
-          ${
-            this.deploySubStep === 'cli-install'
-              ? html`
-                  <div class="wizard-header">
-                    <h3 class="wizard-title">
-                      Install Agent Runtime with Preloop CLI
-                    </h3>
-                    <p class="wizard-copy">
-                      Run these commands on the host where the agent should run.
-                      The agent connects outbound to Preloop, so inbound SSH
-                      access from Preloop is not required.
-                    </p>
-                  </div>
-
-                  <div class="wizard-panel">
-                    <sl-select
-                      label="Agent Runtime"
-                      value=${this.deployAgentType}
-                      @sl-change=${(e: any) => {
-                        this.deployAgentType = e.target.value;
-                        this.requestUpdate();
-                      }}
-                      style="margin-bottom: var(--sl-spacing-large);"
-                    >
-                      <sl-option value="hermes">Hermes</sl-option>
-                      <sl-option value="openclaw">OpenClaw</sl-option>
-                    </sl-select>
-
-                    <div class="command-steps">
-                      <div class="command-step">
-                        <div class="command-label">
-                          1. Install the Preloop CLI on the host
-                        </div>
-                        <div class="command-row">
-                          <code class="command-code"
-                            >${this.preloopCliInstallCommand()}</code
-                          >
-                          <sl-copy-button
-                            .value=${this.preloopCliInstallCommand()}
-                          ></sl-copy-button>
-                        </div>
-                      </div>
-
-                      <div class="command-step">
-                        <div class="command-label">2. Authenticate the CLI</div>
-                        <div class="command-row">
-                          <code class="command-code"
-                            >${this.preloopLoginCommand()}</code
-                          >
-                          <sl-copy-button
-                            .value=${this.preloopLoginCommand()}
-                          ></sl-copy-button>
-                        </div>
-                      </div>
-
-                      <div class="command-step">
-                        <div class="command-label">
-                          3. Install
-                          ${
-                            this.deployAgentType === 'hermes'
-                              ? 'Hermes'
-                              : 'OpenClaw'
-                          }
-                          and onboard through Preloop
-                        </div>
-                        <div class="command-row">
-                          <code class="command-code"
-                            >${this.runtimeInstallAndOnboardCommand(
-                              this.deployAgentType
-                            )}</code
-                          >
-                          <sl-copy-button
-                            .value=${this.runtimeInstallAndOnboardCommand(
-                              this.deployAgentType
-                            )}
-                          ></sl-copy-button>
-                        </div>
-                      </div>
-
-                      <div class="command-step">
-                        <div class="command-label">
-                          Or run the steps separately
-                        </div>
-                        <div class="command-row">
-                          <code class="command-code"
-                            >${this.runtimeInstallCommand(
-                              this.deployAgentType
-                            )}</code
-                          >
-                          <sl-copy-button
-                            .value=${this.runtimeInstallCommand(
-                              this.deployAgentType
-                            )}
-                          ></sl-copy-button>
-                        </div>
-                        <div class="command-row">
-                          <code class="command-code"
-                            >${this.runtimeOnboardCommand(
-                              this.deployAgentType
-                            )}</code
-                          >
-                          <sl-copy-button
-                            .value=${this.runtimeOnboardCommand(
-                              this.deployAgentType
-                            )}
-                          ></sl-copy-button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="wizard-actions">
-                    <sl-button
-                      variant="default"
-                      @click=${() =>
-                        (this.deploySubStep = 'existing-host-method')}
-                      >Back</sl-button
-                    >
-                  </div>
-                `
-              : nothing
-          }
-          ${
-            this.deploySubStep === 'ssh-config'
-              ? html`
-                  <div class="wizard-header">
-                    <h3 class="wizard-title">Deploy via SSH</h3>
-                    <p class="wizard-copy">
-                      Provide SSH credentials for the host where the agent
-                      should run. Preloop must be able to connect to this
-                      address.
-                    </p>
-                  </div>
-
-                  <div class="wizard-panel deploy-grid">
-                    <div
-                      style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium);"
-                    >
-                      <sl-input
-                        label="Host Address / IP"
-                        placeholder="e.g. 192.168.1.100"
-                        .value=${this.sshHost}
-                        @sl-input=${(e: any) => (this.sshHost = e.target.value)}
-                      ></sl-input>
-                      <sl-input
-                        label="SSH Username"
-                        placeholder="e.g. ubuntu"
-                        .value=${this.sshUsername}
-                        @sl-input=${(e: any) =>
-                          (this.sshUsername = e.target.value)}
-                      ></sl-input>
-                      <sl-input
-                        label="SSH Port"
-                        placeholder="22"
-                        .value=${this.sshPort}
-                        @sl-input=${(e: any) => (this.sshPort = e.target.value)}
-                      ></sl-input>
-                    </div>
-
-                    <div
-                      style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium);"
-                    >
-                      <div style="margin-bottom: var(--sl-spacing-small);">
-                        <label
-                          style="display: block; margin-bottom: 0.5rem; font-weight: 500; font-size: 0.875rem;"
-                          >Authentication Method</label
-                        >
-                        <sl-radio-group
-                          value=${this.sshAuthType}
-                          @sl-change=${(e: any) => {
-                            this.sshAuthType = e.target.value;
-                            this.requestUpdate();
-                          }}
-                          style="display: flex; gap: var(--sl-spacing-medium);"
-                        >
-                          <sl-radio value="password">Password</sl-radio>
-                          <sl-radio value="key">Private Key</sl-radio>
-                        </sl-radio-group>
-                      </div>
-
-                      ${
-                        this.sshAuthType === 'password'
-                          ? html`
-                              <sl-input
-                                type="password"
-                                label="SSH Password"
-                                placeholder="Enter SSH password"
-                                password-toggle
-                                .value=${this.sshPassword}
-                                @sl-input=${(e: any) =>
-                                  (this.sshPassword = e.target.value)}
-                              ></sl-input>
-                            `
-                          : html`
-                              <sl-textarea
-                                label="SSH Private Key"
-                                placeholder="Paste your SSH Private Key here..."
-                                rows="4"
-                                .value=${this.sshPrivateKey}
-                                @sl-input=${(e: any) =>
-                                  (this.sshPrivateKey = e.target.value)}
-                              ></sl-textarea>
-                            `
-                      }
-
-                      <div class="inner-deploy-grid">
-                        <sl-select
-                          label="Agent Runtime Kind"
-                          value=${this.deployAgentType}
-                          @sl-change=${(e: any) =>
-                            (this.deployAgentType = e.target.value)}
-                        >
-                          <sl-option value="hermes">Hermes</sl-option>
-                          <sl-option value="openclaw">OpenClaw</sl-option>
-                        </sl-select>
-
-                        <div
-                          style="display: flex; flex-direction: column; gap: var(--sl-spacing-2x-small);"
-                        >
-                          <sl-select
-                            label="AI Model"
-                            value=${this.deployModel}
-                            @sl-change=${(e: any) =>
-                              (this.deployModel = e.target.value)}
-                            style="margin-bottom: 0; width: 100%;"
-                          >
-                            ${this.aiModels
-                              .filter(
-                                (m) =>
-                                  m.model_kind !== 'stt' &&
-                                  m.model_kind !== 'tts'
-                              )
-                              .map(
-                                (m) =>
-                                  html`<sl-option .value=${m.id}
-                                    >${m.name}</sl-option
-                                  >`
-                              )}
-                          </sl-select>
-                          <sl-button
-                            size="small"
-                            variant="text"
-                            @click=${() => (this.isAddingAIModel = true)}
-                            style="align-self: flex-start; margin-top: -0.25rem; height: auto; padding: 0;"
-                          >
-                            <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add
-                            New AI Model
-                          </sl-button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="wizard-actions">
-                    <sl-button
-                      variant="default"
-                      @click=${() =>
-                        (this.deploySubStep = 'existing-host-method')}
-                      >Back</sl-button
-                    >
-                    <sl-button
-                      variant="primary"
-                      ?disabled=${
-                        !this.sshHost ||
-                        !this.sshUsername ||
-                        (this.sshAuthType === 'password'
-                          ? !this.sshPassword
-                          : !this.sshPrivateKey)
-                      }
-                      @click=${this.startSshDeployBootSequence}
-                      >Deploy Agent</sl-button
-                    >
-                  </div>
-                `
-              : nothing
-          }
-          ${
-            this.deploySubStep === 'fresh-vm-premium'
-              ? html`
-                  <div class="wizard-header">
-                    <h3 class="wizard-title">
-                      Provision Secure Cloud Agent VM
-                    </h3>
-                  </div>
-
-                  <div class="wizard-panel deploy-grid">
-                    <div
-                      style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium);"
-                    >
-                      <sl-select
-                        label="Agent Runtime Kind"
-                        value=${this.deployAgentType}
-                        @sl-change=${(e: any) =>
-                          (this.deployAgentType = e.target.value)}
-                      >
-                        <sl-option value="hermes">Hermes</sl-option>
-                        <sl-option value="openclaw">OpenClaw</sl-option>
-                      </sl-select>
-
-                      <sl-select
-                        label="Compute Sandbox Size"
-                        value=${this.deployComputeSize}
-                        @sl-change=${(e: any) =>
-                          (this.deployComputeSize = e.target.value)}
-                      >
-                        <sl-option value="standard"
-                          >Standard (2 vCPU, 4GB RAM)</sl-option
-                        >
-                        <sl-option value="performance"
-                          >Performance (4 vCPU, 8GB RAM)</sl-option
-                        >
-                        <sl-option value="high-mem"
-                          >High Memory (8 vCPU, 16GB RAM)</sl-option
-                        >
-                      </sl-select>
-                    </div>
-
-                    <div
-                      style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium);"
-                    >
-                      <sl-select
-                        label="AI Model"
-                        value=${this.deployModel}
-                        @sl-change=${(e: any) =>
-                          (this.deployModel = e.target.value)}
-                      >
-                        ${this.aiModels
-                          .filter(
-                            (m) =>
-                              m.model_kind !== 'stt' && m.model_kind !== 'tts'
-                          )
-                          .map(
-                            (m) =>
-                              html`<sl-option .value=${m.id}
-                                >${m.name}</sl-option
-                              >`
-                          )}
-                      </sl-select>
-
-                      <div style="margin-top: var(--sl-spacing-medium);">
-                        <sl-checkbox
-                          ?checked=${this.deployEnableVnc}
-                          @sl-change=${(e: any) =>
-                            (this.deployEnableVnc = e.target.checked)}
-                        >
-                          Enable VNC Graphical Desktop access
-                        </sl-checkbox>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="wizard-actions">
-                    <sl-button
-                      variant="default"
-                      @click=${() => (this.deploySubStep = 'agent-host')}
-                      >Back</sl-button
-                    >
-                    <sl-button
-                      variant="primary"
-                      @click=${this.startDeployBootSequence}
-                      >Provision VM Agent Node</sl-button
-                    >
-                  </div>
-                `
-              : nothing
+              ? this.renderAgentHostStep()
+              : this.deploySubStep === 'existing-host-method'
+                ? this.renderHostMethodStep()
+                : this.deploySubStep === 'cli-install'
+                  ? this.renderCliInstallStep()
+                  : this.deploySubStep === 'ssh-config'
+                    ? this.renderSshConfigStep()
+                    : this.renderFreshVmStep()
           }
         </div>
 
         <!-- Compute Backends Support Dialogs -->
         <sl-dialog
-          label="Setup Compute Backend"
+          label="Set up a compute backend"
           ?open=${this.showComputeSetupHelp}
           @sl-after-hide=${() => (this.showComputeSetupHelp = false)}
         >
-          <div
-            style="font-size: 0.9rem; line-height: 1.5; color: var(--sl-color-neutral-700);"
-          >
-            <p>
-              <strong
-                >AWS, GCP, or KubeVirt VM compute backends are not
-                configured.</strong
-              >
-            </p>
-            <p>
-              To enable direct agent deployments to VMs in KubeVirt or Cloud
-              providers, please set the compute configurations on your server
-              environment variables or in the organization configurations.
-            </p>
-            <p>
-              Refer to the
-              <a
-                href="file:///Users/dimo/git/spacecode/preloop-ee/README.md#🖥️-configuring-compute-backends-aws-gcp-kubevirt"
-                style="color: var(--sl-color-primary-600); font-weight: 600;"
-                >README.md instructions</a
-              >
-              for details.
-            </p>
-          </div>
+          <p class="dialog-copy">
+            <strong>
+              No AWS, GCP or KubeVirt compute backend is configured.
+            </strong>
+          </p>
+          <p class="dialog-copy">
+            To deploy agents onto VMs, set the compute configuration in your
+            server environment variables or in the organization configuration,
+            then reopen this step.
+          </p>
           <sl-button
             slot="footer"
             variant="primary"
@@ -1041,19 +589,14 @@ export class PreloopAgentDeployer extends LitElement {
         </sl-dialog>
 
         <sl-dialog
-          label="Provision VM Notice"
+          label="Provision VM notice"
           ?open=${this.showComputeAdminNotice}
           @sl-after-hide=${() => (this.showComputeAdminNotice = false)}
         >
-          <div
-            style="font-size: 0.9rem; line-height: 1.5; color: var(--sl-color-neutral-700);"
-          >
-            <p>
-              Compute backends are not configured for this account. Please ask
-              an Administrator to configure direct VM compute backends in
-              settings.
-            </p>
-          </div>
+          <p class="dialog-copy">
+            Compute backends are not configured for this account. Ask an
+            administrator to configure a VM compute backend in settings.
+          </p>
           <sl-button
             slot="footer"
             variant="primary"
@@ -1063,33 +606,26 @@ export class PreloopAgentDeployer extends LitElement {
         </sl-dialog>
 
         <sl-dialog
-          label="Unlock Cloud VM Provisioning"
+          label="Unlock cloud VM provisioning"
           ?open=${this.showComputePromo}
           @sl-after-hide=${() => (this.showComputePromo = false)}
         >
-          <div style="text-align: center; padding: var(--sl-spacing-medium);">
-            <sl-icon
-              name="cpu"
-              style="font-size: 3rem; color: var(--sl-color-primary-500); margin-bottom: var(--sl-spacing-medium);"
-            ></sl-icon>
-            <h3 style="margin: 0 0 var(--sl-spacing-small) 0;">
-              Cloud VM Compute Backends
-            </h3>
-            <p
-              style="font-size: 0.9rem; color: var(--sl-color-neutral-600); line-height: 1.5; margin-bottom: var(--sl-spacing-large);"
-            >
+          <div class="promo">
+            <sl-icon name="cpu"></sl-icon>
+            <h3 class="promo-title">Cloud VM compute backends</h3>
+            <p class="dialog-copy">
               Provisioning secure virtual machines in the cloud is an Enterprise
-              Edition feature. Connect with our team to upgrade your workspace.
+              Edition feature. Talk to our team to upgrade your workspace.
             </p>
-            <sl-button
-              variant="primary"
-              href="mailto:sales@preloop.ai?subject=Preloop%20Enterprise%20Compute%20Backend"
-              target="_blank"
-              style="width: 100%;"
-            >
-              Contact Sales
-            </sl-button>
           </div>
+          <sl-button
+            slot="footer"
+            variant="primary"
+            href="mailto:sales@preloop.ai?subject=Preloop%20Enterprise%20Compute%20Backend"
+            target="_blank"
+          >
+            Contact sales
+          </sl-button>
         </sl-dialog>
 
         <add-ai-model-modal
@@ -1103,68 +639,349 @@ export class PreloopAgentDeployer extends LitElement {
     `;
   }
 
-  private renderSimulatedBoot() {
+  private renderAgentHostStep() {
     return html`
-      <div style="width: 100%;">
-        <h3
-          style="font-size: var(--sl-font-size-large); font-weight: 600; color: var(--sl-color-neutral-800); margin: 0 0 var(--sl-spacing-medium) 0; display: flex; align-items: center; gap: 8px;"
-        >
-          <sl-spinner style="font-size: 1rem;"></sl-spinner>
-          Deploying Secure Agent Node Environment...
-        </h3>
+      ${this.renderStepHeader(
+        'Choose where the agent runs',
+        'Preloop installs and governs the agent on the host you pick.'
+      )}
 
-        <div
-          style="
-            background: #0f172a;
-            border-radius: var(--sl-border-radius-medium);
-            padding: var(--sl-spacing-large);
-            height: 280px;
-            overflow-y: auto;
-            font-family: var(--sl-font-mono);
-            font-size: 0.85rem;
-            color: #38bdf8;
-            box-shadow: inset 0 2px 8px rgba(0,0,0,0.8);
-          "
+      <div class="wizard-card-grid">
+        ${this.renderOptionCard(
+          'hdd-network',
+          'Deploy on an existing host',
+          'Install a Hermes or OpenClaw agent on a machine you control, over SSH or with the Preloop CLI.',
+          () => {
+            this.deploySubStep = 'existing-host-method';
+            this.requestUpdate();
+          }
+        )}
+        ${
+          this.isEnterprise
+            ? this.renderOptionCard(
+                'cpu',
+                'Deploy on a fresh cloud VM',
+                'Provision a new isolated VM managed by a Preloop compute backend.',
+                () => this.handleFreshVmSelection()
+              )
+            : nothing
+        }
+      </div>
+
+      ${this.renderActions(!this.hideBackButton)}
+    `;
+  }
+
+  private renderHostMethodStep() {
+    return html`
+      ${this.renderStepHeader(
+        'Deploy on an existing host',
+        'Choose how Preloop reaches the host where the agent will run.'
+      )}
+
+      <div class="wizard-card-grid">
+        ${this.renderOptionCard(
+          'key',
+          'SSH access',
+          'Preloop connects to the host over SSH and deploys the agent. Needs an address your Preloop instance can reach.',
+          () => {
+            this.deploySubStep = 'ssh-config';
+            this.requestUpdate();
+          }
+        )}
+        ${this.renderOptionCard(
+          'terminal',
+          'Install with the Preloop CLI',
+          'Run three commands on the host. Works when the host only has outbound access to Preloop.',
+          () => {
+            this.deploySubStep = 'cli-install';
+            this.requestUpdate();
+          }
+        )}
+      </div>
+
+      ${this.renderActions(true)}
+    `;
+  }
+
+  private renderCliInstallStep() {
+    const runtimeLabel =
+      this.deployAgentType === 'hermes' ? 'Hermes' : 'OpenClaw';
+    return html`
+      ${this.renderStepHeader(
+        'Install the runtime with the Preloop CLI',
+        'Run these commands on the host. The agent connects outbound to Preloop, so inbound SSH access is not required.'
+      )}
+
+      <div class="wizard-form">${this.renderRuntimeField()}</div>
+
+      <div class="command-steps">
+        ${this.renderCommandStep(
+          'Install the Preloop CLI on the host',
+          this.preloopCliInstallCommand(),
+          1
+        )}
+        ${this.renderCommandStep(
+          'Authenticate the CLI',
+          this.preloopLoginCommand(),
+          2
+        )}
+        ${this.renderCommandStep(
+          `Install ${runtimeLabel} and onboard it through Preloop`,
+          this.runtimeInstallAndOnboardCommand(this.deployAgentType),
+          3
+        )}
+
+        <div class="command-step">
+          <div class="command-label">
+            <span>Or run the steps separately</span>
+          </div>
+          <div class="command-row">
+            <code class="command-code"
+              >${this.runtimeInstallCommand(this.deployAgentType)}</code
+            >
+            <sl-copy-button
+              .value=${this.runtimeInstallCommand(this.deployAgentType)}
+            ></sl-copy-button>
+          </div>
+          <div class="command-row">
+            <code class="command-code"
+              >${this.runtimeOnboardCommand(this.deployAgentType)}</code
+            >
+            <sl-copy-button
+              .value=${this.runtimeOnboardCommand(this.deployAgentType)}
+            ></sl-copy-button>
+          </div>
+        </div>
+      </div>
+
+      ${this.renderActions(true)}
+    `;
+  }
+
+  private renderSshConfigStep() {
+    const canDeploy =
+      Boolean(this.sshHost) &&
+      Boolean(this.sshUsername) &&
+      (this.sshAuthType === 'password'
+        ? Boolean(this.sshPassword)
+        : Boolean(this.sshPrivateKey));
+
+    return html`
+      ${this.renderStepHeader(
+        'Deploy over SSH',
+        'Preloop connects to this host and installs the governed agent on it.'
+      )}
+
+      <div class="wizard-form">
+        <sl-input
+          label="Host address"
+          help-text="The address or IP your Preloop instance can reach, for example 192.168.1.100."
+          .value=${this.sshHost}
+          @sl-input=${(e: any) => (this.sshHost = e.target.value)}
+        ></sl-input>
+
+        <sl-input
+          label="SSH username"
+          help-text="The account Preloop logs in as, for example ubuntu."
+          .value=${this.sshUsername}
+          @sl-input=${(e: any) => (this.sshUsername = e.target.value)}
+        ></sl-input>
+
+        <sl-input
+          label="SSH port"
+          help-text="Defaults to 22."
+          .value=${this.sshPort}
+          @sl-input=${(e: any) => (this.sshPort = e.target.value)}
+        ></sl-input>
+
+        <sl-radio-group
+          label="Authentication"
+          value=${this.sshAuthType}
+          @sl-change=${(e: any) => {
+            this.sshAuthType = e.target.value;
+            this.requestUpdate();
+          }}
         >
+          <sl-radio value="password">Password</sl-radio>
+          <sl-radio value="key">Private key</sl-radio>
+        </sl-radio-group>
+
+        ${
+          this.sshAuthType === 'password'
+            ? html`
+                <sl-input
+                  type="password"
+                  label="SSH password"
+                  help-text="Used for this deployment only; Preloop does not store it."
+                  password-toggle
+                  .value=${this.sshPassword}
+                  @sl-input=${(e: any) => (this.sshPassword = e.target.value)}
+                ></sl-input>
+              `
+            : html`
+                <sl-textarea
+                  label="SSH private key"
+                  help-text="Paste the private key Preloop should use for this host."
+                  rows="4"
+                  .value=${this.sshPrivateKey}
+                  @sl-input=${(e: any) => (this.sshPrivateKey = e.target.value)}
+                ></sl-textarea>
+              `
+        }
+        ${this.renderRuntimeField()} ${this.renderModelField()}
+
+        <div class="wizard-summary">
+          <div class="wizard-summary-title">About to deploy</div>
+          ${this.renderSummaryRow(
+            'Runtime',
+            this.deployAgentType === 'hermes' ? 'Hermes' : 'OpenClaw'
+          )}
+          ${this.renderSummaryRow(
+            'Host',
+            `${this.sshUsername || 'user'}@${this.sshHost || 'host'}:${
+              this.sshPort || '22'
+            }`
+          )}
+          ${this.renderSummaryRow('Model', this.selectedModelName())}
+          ${this.renderSummaryRow(
+            'Authentication',
+            this.sshAuthType === 'password' ? 'Password' : 'Private key'
+          )}
+        </div>
+      </div>
+
+      ${this.renderActions(
+        true,
+        html`
+          <sl-button
+            variant="primary"
+            ?disabled=${!canDeploy}
+            @click=${this.startSshDeployBootSequence}
+            >Deploy agent</sl-button
+          >
+        `
+      )}
+    `;
+  }
+
+  private renderFreshVmStep() {
+    const sizeLabels: Record<string, string> = {
+      standard: 'Standard (2 vCPU, 4GB RAM)',
+      performance: 'Performance (4 vCPU, 8GB RAM)',
+      'high-mem': 'High memory (8 vCPU, 16GB RAM)',
+    };
+    return html`
+      ${this.renderStepHeader(
+        'Provision a secure cloud agent VM',
+        'Preloop creates the VM, installs the runtime and enrolls the agent for you.'
+      )}
+
+      <div class="wizard-form">
+        ${this.renderRuntimeField()}
+
+        <sl-select
+          label="Compute sandbox size"
+          value=${this.deployComputeSize}
+          help-text="Sizes the sandbox the agent runs in. You can change it later."
+          @sl-change=${(e: any) => (this.deployComputeSize = e.target.value)}
+        >
+          <sl-option value="standard">Standard (2 vCPU, 4GB RAM)</sl-option>
+          <sl-option value="performance"
+            >Performance (4 vCPU, 8GB RAM)</sl-option
+          >
+          <sl-option value="high-mem">High memory (8 vCPU, 16GB RAM)</sl-option>
+        </sl-select>
+
+        ${this.renderModelField()}
+
+        <sl-checkbox
+          ?checked=${this.deployEnableVnc}
+          @sl-change=${(e: any) => (this.deployEnableVnc = e.target.checked)}
+        >
+          Enable VNC graphical desktop access
+        </sl-checkbox>
+
+        <div class="wizard-summary">
+          <div class="wizard-summary-title">About to provision</div>
+          ${this.renderSummaryRow(
+            'Runtime',
+            this.deployAgentType === 'hermes' ? 'Hermes' : 'OpenClaw'
+          )}
+          ${this.renderSummaryRow(
+            'Size',
+            sizeLabels[this.deployComputeSize] || this.deployComputeSize
+          )}
+          ${this.renderSummaryRow('Model', this.selectedModelName())}
+          ${this.renderSummaryRow('VNC', this.deployEnableVnc ? 'On' : 'Off')}
+        </div>
+      </div>
+
+      ${this.renderActions(
+        true,
+        html`
+          <sl-button variant="primary" @click=${this.startDeployBootSequence}
+            >Provision VM agent node</sl-button
+          >
+        `
+      )}
+    `;
+  }
+
+  private renderSimulatedBoot() {
+    const done = this.bootLogs.some((log) => log.startsWith('SUCCESS'));
+    return html`
+      <div class="wizard-shell">
+        <div class="wizard-header">
+          <h3 class="wizard-title boot-title">
+            ${done ? nothing : html`<sl-spinner></sl-spinner>`}
+            <span>
+              ${
+                done
+                  ? 'Agent node provisioned'
+                  : 'Provisioning the secure agent node'
+              }
+            </span>
+          </h3>
+          <p class="wizard-copy">
+            Preloop is preparing the environment, installing the runtime and
+            enrolling the agent.
+          </p>
+        </div>
+
+        <div class="boot-log" role="log" aria-live="polite">
           ${this.bootLogs.map((log) => {
             const isSuccess = log.startsWith('SUCCESS');
-            return html`<div
-              style="margin-bottom: 6px; line-height: 1.4; color: ${
-                isSuccess ? '#4ade80' : '#38bdf8'
-              }; font-weight: ${isSuccess ? 'bold' : 'normal'};"
-            >
-              ${log}
-            </div>`;
+            return html`
+              <div class="boot-log-line ${isSuccess ? 'success' : ''}">
+                ${log}
+              </div>
+            `;
           })}
-          ${
-            this.bootLogs.length < 8 &&
-            !this.bootLogs[this.bootLogs.length - 1]?.startsWith('SUCCESS')
-              ? html`<div style="color: #38bdf8; animation: pulse 1s infinite;">
-                  _
-                </div>`
-              : html`
-                  <div
-                    style="margin-top: var(--sl-spacing-large); display: flex; justify-content: flex-end;"
-                  >
-                    <sl-button
-                      variant="success"
-                      size="small"
-                      @click=${() => {
-                        this.isBooting = false;
-                        this.dispatchEvent(
-                          new CustomEvent('deploy-wizard-done', {
-                            bubbles: true,
-                            composed: true,
-                          })
-                        );
-                      }}
-                    >
-                      View Connected Agent Node
-                    </sl-button>
-                  </div>
-                `
-          }
         </div>
+
+        ${
+          done
+            ? html`
+                <div class="wizard-actions">
+                  <sl-button
+                    variant="primary"
+                    @click=${() => {
+                      this.isBooting = false;
+                      this.dispatchEvent(
+                        new CustomEvent('deploy-wizard-done', {
+                          bubbles: true,
+                          composed: true,
+                        })
+                      );
+                    }}
+                  >
+                    View the connected agent
+                  </sl-button>
+                </div>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/frontend/src/components/preloop-deploy-wizard.test.ts
+++ b/frontend/src/components/preloop-deploy-wizard.test.ts
@@ -875,7 +875,7 @@ describe('PreloopDeployWizard CLI path polling', () => {
     expect((el as any).cliPollingActive).to.equal(true);
     const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
     expect(text).to.contain(
-      'Waiting for the CLI — onboarded agents appear here automatically.'
+      'Waiting for the CLI. Onboarded agents appear here automatically.'
     );
     // The baseline snapshot fetch fires immediately.
     await waitUntil(() => listCallCount >= 1, 'baseline fetch', {
@@ -969,5 +969,212 @@ describe('PreloopDeployWizard CLI path polling', () => {
     );
     // Soft window ~3m; hard cap ~10m from start.
     expect((el as any).cliPollHardStop - before).to.be.at.least(9 * 60 * 1000);
+  });
+});
+
+/**
+ * Step progress, the single-primary action bar, and the phone layout.
+ *
+ * The wizard used to render the same static dialog label on every screen with
+ * no sense of position, and clipped long commands with `white-space: nowrap`
+ * inside an `overflow-x: auto` box, which is invisible to a page-level "does
+ * it scroll sideways" check. These tests pin both.
+ */
+describe('PreloopDeployWizard step progress and phone layout', () => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('preloop-deploy-wizard').forEach((el) => {
+      (el as any).cancelFirstDataPolling?.();
+      (el as any).cancelCliAgentPolling?.();
+    });
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  const PHONE_WIDTH = 390;
+
+  /** Mount the wizard in a phone-width column, the way a 390px viewport does. */
+  async function mountNarrow(
+    initialPath?: string
+  ): Promise<PreloopDeployWizard> {
+    const host = (await fixture(html`
+      <div style="width: ${PHONE_WIDTH}px;">
+        <preloop-deploy-wizard
+          initial-path=${initialPath || 'choose'}
+        ></preloop-deploy-wizard>
+      </div>
+    `)) as HTMLElement;
+    const el = host.querySelector(
+      'preloop-deploy-wizard'
+    ) as PreloopDeployWizard;
+    await el.updateComplete;
+    return el;
+  }
+
+  function stepText(el: PreloopDeployWizard): string {
+    return (
+      el.shadowRoot?.querySelector('.wizard-step-count')?.textContent || ''
+    )
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function rail(el: PreloopDeployWizard): HTMLElement | null {
+    return el.shadowRoot?.querySelector('.wizard-step-rail') || null;
+  }
+
+  function cardByText(
+    el: PreloopDeployWizard,
+    text: string
+  ): HTMLElement | undefined {
+    return (
+      Array.from(
+        el.shadowRoot?.querySelectorAll('.wizard-option-button') || []
+      ) as HTMLElement[]
+    ).find((b) => b.textContent?.includes(text));
+  }
+
+  /**
+   * Nothing inside the component may stick out past the column it was given.
+   * Measured on the rendered boxes rather than on the document, because the
+   * clipping this guards against happens inside the component.
+   */
+  function expectNoHorizontalOverflow(el: PreloopDeployWizard, step: string) {
+    const shell = el.shadowRoot?.querySelector('.wizard-shell') as HTMLElement;
+    expect(shell, `${step}: shell renders`).to.exist;
+    expect(shell.scrollWidth, `${step}: shell scrollWidth`).to.be.at.most(
+      PHONE_WIDTH + 1
+    );
+    const right = el.getBoundingClientRect().right;
+    Array.from(el.shadowRoot?.querySelectorAll('*') || []).forEach((node) => {
+      const rect = (node as HTMLElement).getBoundingClientRect();
+      if (rect.width === 0) {
+        return;
+      }
+      expect(
+        Math.round(rect.right),
+        `${step}: ${(node as HTMLElement).className || node.tagName} right edge`
+      ).to.be.at.most(Math.round(right) + 1);
+    });
+    // A command must wrap, not scroll: a clipped command cannot be read.
+    Array.from(el.shadowRoot?.querySelectorAll('.command-code') || []).forEach(
+      (code) => {
+        const box = code as HTMLElement;
+        expect(box.scrollWidth, `${step}: command block`).to.be.at.most(
+          box.clientWidth + 1
+        );
+      }
+    );
+  }
+
+  it('numbers the choose path and draws a rail only once the total is known', async () => {
+    const el = await mountNarrow('choose');
+    expect(stepText(el)).to.equal('Step 1');
+    expect(rail(el), 'no rail on a branch screen').to.equal(null);
+
+    cardByText(el, 'Govern Existing Agents')!.click();
+    await el.updateComplete;
+    expect(stepText(el)).to.equal('Step 2');
+    expect(rail(el)).to.equal(null);
+
+    cardByText(el, 'Autodiscover via CLI')!.click();
+    await el.updateComplete;
+    expect(stepText(el)).to.contain('Step 3 of 3');
+    expect(rail(el)!.children.length).to.equal(3);
+    expect(rail(el)!.querySelectorAll('.done').length).to.equal(3);
+  });
+
+  it('counts the custom path from the step the wizard was opened on', async () => {
+    // Deep-linked at govern (the agents-view dialog): govern is step 1, so the
+    // custom path runs 2, 3, 4 rather than repeating a phantom step 1.
+    const el = await mountNarrow('govern');
+    expect(stepText(el)).to.equal('Step 1');
+
+    cardByText(el, 'Connect a custom agent')!.click();
+    await el.updateComplete;
+    expect(stepText(el)).to.contain('Step 2 of 4');
+    expect(rail(el)!.querySelectorAll('.done').length).to.equal(2);
+
+    (el as any).customDisplayName = 'Support triage agent';
+    (el as any).handleCustomContinueToModels();
+    await el.updateComplete;
+    expect(stepText(el)).to.contain('Step 3 of 4');
+    expect(rail(el)!.querySelectorAll('.done').length).to.equal(3);
+  });
+
+  it('gives each step one primary action with Back as text beside it', async () => {
+    const el = await mountNarrow('govern');
+    cardByText(el, 'Connect a custom agent')!.click();
+    await el.updateComplete;
+
+    const actions = el.shadowRoot?.querySelector(
+      '.wizard-actions'
+    ) as HTMLElement;
+    expect(actions, 'action bar').to.exist;
+    const primaries = actions.querySelectorAll('sl-button[variant="primary"]');
+    expect(primaries.length, 'exactly one primary').to.equal(1);
+    expect(primaries[0].textContent?.trim()).to.equal('Continue');
+    const back = actions.querySelector('.wizard-back') as HTMLElement;
+    expect(back, 'back button').to.exist;
+    expect(back.getAttribute('variant')).to.equal('text');
+  });
+
+  it('states what is about to be registered before minting a credential', async () => {
+    const el = await mountNarrow('govern');
+    cardByText(el, 'Connect a custom agent')!.click();
+    await el.updateComplete;
+    (el as any).customDisplayName = 'Support triage agent';
+    (el as any).customTagsInput = 'env=prod';
+    (el as any).handleCustomContinueToModels();
+    await el.updateComplete;
+
+    const summary = el.shadowRoot?.querySelector('.wizard-summary');
+    expect(summary, 'summary block').to.exist;
+    const text = (summary?.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.contain('Support triage agent');
+    expect(text).to.contain('env=prod');
+    expect(text).to.contain('shown once');
+  });
+
+  it('does not overflow horizontally at 390px on any step', async () => {
+    const choose = await mountNarrow('choose');
+    expectNoHorizontalOverflow(choose, 'choose');
+
+    const govern = await mountNarrow('govern');
+    expectNoHorizontalOverflow(govern, 'govern');
+
+    const cli = await mountNarrow('cli');
+    await cli.updateComplete;
+    expectNoHorizontalOverflow(cli, 'cli');
+
+    const custom = await mountNarrow('custom');
+    expectNoHorizontalOverflow(custom, 'custom-name');
+
+    (custom as any).customDisplayName = 'Support triage agent';
+    (custom as any).handleCustomContinueToModels();
+    await custom.updateComplete;
+    expectNoHorizontalOverflow(custom, 'custom-models');
+
+    // The result screen carries the longest strings in the wizard: a minted
+    // token and a multi-line snippet.
+    (custom as any).customCredentialToken =
+      'pl_gw_9f3c2a7e5b1d4c8f6a0e2b7d9c4f1a3e0b8d6c4a2f1e9b7d5c3a1f0e8d6c4b2';
+    (custom as any).customModelAlias = 'openai/gpt-4o';
+    (custom as any).customSubStep = 'result';
+    await custom.updateComplete;
+    expectNoHorizontalOverflow(custom, 'custom-result');
   });
 });

--- a/frontend/src/components/preloop-deploy-wizard.ts
+++ b/frontend/src/components/preloop-deploy-wizard.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, nothing, unsafeCSS } from 'lit';
+import type { TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -23,6 +24,8 @@ import type { ManagedAgentModelBindingSyncItem } from '../api';
 import type { AIModel, ManagedAgentSummary } from '../types';
 import './preloop-flow-form';
 import './preloop-agent-deployer';
+import consoleStyles from '../styles/console-styles.css?inline';
+import { deployWizardStyles } from '../styles/deploy-wizard';
 
 type OnboardingPath = 'choose' | 'govern' | 'cli' | 'deploy' | 'custom';
 
@@ -47,222 +50,7 @@ const FIRST_DATA_SUCCESS_DISMISS_MS = 2000;
 
 @customElement('preloop-deploy-wizard')
 export class PreloopDeployWizard extends LitElement {
-  static styles = css`
-    :host {
-      display: block;
-      width: 100%;
-    }
-
-    .wizard-shell {
-      width: 100%;
-      max-width: 820px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-large);
-      color: var(--sl-color-neutral-800);
-    }
-
-    .wizard-shell.wide {
-      max-width: 920px;
-    }
-
-    .wizard-header {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-2x-small);
-    }
-
-    .wizard-title {
-      color: var(--sl-color-neutral-900);
-      font-size: var(--sl-font-size-large);
-      font-weight: var(--sl-font-weight-semibold);
-      line-height: 1.25;
-      margin: 0;
-    }
-
-    .wizard-copy {
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-medium);
-      line-height: 1.55;
-      margin: 0;
-    }
-
-    .wizard-card-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: var(--sl-spacing-large);
-      width: 100%;
-    }
-
-    .wizard-option-button {
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-
-    .wizard-option-button::part(base) {
-      width: 100%;
-      height: auto;
-      min-height: 132px;
-      padding: var(--sl-spacing-large);
-      justify-content: flex-start;
-      text-align: left;
-      align-items: center;
-      text-wrap: wrap;
-    }
-
-    .wizard-option-body {
-      display: flex;
-      align-items: flex-start;
-      gap: var(--sl-spacing-medium);
-    }
-
-    .wizard-option-icon {
-      width: 44px;
-      height: 44px;
-      border-radius: var(--sl-border-radius-large);
-      color: var(--sl-color-primary-600);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      flex: 0 0 auto;
-    }
-
-    .wizard-option-icon sl-icon {
-      font-size: 1.35rem;
-    }
-
-    .wizard-option-copy {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-2x-small);
-      min-width: 0;
-    }
-
-    .wizard-option-title {
-      color: var(--sl-color-neutral-900);
-      font-size: var(--sl-font-size-medium);
-      font-weight: var(--sl-font-weight-semibold);
-      line-height: 1.3;
-    }
-
-    .wizard-option-description {
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
-      font-weight: var(--sl-font-weight-normal);
-      line-height: 1.45;
-    }
-
-    .wizard-panel {
-      width: 100%;
-      border: 1px solid var(--sl-color-neutral-200);
-      border-radius: var(--sl-border-radius-large);
-      background: var(--sl-color-neutral-0);
-      box-shadow: var(--sl-shadow-small);
-      padding: var(--sl-spacing-large);
-      box-sizing: border-box;
-    }
-
-    .command-steps {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-large);
-    }
-
-    .command-step {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-2x-small);
-    }
-
-    .command-label {
-      color: var(--sl-color-neutral-800);
-      font-weight: var(--sl-font-weight-semibold);
-    }
-
-    .command-row {
-      display: flex;
-      align-items: center;
-      gap: var(--sl-spacing-small);
-    }
-
-    .command-code {
-      flex: 1;
-      min-width: 0;
-      background: var(--sl-color-neutral-100);
-      border: 1px solid var(--sl-color-neutral-200);
-      border-radius: var(--sl-border-radius-medium);
-      color: var(--sl-color-neutral-800);
-      font-family: var(--sl-font-mono);
-      font-size: var(--sl-font-size-small);
-      padding: var(--sl-spacing-small) var(--sl-spacing-medium);
-      overflow-x: auto;
-      white-space: nowrap;
-    }
-
-    .wizard-back {
-      align-self: flex-start;
-      margin-left: calc(-1 * var(--sl-spacing-small));
-    }
-
-    .custom-form {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-medium);
-    }
-
-    .custom-error {
-      width: 100%;
-    }
-
-    .command-snippet {
-      margin: 0;
-      white-space: pre;
-      line-height: 1.5;
-    }
-
-    .conn-status {
-      width: 100%;
-    }
-
-    .cli-connected-line {
-      color: var(--sl-color-success-600);
-      font-size: var(--sl-font-size-small);
-      font-weight: var(--sl-font-weight-semibold);
-    }
-
-    .cli-connected-link {
-      color: var(--sl-color-primary-600);
-      display: inline-block;
-      font-size: var(--sl-font-size-small);
-      margin-top: var(--sl-spacing-2x-small);
-    }
-
-    .conn-status .conn-waiting {
-      margin-top: var(--sl-spacing-x-small);
-    }
-
-    .conn-waiting {
-      display: flex;
-      align-items: center;
-      gap: var(--sl-spacing-small);
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
-    }
-
-    .conn-waiting sl-spinner {
-      font-size: 1rem;
-    }
-
-    @media (max-width: 640px) {
-      .wizard-option-body,
-      .command-row {
-        align-items: stretch;
-        flex-direction: column;
-      }
-    }
-  `;
+  static styles = [unsafeCSS(consoleStyles), deployWizardStyles];
 
   @property({ type: Array })
   aiModels: AIModel[] = [];
@@ -907,6 +695,162 @@ agent.invoke(
 )`;
   }
 
+  /**
+   * Where this screen sits in the path. `total` is null on a screen that
+   * branches: the wizard cannot honestly promise a length before the user has
+   * picked a path, so the header shows the number alone rather than inventing
+   * a total it may not keep.
+   */
+  private stepPosition(): { index: number; total: number | null } {
+    // The choose screen only counts as a step when the wizard starts there.
+    // Deep links (initial-path="govern" from the agents view) start at 1.
+    const base = this.initialPath === 'choose' ? 1 : 0;
+    switch (this.onboardingPath) {
+      case 'choose':
+        return { index: 1, total: null };
+      case 'govern':
+        return { index: base + 1, total: null };
+      case 'cli':
+        return { index: base + 2, total: base + 2 };
+      case 'custom': {
+        const first = base + 2;
+        const offset =
+          this.customSubStep === 'name'
+            ? 0
+            : this.customSubStep === 'models'
+              ? 1
+              : 2;
+        return { index: first + offset, total: first + 2 };
+      }
+      default:
+        return this.deploySubStep === 'type'
+          ? { index: base + 1, total: null }
+          : { index: base + 2, total: base + 2 };
+    }
+  }
+
+  /** Steps already taken when the nested deployer takes over the screen. */
+  private deployerStepOffset(): number {
+    return (this.initialPath === 'choose' ? 1 : 0) + 1;
+  }
+
+  /**
+   * Every step opens the same way: which step this is, what it is for, and one
+   * line of context. The rail is only drawn when the total is known.
+   */
+  private renderStepHeader(title: string, copy: unknown) {
+    const { index, total } = this.stepPosition();
+    return html`
+      <div class="wizard-header">
+        <div class="wizard-step-count">
+          <span
+            >${total === null ? `Step ${index}` : `Step ${index} of ${total}`}</span
+          >
+          ${
+            total === null
+              ? nothing
+              : html`
+                  <span class="wizard-step-rail" aria-hidden="true">
+                    ${Array.from(
+                      { length: total },
+                      (_unused, i) =>
+                        html`<span class=${i < index ? 'done' : ''}></span>`
+                    )}
+                  </span>
+                `
+          }
+        </div>
+        ${
+          this.hideStepTitle
+            ? nothing
+            : html`<h3 class="wizard-title">${title}</h3>`
+        }
+        <p class="wizard-copy">${copy}</p>
+      </div>
+    `;
+  }
+
+  /**
+   * One action bar per step: the primary action on the right, Back as a text
+   * button on the left. Back stays in the DOM before the primary so the
+   * keyboard reaches the step's main action last.
+   */
+  private renderActions(showBack: boolean, primary: unknown = nothing) {
+    if (!showBack && primary === nothing) {
+      return nothing;
+    }
+    return html`
+      <div class="wizard-actions">
+        ${
+          showBack
+            ? html`
+                <sl-button
+                  class="wizard-back"
+                  variant="text"
+                  size="small"
+                  @click=${this.handleBack}
+                >
+                  <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
+                </sl-button>
+              `
+            : nothing
+        }
+        ${primary}
+      </div>
+    `;
+  }
+
+  /** A choice on a branch screen: icon column, title, one line, chevron. */
+  private renderOptionCard(
+    icon: string,
+    title: string,
+    description: string,
+    onClick: () => void
+  ): TemplateResult {
+    return html`
+      <button type="button" class="wizard-option-button" @click=${onClick}>
+        <sl-icon class="wizard-option-icon" name=${icon}></sl-icon>
+        <span class="wizard-option-copy">
+          <span class="wizard-option-title">${title}</span>
+          <span class="wizard-option-description">${description}</span>
+        </span>
+        <sl-icon class="wizard-option-arrow" name="chevron-right"></sl-icon>
+      </button>
+    `;
+  }
+
+  /** A labelled, copyable command. Long commands wrap; they never clip. */
+  private renderCommandStep(
+    label: string,
+    command: string,
+    index?: number
+  ): TemplateResult {
+    return html`
+      <div class="command-step">
+        <div class="command-label">
+          ${index ? html`<span class="command-index">${index}</span>` : nothing}
+          <span>${label}</span>
+        </div>
+        <div class="command-row">
+          <code class="command-code">${command}</code>
+          <sl-copy-button .value=${command}></sl-copy-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    if (!this.customError) {
+      return nothing;
+    }
+    return html`
+      <div class="notice danger" role="alert">
+        <sl-icon name="exclamation-octagon"></sl-icon>
+        <span>${this.customError}</span>
+      </div>
+    `;
+  }
+
   render() {
     return html`
       <div style="width: 100%;">
@@ -928,56 +872,31 @@ agent.invoke(
   private renderChoosePathState() {
     return html`
       <div class="wizard-shell">
-        <div class="wizard-header" style="text-align: center;">
-          <p class="wizard-copy">
-            Preloop is the open source control plane for AI agents. Connect or
-            deploy your first agent to begin.
-          </p>
-        </div>
+        ${this.renderStepHeader(
+          'Choose how to start',
+          `Preloop is the open source control plane for AI agents. Connect the
+           agents you already run, or deploy a new one.`
+        )}
         <div class="wizard-card-grid">
-          <sl-button
-            class="wizard-option-button"
-            variant="default"
-            @click=${() => {
+          ${this.renderOptionCard(
+            'shield-check',
+            'Govern Existing Agents',
+            'Connect agents you already run, via CLI autodiscovery or by onboarding a custom agent.',
+            () => {
               this.onboardingPath = 'govern';
               this.requestUpdate();
-            }}
-          >
-            <div class="wizard-option-body">
-              <span class="wizard-option-icon">
-                <sl-icon name="shield-check"></sl-icon>
-              </span>
-              <span class="wizard-option-copy">
-                <span class="wizard-option-title">Govern Existing Agents</span>
-                <span class="wizard-option-description">
-                  Connect agents you already run — via CLI autodiscovery or by
-                  onboarding a custom agent
-                </span>
-              </span>
-            </div>
-          </sl-button>
-
-          <sl-button
-            class="wizard-option-button"
-            variant="default"
-            @click=${() => {
+            }
+          )}
+          ${this.renderOptionCard(
+            'cloud-arrow-up',
+            'Deploy New Agents',
+            'Spin up a new persistent agent or an event-driven flow.',
+            () => {
               this.onboardingPath = 'deploy';
               this.deploySubStep = 'type';
               this.requestUpdate();
-            }}
-          >
-            <div class="wizard-option-body">
-              <span class="wizard-option-icon">
-                <sl-icon name="cloud-arrow-up"></sl-icon>
-              </span>
-              <span class="wizard-option-copy">
-                <span class="wizard-option-title">Deploy New Agents</span>
-                <span class="wizard-option-description">
-                  Spin up new persistent agents or flows
-                </span>
-              </span>
-            </div>
-          </sl-button>
+            }
+          )}
         </div>
       </div>
     `;
@@ -993,80 +912,36 @@ agent.invoke(
     const hideGovernBack = this.hideBack || this.initialPath === 'govern';
     return html`
       <div class="wizard-shell">
-        ${
-          hideGovernBack
-            ? nothing
-            : html`
-                <sl-button
-                  class="wizard-back"
-                  variant="text"
-                  size="small"
-                  @click=${this.handleBack}
-                >
-                  <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
-                </sl-button>
-              `
-        }
-
-        <div class="wizard-header">
-          ${
-            this.hideStepTitle
-              ? nothing
-              : html`<h3 class="wizard-title">Govern Existing Agents</h3>`
-          }
-          <p class="wizard-copy">
-            Bring agents you already run under Preloop's control plane. Let the
-            CLI autodiscover local agents, or onboard a custom agent the CLI
-            can't reach.
-          </p>
-        </div>
+        ${this.renderStepHeader(
+          'Govern existing agents',
+          `Bring agents you already run under Preloop's control plane. The CLI
+           can autodiscover local agents, or you can onboard a custom agent it
+           cannot reach.`
+        )}
 
         <div class="wizard-card-grid">
-          <sl-button
-            class="wizard-option-button"
-            variant="default"
-            @click=${() => {
+          ${this.renderOptionCard(
+            'terminal',
+            'Autodiscover via CLI',
+            'Install the Preloop CLI and discover local running agents automatically.',
+            () => {
               this.onboardingPath = 'cli';
               this.requestUpdate();
-            }}
-          >
-            <div class="wizard-option-body">
-              <span class="wizard-option-icon">
-                <sl-icon name="terminal"></sl-icon>
-              </span>
-              <span class="wizard-option-copy">
-                <span class="wizard-option-title">Autodiscover via CLI</span>
-                <span class="wizard-option-description">
-                  Install the Preloop CLI and discover local running agents
-                  automatically
-                </span>
-              </span>
-            </div>
-          </sl-button>
-
-          <sl-button
-            class="wizard-option-button"
-            variant="default"
-            @click=${() => {
+            }
+          )}
+          ${this.renderOptionCard(
+            'plug',
+            'Connect a custom agent',
+            "Onboard an existing agent (LangGraph, custom SDK) the CLI can't discover.",
+            () => {
               this.resetCustomState();
               this.onboardingPath = 'custom';
               this.requestUpdate();
-            }}
-          >
-            <div class="wizard-option-body">
-              <span class="wizard-option-icon">
-                <sl-icon name="plug"></sl-icon>
-              </span>
-              <span class="wizard-option-copy">
-                <span class="wizard-option-title">Connect a custom agent</span>
-                <span class="wizard-option-description">
-                  Onboard an existing agent (LangGraph, custom SDK) the CLI
-                  can't discover
-                </span>
-              </span>
-            </div>
-          </sl-button>
+            }
+          )}
         </div>
+
+        ${this.renderActions(!hideGovernBack)}
       </div>
     `;
   }
@@ -1083,73 +958,35 @@ agent.invoke(
 
     return html`
       <div class="wizard-shell">
-        ${
-          this.hideBack
-            ? nothing
-            : html`
-                <sl-button
-                  class="wizard-back"
-                  variant="text"
-                  size="small"
-                  @click=${this.handleBack}
-                >
-                  <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
-                </sl-button>
-              `
-        }
+        ${this.renderStepHeader(
+          'Install the CLI and discover agents',
+          `Run these three commands on the machine where your agents live. It
+           takes about two minutes.`
+        )}
 
-        <div class="wizard-header">
-          ${
-            this.hideStepTitle
-              ? nothing
-              : html`
-                  <h3 class="wizard-title">
-                    Onboard Existing Agent via Preloop CLI
-                  </h3>
-                `
-          }
-          <p class="wizard-copy">
-            Run these commands on the machine where your agents live. Takes
-            about two minutes.
-          </p>
-        </div>
-
-        <div class="wizard-panel command-steps">
-          <div class="command-step">
-            <div class="command-label">1. Install the Preloop CLI tool</div>
-            <div class="command-row">
-              <code class="command-code">${installCommand}</code>
-              <sl-copy-button .value=${installCommand}></sl-copy-button>
-            </div>
-          </div>
-
-          <div class="command-step">
-            <div class="command-label">2. Authenticate CLI session</div>
-            <div class="command-row">
-              <code class="command-code">${loginCommand}</code>
-              <sl-copy-button .value=${loginCommand}></sl-copy-button>
-            </div>
-          </div>
-
-          <div class="command-step">
-            <div class="command-label">
-              3. Discover and onboard local agents
-            </div>
-            <div class="command-row">
-              <code class="command-code">preloop agents discover</code>
-              <sl-copy-button value="preloop agents discover"></sl-copy-button>
-            </div>
-          </div>
-
+        <div class="command-steps">
+          ${this.renderCommandStep(
+            'Install the Preloop CLI tool',
+            installCommand,
+            1
+          )}
+          ${this.renderCommandStep('Authenticate the CLI session', loginCommand, 2)}
+          ${this.renderCommandStep(
+            'Discover and onboard local agents',
+            'preloop agents discover',
+            3
+          )}
           ${this.renderCliConnStatus()}
         </div>
 
         <p class="wizard-copy">
-          The CLI lists what it finds — Claude Code, Cursor, Codex CLI,
-          OpenClaw, Gemini CLI and more — and asks before onboarding each one.
-          Onboarded agents appear on the Agents page; their first model call
-          shows up under Sessions.
+          The CLI lists what it finds (Claude Code, Cursor, Codex CLI, OpenClaw,
+          Gemini CLI and more) and asks before onboarding each one. Onboarded
+          agents appear on the Agents page; their first model call shows up
+          under Sessions.
         </p>
+
+        ${this.renderActions(!this.hideBack)}
       </div>
     `;
   }
@@ -1188,7 +1025,7 @@ agent.invoke(
                 <div class="conn-waiting">
                   <sl-spinner></sl-spinner>
                   <span>
-                    Waiting for the CLI — onboarded agents appear here
+                    Waiting for the CLI. Onboarded agents appear here
                     automatically.
                   </span>
                 </div>
@@ -1203,20 +1040,6 @@ agent.invoke(
     return html`
       <div class="wizard-shell">
         ${
-          this.hideBack
-            ? nothing
-            : html`
-                <sl-button
-                  class="wizard-back"
-                  variant="text"
-                  size="small"
-                  @click=${this.handleBack}
-                >
-                  <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
-                </sl-button>
-              `
-        }
-        ${
           this.customSubStep === 'name'
             ? this.renderCustomNameState()
             : this.customSubStep === 'models'
@@ -1229,35 +1052,20 @@ agent.invoke(
 
   private renderCustomNameState() {
     return html`
-      <div class="wizard-header">
-        ${
-          this.hideStepTitle
-            ? nothing
-            : html`<h3 class="wizard-title">Connect a custom agent</h3>`
-        }
-        <p class="wizard-copy">
-          Register an existing agent (LangGraph, custom SDK) the CLI can't
-          discover. We'll mint a gateway credential so it can route model
-          traffic through Preloop.
-        </p>
-      </div>
+      ${this.renderStepHeader(
+        'Name the agent',
+        `Register an existing agent (LangGraph, custom SDK) the CLI cannot
+         discover. Preloop mints a gateway credential so the agent can route
+         model traffic through the control plane.`
+      )}
 
-      <div class="wizard-panel custom-form">
-        ${
-          this.customError
-            ? html`
-                <sl-alert variant="danger" open class="custom-error">
-                  <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
-                  ${this.customError}
-                </sl-alert>
-              `
-            : nothing
-        }
+      <div class="wizard-form">
+        ${this.renderError()}
 
         <sl-input
           label="Agent name"
           name="display_name"
-          placeholder="e.g. Support triage agent"
+          help-text="The name you will recognise in the console, for example Support triage agent."
           required
           ?disabled=${this.customBusy}
           .value=${this.customDisplayName}
@@ -1267,9 +1075,9 @@ agent.invoke(
         ></sl-input>
 
         <sl-textarea
-          label="Description (optional)"
+          label="Description"
           name="description"
-          placeholder="What does this agent do?"
+          help-text="Optional. One line on what this agent does."
           rows="2"
           ?disabled=${this.customBusy}
           .value=${this.customDescription}
@@ -1279,25 +1087,29 @@ agent.invoke(
         ></sl-textarea>
 
         <sl-input
-          label="Tags (optional)"
+          label="Tags"
           name="tags"
-          placeholder="e.g. env=prod team=support beta"
-          help-text="Space-separated. Use key=value for pairs, or just key for a label."
+          help-text="Optional. Space-separated: key=value for pairs, or just key for a label. For example env=prod team=support."
           ?disabled=${this.customBusy}
           .value=${this.customTagsInput}
           @sl-input=${(e: Event) => {
             this.customTagsInput = (e.target as HTMLInputElement).value;
           }}
         ></sl-input>
-
-        <sl-button
-          variant="primary"
-          ?disabled=${!this.customDisplayName.trim()}
-          @click=${this.handleCustomContinueToModels}
-        >
-          Continue
-        </sl-button>
       </div>
+
+      ${this.renderActions(
+        !this.hideBack,
+        html`
+          <sl-button
+            variant="primary"
+            ?disabled=${!this.customDisplayName.trim()}
+            @click=${this.handleCustomContinueToModels}
+          >
+            Continue
+          </sl-button>
+        `
+      )}
     `;
   }
 
@@ -1306,7 +1118,7 @@ agent.invoke(
   // from MCP/HTTP servers and built-ins, and persists governance via separate
   // per-subject endpoints; it has no notion of "define this new agent's tool
   // surface" and no register-time persistence path. Wiring it here would require
-  // new backend endpoints (out of scope for this task — account.py must not
+  // new backend endpoints (out of scope for this task: account.py must not
   // change). Tool selection is therefore deferred pending a dedicated backend
   // endpoint. Tags + models ship now.
   private renderCustomModelState() {
@@ -1317,29 +1129,14 @@ agent.invoke(
       (!hasModels || this.customSelectedModelIds.length > 0);
 
     return html`
-      <div class="wizard-header">
-        ${
-          this.hideStepTitle
-            ? nothing
-            : html`<h3 class="wizard-title">Choose allowed models</h3>`
-        }
-        <p class="wizard-copy">
-          Pick which models this agent may use through the Preloop gateway. The
-          first model becomes the default the example snippet routes to.
-        </p>
-      </div>
+      ${this.renderStepHeader(
+        'Choose allowed models',
+        `Pick the models this agent may use through the Preloop gateway. The
+         first one becomes the default the example snippet routes to.`
+      )}
 
-      <div class="wizard-panel custom-form">
-        ${
-          this.customError
-            ? html`
-                <sl-alert variant="danger" open class="custom-error">
-                  <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
-                  ${this.customError}
-                </sl-alert>
-              `
-            : nothing
-        }
+      <div class="wizard-form">
+        ${this.renderError()}
         ${
           hasModels
             ? html`
@@ -1349,6 +1146,7 @@ agent.invoke(
                   multiple
                   clearable
                   placeholder="Select one or more models"
+                  help-text="The agent may only call the models you grant it here."
                   ?disabled=${this.customBusy}
                   .value=${this.customSelectedModelIds}
                   @sl-change=${(e: Event) => {
@@ -1373,22 +1171,71 @@ agent.invoke(
                 </sl-select>
               `
             : html`
-                <sl-alert variant="primary" open class="custom-error">
-                  <sl-icon slot="icon" name="info-circle"></sl-icon>
-                  No gateway-enabled models are configured for this account. You
-                  can register the agent now and set its allowed model later.
-                </sl-alert>
+                <div class="notice info">
+                  <sl-icon name="info-circle"></sl-icon>
+                  <span>
+                    No gateway-enabled models are configured for this account.
+                    You can register the agent now and set its allowed model
+                    later.
+                  </span>
+                </div>
               `
         }
+        ${this.renderCustomSummary(enabledModels)}
+      </div>
 
-        <sl-button
-          variant="primary"
-          ?loading=${this.customBusy}
-          ?disabled=${!canRegister}
-          @click=${this.handleCustomRegister}
-        >
-          Register agent &amp; mint credential
-        </sl-button>
+      ${this.renderActions(
+        !this.hideBack,
+        html`
+          <sl-button
+            variant="primary"
+            ?loading=${this.customBusy}
+            ?disabled=${!canRegister}
+            @click=${this.handleCustomRegister}
+          >
+            Register agent &amp; mint credential
+          </sl-button>
+        `
+      )}
+    `;
+  }
+
+  /**
+   * What the next click is about to create. Registering mints a credential
+   * that is shown once, so the last screen before it states the agent it is
+   * about to register rather than asking the user to remember two screens
+   * back.
+   */
+  private renderCustomSummary(enabledModels: AIModel[]) {
+    const selected = enabledModels.filter((model) =>
+      this.customSelectedModelIds.includes(model.id)
+    );
+    const tags = Object.entries(this.parseCustomTags()).map(
+      ([key, value]) => `${key}=${value}`
+    );
+    const row = (key: string, value: unknown) => html`
+      <div class="wizard-summary-row">
+        <span class="wizard-summary-key">${key}</span>
+        <span class="wizard-summary-value">${value}</span>
+      </div>
+    `;
+    return html`
+      <div class="wizard-summary">
+        <div class="wizard-summary-title">About to register</div>
+        ${row('Agent', this.customDisplayName.trim() || 'Not set')}
+        ${
+          this.customDescription.trim()
+            ? row('Description', this.customDescription.trim())
+            : nothing
+        }
+        ${tags.length > 0 ? row('Tags', tags.join(' ')) : nothing}
+        ${row(
+          'Models',
+          selected.length > 0
+            ? selected.map((model) => model.name).join(', ')
+            : 'None selected'
+        )}
+        ${row('Credential', 'One gateway credential, shown once')}
       </div>
     `;
   }
@@ -1399,44 +1246,32 @@ agent.invoke(
     const snippet = this.buildCustomSnippet(baseUrl, token);
 
     return html`
-      <div class="wizard-header">
-        ${
-          this.hideStepTitle
-            ? nothing
-            : html`<h3 class="wizard-title">Your agent is connected</h3>`
-        }
-        <p class="wizard-copy">
-          Point your agent at the Preloop gateway using the base URL and
-          credential below, then route model traffic through it.
-        </p>
-      </div>
+      ${this.renderStepHeader(
+        'Your agent is connected',
+        `Point your agent at the Preloop gateway with the base URL and
+         credential below, then route its model traffic through it.`
+      )}
 
-      <div class="wizard-panel command-steps">
-        <sl-alert variant="warning" open>
-          <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+      <div class="notice warning">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <span>
           This credential token is shown only once and cannot be recovered. Copy
           it now and store it securely.
-        </sl-alert>
+        </span>
+      </div>
 
-        <div class="command-step">
-          <div class="command-label">Gateway base URL (OpenAI-compatible)</div>
-          <div class="command-row">
-            <code class="command-code">${baseUrl}</code>
-            <sl-copy-button .value=${baseUrl}></sl-copy-button>
-          </div>
-        </div>
-
-        <div class="command-step">
-          <div class="command-label">Gateway credential (api_key)</div>
-          <div class="command-row">
-            <code class="command-code">${token}</code>
-            <sl-copy-button .value=${token}></sl-copy-button>
-          </div>
-        </div>
+      <div class="command-steps">
+        ${this.renderCommandStep(
+          'Gateway base URL (OpenAI-compatible)',
+          baseUrl
+        )}
+        ${this.renderCommandStep('Gateway credential (api_key)', token)}
 
         <div class="command-step">
           <div class="command-label">
-            Example: LangGraph + OpenAI SDK with a per-run session id
+            <span
+              >Example: LangGraph + OpenAI SDK with a per-run session id</span
+            >
           </div>
           <div class="command-row">
             <pre class="command-code command-snippet">${snippet}</pre>
@@ -1445,25 +1280,30 @@ agent.invoke(
         </div>
 
         ${this.renderCustomConnStatus()}
-
-        <sl-button
-          variant=${
-            this.customConnState === 'connected' ? 'success' : 'primary'
-          }
-          @click=${() => {
-            this.cancelFirstDataPolling();
-            this.customCredentialToken = null;
-            this.dispatchEvent(
-              new CustomEvent('deploy-wizard-done', {
-                bubbles: true,
-                composed: true,
-              })
-            );
-          }}
-        >
-          Done
-        </sl-button>
       </div>
+
+      ${this.renderActions(
+        !this.hideBack,
+        html`
+          <sl-button
+            variant=${
+              this.customConnState === 'connected' ? 'success' : 'primary'
+            }
+            @click=${() => {
+              this.cancelFirstDataPolling();
+              this.customCredentialToken = null;
+              this.dispatchEvent(
+                new CustomEvent('deploy-wizard-done', {
+                  bubbles: true,
+                  composed: true,
+                })
+              );
+            }}
+          >
+            Done
+          </sl-button>
+        `
+      )}
     `;
   }
 
@@ -1472,19 +1312,23 @@ agent.invoke(
       const count = this.customConnRequestCount;
       const label =
         count > 0
-          ? `Agent connected — ${count} request${count === 1 ? '' : 's'} received`
+          ? `Agent connected: ${count} request${count === 1 ? '' : 's'} received`
           : 'Agent connected';
       return html`
-        <sl-alert variant="success" open class="conn-status">
-          <sl-icon slot="icon" name="check-circle"></sl-icon>
-          ${label}
-        </sl-alert>
+        <div class="conn-status">
+          <div class="conn-connected">
+            <sl-icon name="check-circle"></sl-icon>
+            <span>${label}</span>
+          </div>
+        </div>
       `;
     }
     return html`
-      <div class="conn-status conn-waiting">
-        <sl-spinner></sl-spinner>
-        <span>Waiting for your agent's first request…</span>
+      <div class="conn-status">
+        <div class="conn-waiting">
+          <sl-spinner></sl-spinner>
+          <span>Waiting for your agent's first request…</span>
+        </div>
       </div>
     `;
   }
@@ -1497,122 +1341,79 @@ agent.invoke(
           .computeFeatureEnabled=${this.computeFeatureEnabled}
           .isEnterprise=${this.isEnterprise}
           .isAdmin=${this.isAdmin}
+          .stepOffset=${this.deployerStepOffset()}
           @deploy-agent-success=${this.handleAgentDeploySuccess}
           @deploy-cancel=${this.handleAgentDeployCancel}
         ></preloop-agent-deployer>
       `;
     }
 
+    if (this.deploySubStep === 'flow-config') {
+      return html`
+        <div class="wizard-shell wide">
+          ${this.renderStepHeader(
+            'Configure the event-driven flow',
+            `Start an agent when an event fires (issue created, webhook) and
+             stop it when the run completes.`
+          )}
+          <div class="wizard-section">
+            <preloop-flow-form
+              @flow-submit=${async (e: CustomEvent) => {
+                const payload = e.detail.flow;
+                try {
+                  const newFlow = await createFlow(payload);
+                  this.dispatchEvent(
+                    new CustomEvent('deploy-flow-success', {
+                      bubbles: true,
+                      composed: true,
+                      detail: { flow: newFlow },
+                    })
+                  );
+                } catch (error: any) {
+                  const form = e.target as HTMLElement & {
+                    formError?: string;
+                  };
+                  form.formError = error?.message || 'Failed to create flow.';
+                }
+              }}
+              @flow-cancel=${() => {
+                this.deploySubStep = 'type';
+              }}
+            ></preloop-flow-form>
+          </div>
+        </div>
+      `;
+    }
+
     return html`
-      <div class="wizard-shell wide">
-        <sl-button
-          class="wizard-back"
-          variant="text"
-          size="small"
-          @click=${this.handleBack}
-        >
-          <sl-icon name="arrow-left" slot="prefix"></sl-icon> Back
-        </sl-button>
+      <div class="wizard-shell">
+        ${this.renderStepHeader(
+          'Deploy a new agent',
+          'Choose how the new agent should run.'
+        )}
 
-        ${
-          this.deploySubStep === 'type'
-            ? html`
-                <div class="wizard-header">
-                  <h3 class="wizard-title">Deploy New Agent or Flow</h3>
-                  <p class="wizard-copy">
-                    Choose how the new agent should run.
-                  </p>
-                </div>
+        <div class="wizard-card-grid">
+          ${this.renderOptionCard(
+            'server',
+            'Deploy Persistent Agent',
+            'Run a long-lived agent that stays connected and picks up work continuously.',
+            () => {
+              this.deploySubStep = 'agent-host';
+              this.requestUpdate();
+            }
+          )}
+          ${this.renderOptionCard(
+            'diagram-3',
+            'Configure Event-Driven Flow',
+            'Start an agent when an event fires (issue created, webhook), stop it when the run completes.',
+            () => {
+              this.deploySubStep = 'flow-config';
+              this.requestUpdate();
+            }
+          )}
+        </div>
 
-                <div class="wizard-card-grid">
-                  <sl-button
-                    class="wizard-option-button"
-                    variant="default"
-                    @click=${() => {
-                      this.deploySubStep = 'agent-host';
-                      this.requestUpdate();
-                    }}
-                  >
-                    <div class="wizard-option-body">
-                      <span class="wizard-option-icon">
-                        <sl-icon name="server"></sl-icon>
-                      </span>
-                      <span class="wizard-option-copy">
-                        <span class="wizard-option-title">
-                          Deploy Persistent Agent
-                        </span>
-                        <span class="wizard-option-description">
-                          Run a long-lived agent that stays connected and picks
-                          up work continuously.
-                        </span>
-                      </span>
-                    </div>
-                  </sl-button>
-
-                  <sl-button
-                    class="wizard-option-button"
-                    variant="default"
-                    @click=${() => {
-                      this.deploySubStep = 'flow-config';
-                      this.requestUpdate();
-                    }}
-                  >
-                    <div class="wizard-option-body">
-                      <span class="wizard-option-icon">
-                        <sl-icon name="diagram-3"></sl-icon>
-                      </span>
-                      <span class="wizard-option-copy">
-                        <span class="wizard-option-title">
-                          Configure Event-Driven Flow
-                        </span>
-                        <span class="wizard-option-description">
-                          Start an agent when an event fires (issue created,
-                          webhook), stop it when the run completes.
-                        </span>
-                      </span>
-                    </div>
-                  </sl-button>
-                </div>
-              `
-            : nothing
-        }
-        ${
-          this.deploySubStep === 'flow-config'
-            ? html`
-                <div class="wizard-header">
-                  <h3 class="wizard-title">
-                    Configure Event-Driven Agentic Flow
-                  </h3>
-                </div>
-                <div class="wizard-panel">
-                  <preloop-flow-form
-                    @flow-submit=${async (e: CustomEvent) => {
-                      const payload = e.detail.flow;
-                      try {
-                        const newFlow = await createFlow(payload);
-                        this.dispatchEvent(
-                          new CustomEvent('deploy-flow-success', {
-                            bubbles: true,
-                            composed: true,
-                            detail: { flow: newFlow },
-                          })
-                        );
-                      } catch (error: any) {
-                        const form = e.target as HTMLElement & {
-                          formError?: string;
-                        };
-                        form.formError =
-                          error?.message || 'Failed to create flow.';
-                      }
-                    }}
-                    @flow-cancel=${() => {
-                      this.deploySubStep = 'type';
-                    }}
-                  ></preloop-flow-form>
-                </div>
-              `
-            : nothing
-        }
+        ${this.renderActions(!this.hideBack && this.initialPath !== 'deploy')}
       </div>
     `;
   }

--- a/frontend/src/components/preloop-deploy-wizard.ts
+++ b/frontend/src/components/preloop-deploy-wizard.ts
@@ -7,7 +7,6 @@ import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
-import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import {

--- a/frontend/src/styles/deploy-wizard.ts
+++ b/frontend/src/styles/deploy-wizard.ts
@@ -219,12 +219,6 @@ export const deployWizardStyles = css`
     padding: 0;
   }
 
-  .wizard-field-note {
-    color: var(--console-meta-color);
-    font-size: var(--console-text-meta);
-    margin: calc(-1 * var(--sl-spacing-x-small)) 0 0;
-  }
-
   /* A review block is rows under a rule, not a filled box. */
   .wizard-summary {
     display: flex;

--- a/frontend/src/styles/deploy-wizard.ts
+++ b/frontend/src/styles/deploy-wizard.ts
@@ -1,0 +1,460 @@
+import { css } from 'lit';
+
+/**
+ * One stylesheet for both deploy surfaces: `preloop-deploy-wizard` (the
+ * onboarding path) and `preloop-agent-deployer` (the "Deploy Governed Agent"
+ * dialog, which the wizard also nests inside its deploy path). The two
+ * components carried two copies of the same rules, so a fix to the option
+ * cards or the command blocks had to be made twice and drifted anyway.
+ *
+ * The recipe follows DESIGN.md:
+ *  - Depth stays at two. A dialog panel is already the raised surface, so the
+ *    step body adds no fill, no border and no shadow of its own. The single
+ *    exception the design allows is a copyable command block, which sits on
+ *    --console-page because it is a literal thing to select.
+ *  - Type comes from the console scale (15 title / 14 body / 13 meta / 11
+ *    eyebrow), not from the marketing sizes the wizard used.
+ *  - One primary action per step, right aligned in an action bar; the
+ *    secondary (Back) is a text button on the left.
+ *  - Nothing scrolls sideways: commands wrap instead of clipping.
+ */
+export const deployWizardStyles = css`
+  :host {
+    display: block;
+    width: 100%;
+  }
+
+  .wizard-shell {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 46rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-large);
+    color: var(--sl-color-neutral-800);
+    font-size: var(--console-text-body);
+    line-height: 1.5;
+  }
+
+  /* The flow form is a form of its own and wants the extra column width. */
+  .wizard-shell.wide {
+    max-width: 56rem;
+  }
+
+  /* ---------------------------------------------------------------
+     Step header: where am I, of how many, and what am I doing here.
+     --------------------------------------------------------------- */
+  .wizard-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-2x-small);
+    min-width: 0;
+  }
+
+  .wizard-step-count {
+    align-items: center;
+    color: var(--console-meta-color);
+    display: flex;
+    font-size: var(--console-text-eyebrow);
+    font-weight: 600;
+    gap: var(--sl-spacing-small);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  /* The rail is the count made visible: one tick per step, filled up to the
+     step you are on. It is only drawn when the total is known (a branch
+     screen does not yet know how long its path is). */
+  .wizard-step-rail {
+    display: inline-flex;
+    gap: 4px;
+  }
+
+  .wizard-step-rail span {
+    background: var(--console-hairline);
+    border-radius: 999px;
+    display: block;
+    height: 3px;
+    width: 18px;
+  }
+
+  .wizard-step-rail span.done {
+    background: var(--sl-color-primary-600);
+  }
+
+  .wizard-title {
+    color: var(--sl-color-neutral-900);
+    font-size: var(--console-text-card-title);
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 0;
+  }
+
+  .wizard-copy {
+    color: var(--console-meta-color);
+    font-size: var(--console-text-meta);
+    line-height: 1.5;
+    margin: 0;
+    max-width: 46rem;
+  }
+
+  /* ---------------------------------------------------------------
+     Choice cards. Same object as a console row: a hairline box, an icon
+     column of a fixed width, a title, one line of meta, a chevron. No fill,
+     so a card inside a dialog panel does not become a third surface.
+     --------------------------------------------------------------- */
+  .wizard-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+    gap: var(--sl-spacing-medium);
+    width: 100%;
+  }
+
+  .wizard-option-button {
+    align-items: start;
+    background: transparent;
+    border: 1px solid var(--console-hairline);
+    border-radius: var(--console-card-radius, 0.5rem);
+    box-sizing: border-box;
+    color: inherit;
+    column-gap: var(--sl-spacing-small);
+    cursor: pointer;
+    display: grid;
+    font: inherit;
+    grid-template-columns: 1.25rem minmax(0, 1fr) 1rem;
+    height: 100%;
+    padding: var(--sl-spacing-medium);
+    text-align: left;
+    transition:
+      background-color 120ms ease-out,
+      border-color 120ms ease-out;
+    width: 100%;
+  }
+
+  .wizard-option-button:hover {
+    background: var(--console-hover-tint);
+    border-color: var(
+      --console-button-border-hover,
+      var(--sl-color-neutral-300)
+    );
+  }
+
+  .wizard-option-button:focus-visible {
+    outline: 2px solid var(--sl-color-primary-500);
+    outline-offset: 2px;
+  }
+
+  .wizard-option-icon {
+    color: var(--sl-color-primary-600);
+    font-size: 1rem;
+    line-height: 1.35;
+  }
+
+  .wizard-option-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .wizard-option-title {
+    color: var(--sl-color-neutral-900);
+    font-size: var(--console-text-body);
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .wizard-option-description {
+    color: var(--console-meta-color);
+    font-size: var(--console-text-meta);
+    line-height: 1.45;
+  }
+
+  .wizard-option-arrow {
+    align-self: center;
+    color: var(--console-meta-color);
+    font-size: 0.875rem;
+  }
+
+  /* ---------------------------------------------------------------
+     Step body and forms. One field width per step, help under the field.
+     --------------------------------------------------------------- */
+  .wizard-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-medium);
+    min-width: 0;
+    width: 100%;
+  }
+
+  .wizard-form {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-medium);
+    max-width: 32rem;
+    width: 100%;
+  }
+
+  .wizard-form sl-input,
+  .wizard-form sl-textarea,
+  .wizard-form sl-select {
+    width: 100%;
+  }
+
+  /* A field plus the one link that belongs to it (add a model, learn more). */
+  .wizard-field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .wizard-field .field-link {
+    align-self: flex-start;
+  }
+
+  .wizard-field .field-link::part(base) {
+    height: auto;
+    padding: 0;
+  }
+
+  .wizard-field-note {
+    color: var(--console-meta-color);
+    font-size: var(--console-text-meta);
+    margin: calc(-1 * var(--sl-spacing-x-small)) 0 0;
+  }
+
+  /* A review block is rows under a rule, not a filled box. */
+  .wizard-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-width: 32rem;
+  }
+
+  .wizard-summary-title {
+    color: var(--console-meta-color);
+    font-size: var(--console-text-eyebrow);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    padding-bottom: var(--sl-spacing-2x-small);
+    text-transform: uppercase;
+  }
+
+  .wizard-summary-row {
+    align-items: baseline;
+    border-top: 1px solid var(--console-hairline);
+    display: flex;
+    gap: var(--sl-spacing-medium);
+    justify-content: space-between;
+    padding: var(--sl-spacing-x-small) 0;
+  }
+
+  .wizard-summary-key {
+    color: var(--console-meta-color);
+    flex: 0 0 auto;
+    font-size: var(--console-text-meta);
+  }
+
+  .wizard-summary-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    text-align: right;
+  }
+
+  /* ---------------------------------------------------------------
+     Notices. A tint and an icon, never a second card.
+     --------------------------------------------------------------- */
+  .notice {
+    align-items: flex-start;
+    border-radius: var(--sl-border-radius-medium);
+    display: flex;
+    font-size: var(--console-text-meta);
+    gap: var(--sl-spacing-small);
+    line-height: 1.45;
+    padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+  }
+
+  .notice sl-icon {
+    flex: 0 0 auto;
+    font-size: 1rem;
+    margin-top: 1px;
+  }
+
+  .notice.warning {
+    background: color-mix(
+      in srgb,
+      var(--sl-color-warning-500) 12%,
+      transparent
+    );
+    color: var(--sl-color-warning-800);
+  }
+
+  .notice.danger {
+    background: color-mix(in srgb, var(--sl-color-danger-500) 12%, transparent);
+    color: var(--sl-color-danger-800);
+  }
+
+  .notice.info {
+    background: color-mix(
+      in srgb,
+      var(--sl-color-primary-500) 12%,
+      transparent
+    );
+    color: var(--sl-color-primary-800);
+  }
+
+  /* ---------------------------------------------------------------
+     Command blocks. The one place a filled box is allowed inside a card,
+     because it is a literal thing to select. It wraps: a command that runs
+     off the right edge cannot be read or copied by eye.
+     --------------------------------------------------------------- */
+  .command-steps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-medium);
+    min-width: 0;
+  }
+
+  .command-step {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-2x-small);
+    min-width: 0;
+  }
+
+  .command-label {
+    align-items: baseline;
+    color: var(--sl-color-neutral-900);
+    display: flex;
+    font-size: var(--console-text-body);
+    font-weight: 600;
+    gap: var(--sl-spacing-x-small);
+  }
+
+  .command-index {
+    color: var(--console-meta-color);
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    min-width: 1rem;
+  }
+
+  .command-row {
+    align-items: flex-start;
+    display: flex;
+    gap: var(--sl-spacing-x-small);
+    min-width: 0;
+  }
+
+  .command-row + .command-row {
+    margin-top: var(--sl-spacing-2x-small);
+  }
+
+  .command-code {
+    background: var(--console-page);
+    border-radius: var(--sl-border-radius-medium);
+    box-sizing: border-box;
+    color: var(--sl-color-neutral-800);
+    flex: 1 1 auto;
+    font-family: var(--sl-font-mono);
+    font-size: var(--console-text-meta);
+    line-height: 1.5;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .command-snippet {
+    margin: 0;
+    max-height: 15rem;
+    overflow-y: auto;
+  }
+
+  .command-row sl-copy-button {
+    flex: 0 0 auto;
+    margin-top: 2px;
+  }
+
+  /* ---------------------------------------------------------------
+     Action bar: one primary on the right, one text secondary on the left.
+     --------------------------------------------------------------- */
+  .wizard-actions {
+    align-items: center;
+    border-top: 1px solid var(--console-hairline);
+    display: flex;
+    gap: var(--sl-spacing-small);
+    justify-content: flex-end;
+    padding-top: var(--sl-spacing-medium);
+  }
+
+  .wizard-actions .wizard-back {
+    margin-right: auto;
+  }
+
+  /* ---------------------------------------------------------------
+     Live connection status.
+     --------------------------------------------------------------- */
+  .conn-status {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sl-spacing-2x-small);
+    width: 100%;
+  }
+
+  .conn-waiting {
+    align-items: center;
+    color: var(--console-meta-color);
+    display: flex;
+    font-size: var(--console-text-meta);
+    gap: var(--sl-spacing-small);
+  }
+
+  .conn-waiting sl-spinner {
+    font-size: 0.875rem;
+  }
+
+  .conn-connected {
+    align-items: center;
+    color: var(--sl-color-success-700);
+    display: flex;
+    font-size: var(--console-text-meta);
+    font-weight: 600;
+    gap: var(--sl-spacing-x-small);
+  }
+
+  .cli-connected-line {
+    color: var(--sl-color-success-700);
+    font-size: var(--console-text-meta);
+    font-weight: 600;
+  }
+
+  .cli-connected-link {
+    color: var(--console-link-color);
+    display: inline-block;
+    font-size: var(--console-text-meta);
+  }
+
+  @media (max-width: 640px) {
+    /* Phones get one full-width primary, with the secondary under it. The
+       DOM order stays secondary-then-primary so the keyboard reaches the
+       action it is most likely to want last. */
+    .wizard-actions {
+      flex-direction: column-reverse;
+      align-items: stretch;
+    }
+
+    .wizard-actions .wizard-back {
+      margin-right: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wizard-option-button {
+      transition: none;
+    }
+  }
+`;

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -4620,7 +4620,6 @@ export class AgentsView extends LitElement {
             ? html`
                 <preloop-deploy-wizard
                   initial-path="govern"
-                  hide-step-title
                   .aiModels=${this.aiModels}
                   .computeFeatureEnabled=${this.computeFeatureEnabled}
                   .isEnterprise=${this.isEnterprise}

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -3121,9 +3121,9 @@ export class DashboardView extends AuthedElement {
         />
 
         <h2
-          style="font-size: 1.75rem; font-weight: 700; color: var(--sl-color-neutral-900); margin: 0 0 var(--sl-spacing-medium) 0; text-align: center;"
+          style="font-size: var(--console-text-h1); font-weight: 600; letter-spacing: -0.01em; color: var(--sl-color-neutral-900); margin: 0 0 var(--sl-spacing-medium) 0; text-align: center;"
         >
-          Get Started with Preloop
+          Get started with Preloop
         </h2>
 
         <div


### PR DESCRIPTION
Deploy new agent dialog (and the onboarding path): rebuild on the console idiom

## Why

Founder report (prod, 2026-09-07): "We should improve the look and feel of the deploy new agent popup which also appears when onboarding."

The wizard predates the console revamp. It is the first surface a new account sees (it auto-opens on an agent-less account and it is embedded in the dashboard welcome card), and it did not look like the console it opens on top of.

## What was wrong (measured on the current main)

The two components (`preloop-deploy-wizard.ts`, `preloop-agent-deployer.ts`) carried two copies of the same ~150-line CSS block, so the same defects appear on both surfaces.

1. No step progress anywhere. 13 distinct screens, all labelled "Onboard Agents" plus an in-body title. Nothing says which step of how many.
2. Back appears in two places with two weights: a blue text button top left on the wizard steps, a default `sl-button` bottom right on the deployer steps.
3. Box inside a box. `.wizard-panel` paints `--sl-color-neutral-0` + a 1px border + `--sl-shadow-small` inside the already raised dialog panel, and `sl-alert`s and command blocks nest a third fill inside that. DESIGN.md caps depth at two.
4. Commands were clipped, not wrapped (`white-space: nowrap; overflow-x: auto`). At 390px the install line showed `export PRELOOP_URL=http://loca` and nothing else, with no visible scrollbar.
5. No single primary. Steps rendered full-width primary buttons (~940px wide inline).
6. Marketing type scale (`--sl-font-size-large` / `medium`) instead of the console scale (15 / 14 / 13 / 11).
7. Help text lived in placeholders, so it vanished on the first keystroke.
8. Choice cards read centred: `::part(base) { align-items: center }` against `text-align: left` in the body. Measured on the choose step: card x=360 w=350, inner body x=397 w=276, 37px of dead gutter on each side.
9. The result step buried the payload: body scrollHeight 1135 vs clientHeight 796 on desktop, 1390 vs 607 on mobile, and no summary of what had just been created.
10. Inconsistent field widths on the SSH step (full-width inputs plus a 2-column inner grid in the same form).
11. `renderSimulatedBoot()` inlined `#0f172a`, `#38bdf8`, `#4ade80` and referenced `animation: pulse 1s infinite` with no `@keyframes pulse` anywhere in the component.
12. A help dialog shipped a link to `file:///Users/dimo/git/spacecode/preloop-ee/README.md#...`, a path on a developer's laptop.

## What changed

- New `frontend/src/styles/deploy-wizard.ts`: one stylesheet for both surfaces, built on the console tokens.
- Step header on every screen: `STEP N` (or `STEP N OF M` once the path is known) plus a rail that fills as you advance, then the step title and one line of copy. Branch screens print `STEP N` with no total rather than inventing one.
- The deployer continues the wizard's count through a new `step-offset` attribute instead of restarting at step one when the wizard nests it.
- One primary per step, right aligned in an action bar with a hairline top border; Back is a text button on the left of the same bar. On phones the bar becomes a column with the primary on top and Back under it (DOM order keeps Back first for the keyboard).
- Depth back to two: `.wizard-panel` is gone, alerts became tinted `.notice` rows, and command blocks sit on `--console-page` (the one exception DESIGN.md allows, because a command is a literal thing to select).
- Commands wrap (`pre-wrap` + `overflow-wrap: anywhere`); the snippet gets `max-height: 15rem` with vertical scroll only.
- Choice cards are left-aligned console rows: fixed icon column, title, one line of meta, chevron, hairline border, no fill.
- Help text moved under the fields; placeholder-only guidance removed.
- Summaries before the irreversible action: "About to register" (custom agent), "About to deploy" (SSH), "About to provision" (VM).
- The provisioning log lost the inline hexes and the dead animation, gained `role="log" aria-live="polite"`, and ends in a single "View the connected agent" primary.
- The `file://` link is gone; the welcome heading uses the console H1 (26/600) in sentence case.

## Screenshots

26 before and 26 after captures at 1440x900 and 390x844 (deviceScaleFactor 2), plus 3 dark-theme checks. Files are on the machine that produced this PR:

| Step | Before | After |
| --- | --- | --- |
| Choose path (desktop) | `/tmp/preloop-reports/ux6-deploy-before-desktop-choose.png` | `/tmp/preloop-reports/ux6-deploy-after-desktop-choose.png` |
| Govern existing (desktop) | `...before-desktop-govern.png` | `...after-desktop-govern.png` |
| CLI install (desktop) | `...before-desktop-cli.png` | `...after-desktop-cli.png` |
| Custom name (desktop) | `...before-desktop-custom-name.png` | `...after-desktop-custom-name.png` |
| Custom models (desktop) | `...before-desktop-custom-models.png` | `...after-desktop-custom-models.png` |
| Custom result (desktop) | `...before-desktop-custom-result.png` | `...after-desktop-custom-result.png` |
| Deploy type (desktop) | `...before-desktop-deploy-type.png` | `...after-desktop-deploy-type.png` |
| Deployer host / method / ssh / cli / vm / boot (desktop) | `...before-desktop-deployer-*.png` | `...after-desktop-deployer-*.png` |
| All 13 steps (390x844) | `...before-mobile-*.png` | `...after-mobile-*.png` |

## Numbers

- Custom result step, dialog body scrollHeight: 1135 to 717 (desktop, clientHeight 717 so it no longer scrolls), 1390 to 876 (mobile).
- Horizontal overflow at 390px: every `.command-code` now has `scrollWidth <= clientWidth` on all 13 steps; before, the CLI and result commands overflowed inside a clipped box.
- Frontend suite: 169 files, 2085 passed, 0 failed (was 168 files, 2072 tests). `preloop-deploy-wizard.test.ts` 33 passed (28 before, 5 new), `preloop-agent-deployer.test.ts` 8 passed (new file, the component had no tests).
- `npx tsc --noEmit`: 108 errors before and 108 after, none in the touched files (pre-existing baseline).
- `npm run build`: passes. Total emitted JS 3,083,878 to 3,074,295 bytes (-9,583).
- Source: deployer 1177 to 994 lines, wizard 1625 to 1426 lines, plus 460 lines of shared CSS that used to be duplicated in both.

## Behaviour and contracts

No backend change, no new deployment option, no change to any event: `deploy-wizard-done`, `deploy-cancel`, `deploy-success`, `open-add-model`, the `initial-path` / `hide-back-button` / `hide-cancel` / `hide-step-title` attributes and the polling constants are untouched. The e2e-pinned surface is preserved verbatim: the `Connect a custom agent` card, `sl-input[name="display_name"]`, the `Register agent & mint credential` button, `Your agent is connected`, `shown only once`, the `.command-step` + `sl-copy-button` pairs keyed by `Gateway base URL` / `Gateway credential (api_key)` / `per-run session id`.

One copy string changed in a way a test asserted: "Waiting for the CLI - onboarded agents appear here automatically." lost its em dash and became two sentences; the wizard test was updated with it.

## Follow-ups (not in this PR)

1. The result screen still says "Your agent is connected" while it is in fact waiting for the agent's first request. The honest header is "Your agent is registered", but that string is pinned by `frontend/tests/e2e/custom-agent-session.spec.ts:196`, so changing it needs a coordinated spec update.
2. The two dialog labels ("Onboard Agents", "Deploy Governed Agent") stay static while the step header changes underneath. A dialog label that tracks the path would read better.
3. `preloop-agent-deployer` still simulates provisioning in the browser. Real progress needs a backend stream.


<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure frontend rebuild of the deploy/onboarding dialogs; no backend, API, or event-contract changes, and strong test coverage.
>
> **Overview**
> Rebuilds the deploy-new-agent wizard and the onboarding path onto the console idiom via a single shared stylesheet, adding step progress, a one-primary action bar, wrapped (non-clipping) command blocks, and pre-action summaries. Extensively covered by new and expanded component tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 695762f. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
