### PR TITLE
Resource actions: one registry by type and state, shared by lists and detail pages

### DIFF
--- a/frontend/src/actions/agent-actions.test.ts
+++ b/frontend/src/actions/agent-actions.test.ts
@@ -117,6 +117,12 @@ describe('agentActions', () => {
 
   it('keeps Remove last, outlined and set apart (DESIGN.md)', () => {
     const actions = agentActions(makeAgent(), rowCtx);
+    const decommission = actions.find(
+      (action) => action.id === 'decommission'
+    )!;
+    expect(decommission.separated).to.equal(true);
+    expect(decommission.variant).to.equal('danger');
+    expect(decommission.outline).to.equal(true);
     const remove = actions[actions.length - 1];
     expect(remove.id).to.equal('remove');
     expect(remove.variant).to.equal('danger');

--- a/frontend/src/actions/agent-actions.test.ts
+++ b/frontend/src/actions/agent-actions.test.ts
@@ -1,0 +1,152 @@
+import { expect } from '@open-wc/testing';
+import type { ManagedAgentSummary } from '../types';
+import { agentActions } from './agent-actions';
+import { actionIds, intersectActions } from './registry';
+
+function makeAgent(
+  overrides: Partial<ManagedAgentSummary> = {}
+): ManagedAgentSummary {
+  return {
+    id: 'agent-1',
+    runtime_session_id: 'session-1',
+    owner_user_id: null,
+    owner_username: null,
+    owner_email: null,
+    display_name: 'Alpha runner',
+    session_source_type: 'claude_code',
+    session_source_id: 'workspace-1',
+    session_reference: 'ref-1',
+    enrolled_via: 'runtime_session_token',
+    managed_mcp_servers: [],
+    lifecycle_state: 'active',
+    lifecycle_reason: null,
+    lifecycle_updated_at: null,
+    is_active_now: true,
+    activity_status: 'active_now',
+    last_seen_at: '2026-09-01T10:00:00Z',
+    started_at: null,
+    last_activity_at: null,
+    ended_at: null,
+    total_requests: 0,
+    estimated_cost: 0,
+    configured_model_alias: null,
+    latest_model_alias: null,
+    latest_provider_name: null,
+    last_request_at: null,
+    mcp_proxy_configured: true,
+    model_gateway_configured: true,
+    onboarding_state: 'fully_onboarded',
+    ...overrides,
+  } as ManagedAgentSummary;
+}
+
+/** Every handler a list row wires. */
+const rowCtx = {
+  onTalk: () => {},
+  onRename: () => {},
+  onEditTags: () => {},
+  onChangeOwner: () => {},
+  onLifecycle: () => {},
+  onRemove: () => {},
+};
+
+describe('agentActions', () => {
+  it('offers pause and decommission for a running agent', () => {
+    expect(actionIds(agentActions(makeAgent(), rowCtx))).to.deep.equal([
+      'rename',
+      'edit-tags',
+      'pause',
+      'decommission',
+      'remove',
+    ]);
+  });
+
+  it('offers resume instead of pause for a suspended agent', () => {
+    const ids = actionIds(
+      agentActions(makeAgent({ lifecycle_state: 'suspended' }), rowCtx)
+    );
+    expect(ids).to.contain('resume');
+    expect(ids).to.not.contain('pause');
+    expect(ids).to.contain('decommission');
+  });
+
+  it('never offers decommission twice for a decommissioned agent', () => {
+    const ids = actionIds(
+      agentActions(makeAgent({ lifecycle_state: 'decommissioned' }), rowCtx)
+    );
+    expect(ids).to.deep.equal(['rename', 'edit-tags', 'resume', 'remove']);
+  });
+
+  it('adds Change owner only where an owner can be chosen', () => {
+    expect(
+      actionIds(agentActions(makeAgent(), { ...rowCtx, canChangeOwner: true }))
+    ).to.contain('change-owner');
+    expect(actionIds(agentActions(makeAgent(), rowCtx))).to.not.contain(
+      'change-owner'
+    );
+  });
+
+  it('leads with Talk for an agent with Agent Control, disabled while offline', () => {
+    const connected = agentActions(
+      makeAgent({
+        control_state: 'plugin_connected',
+        control_enabled: true,
+        control_online: true,
+        control_capabilities: ['send_text_prompt'],
+      } as Partial<ManagedAgentSummary>),
+      rowCtx
+    );
+    expect(connected[0].id).to.equal('talk');
+    expect(connected[0].disabled).to.equal(false);
+
+    const pending = agentActions(
+      makeAgent({
+        control_state: 'install_pending',
+      } as Partial<ManagedAgentSummary>),
+      rowCtx
+    );
+    const talk = pending.find((action) => action.id === 'talk');
+    expect(talk, 'a pending install still says Talk, disabled').to.exist;
+    expect(talk!.disabled).to.equal(true);
+
+    expect(
+      actionIds(agentActions(makeAgent(), rowCtx)),
+      'a runtime without Agent Control gets no Talk'
+    ).to.not.contain('talk');
+  });
+
+  it('keeps Remove last, outlined and set apart (DESIGN.md)', () => {
+    const actions = agentActions(makeAgent(), rowCtx);
+    const remove = actions[actions.length - 1];
+    expect(remove.id).to.equal('remove');
+    expect(remove.variant).to.equal('danger');
+    expect(remove.outline).to.equal(true);
+    expect(remove.separated).to.equal(true);
+  });
+
+  it('offers only what a surface wired handlers for', () => {
+    expect(
+      actionIds(agentActions(makeAgent(), { onLifecycle: () => {} }))
+    ).to.deep.equal(['pause', 'decommission']);
+  });
+
+  it('offers a running and a stopped agent only their common actions', () => {
+    const running = agentActions(makeAgent({ id: 'a' }), rowCtx);
+    const stopped = agentActions(
+      makeAgent({ id: 'b', lifecycle_state: 'suspended' }),
+      rowCtx
+    );
+    expect(actionIds(intersectActions([running, stopped]))).to.deep.equal([
+      'rename',
+      'edit-tags',
+      'decommission',
+      'remove',
+    ]);
+  });
+
+  it('leaves two running agents every lifecycle move they share', () => {
+    const one = agentActions(makeAgent({ id: 'a' }), rowCtx);
+    const two = agentActions(makeAgent({ id: 'b' }), rowCtx);
+    expect(actionIds(intersectActions([one, two]))).to.contain('pause');
+  });
+});

--- a/frontend/src/actions/agent-actions.ts
+++ b/frontend/src/actions/agent-actions.ts
@@ -172,7 +172,8 @@ export function agentActions(
           : undefined,
       },
       // Decommission is the reversible offboard: credentials are revoked but
-      // the agent and its history stay. Remove deletes the record, so the two
+      // the agent and its history stay. The list set it apart from Pause and
+      // Resume with a gap (DESIGN.md). Remove deletes the record, so the two
       // are not the same action and both belong here.
       {
         id: 'decommission',
@@ -180,6 +181,7 @@ export function agentActions(
         icon: 'box-arrow-right',
         variant: 'danger',
         outline: true,
+        separated: true,
         loading: busy,
         available: (item) => item.lifecycle_state !== 'decommissioned',
         onClick: ctx.onLifecycle

--- a/frontend/src/actions/agent-actions.ts
+++ b/frontend/src/actions/agent-actions.ts
@@ -22,6 +22,44 @@ export const AGENT_LIFECYCLE_ACTION_IDS: Record<string, AgentLifecycleMove> = {
   decommission: 'decommission',
 };
 
+/**
+ * One wording per lifecycle move, so the confirmation an operator reads is
+ * the same on the agents list and on the agent page.
+ */
+export const AGENT_LIFECYCLE_WORDING: Record<
+  AgentLifecycleMove,
+  { title: string; verb: string; verbPast: string; detail: string }
+> = {
+  suspend: {
+    title: 'Pause',
+    verb: 'pause',
+    verbPast: 'paused',
+    detail:
+      'Requests are blocked while paused. Resume restores the agent without re-onboarding it.',
+  },
+  resume: {
+    title: 'Resume',
+    verb: 'resume',
+    verbPast: 'resumed',
+    detail: 'The existing credentials start working again immediately.',
+  },
+  decommission: {
+    title: 'Decommission',
+    verb: 'decommission',
+    verbPast: 'decommissioned',
+    detail:
+      "Decommissioning revokes the agent's runtime credentials. The agent and its history stay in the list, and resuming it restores its own unexpired keys.",
+  },
+};
+
+/** The audit reason the PATCH carries, naming where the move was made. */
+export function agentLifecycleReason(
+  move: AgentLifecycleMove,
+  surface: string
+): string {
+  return `Manually ${AGENT_LIFECYCLE_WORDING[move].verbPast} from ${surface}`;
+}
+
 export interface AgentActionContext extends ActionContext {
   /** True while a call for this agent is in flight. */
   busy?: boolean;

--- a/frontend/src/actions/agent-actions.ts
+++ b/frontend/src/actions/agent-actions.ts
@@ -1,0 +1,166 @@
+/**
+ * What a managed agent offers, by lifecycle state.
+ *
+ * The agents list and the agent page each kept their own array, and they
+ * drifted: the list offered Decommission, the page did not; Change owner
+ * needed a loaded user list in one place and only a feature flag in the
+ * other. Both now call this.
+ */
+import type { TemplateResult } from 'lit';
+import type { ManagedAgentSummary } from '../types';
+import { getAgentControlState } from '../utils/agent-control';
+import type { ResourceAction } from '../components/resource-actions';
+import { defineActions, type ActionContext } from './registry';
+
+/** The lifecycle moves an agent can be asked to make. */
+export type AgentLifecycleMove = 'suspend' | 'resume' | 'decommission';
+
+/** The action id each lifecycle move is offered under. */
+export const AGENT_LIFECYCLE_ACTION_IDS: Record<string, AgentLifecycleMove> = {
+  pause: 'suspend',
+  resume: 'resume',
+  decommission: 'decommission',
+};
+
+export interface AgentActionContext extends ActionContext {
+  /** True while a call for this agent is in flight. */
+  busy?: boolean;
+  /** `user_management` is on and there is somebody to hand the agent to. */
+  canChangeOwner?: boolean;
+  /**
+   * The agents table has no room for a Talk button per row, so its kebab
+   * carries the action; cards and the canvas draw their own button and would
+   * otherwise offer it twice.
+   */
+  onTalk?: (agent: ManagedAgentSummary) => void;
+  /** The agent page renders Talk as its own element instead. */
+  renderTalk?: (agent: ManagedAgentSummary) => TemplateResult;
+  onRename?: (agent: ManagedAgentSummary) => void;
+  onEditTags?: (agent: ManagedAgentSummary) => void;
+  onChangeOwner?: (agent: ManagedAgentSummary) => void;
+  onLifecycle?: (agent: ManagedAgentSummary, move: AgentLifecycleMove) => void;
+  onRemove?: (agent: ManagedAgentSummary) => void;
+}
+
+/** Paused or offboarded: the states Resume applies to. */
+export function isAgentStopped(agent: ManagedAgentSummary): boolean {
+  return (
+    agent.lifecycle_state === 'suspended' ||
+    agent.lifecycle_state === 'decommissioned'
+  );
+}
+
+export function agentActions(
+  agent: ManagedAgentSummary,
+  ctx: AgentActionContext = {}
+): ResourceAction[] {
+  const control = getAgentControlState(agent);
+  const busy = ctx.busy === true;
+
+  return defineActions(
+    agent,
+    [
+      // Talk leads: it is what people come to an agent for.
+      control.visible && ctx.renderTalk
+        ? {
+            id: 'talk',
+            label: 'Talk',
+            render: () => ctx.renderTalk!(agent),
+          }
+        : control.visible && ctx.onTalk
+          ? {
+              id: 'talk',
+              label: 'Talk',
+              icon: 'chat-dots',
+              disabled: false,
+              // Runs inside the click handler, so the window still opens on
+              // the user gesture.
+              onClick: () => ctx.onTalk!(agent),
+              available: () => getAgentControlState(agent).enabled,
+              visibleWhenUnavailable: true,
+              unavailableTooltip: control.detail,
+            }
+          : null,
+      {
+        id: 'rename',
+        label: 'Rename',
+        icon: 'pencil',
+        loading: busy,
+        onClick: ctx.onRename ? () => ctx.onRename!(agent) : undefined,
+      },
+      {
+        id: 'edit-tags',
+        label: 'Edit tags',
+        icon: 'tags',
+        loading: busy,
+        onClick: ctx.onEditTags ? () => ctx.onEditTags!(agent) : undefined,
+      },
+      {
+        id: 'change-owner',
+        label: 'Change owner',
+        icon: 'person-gear',
+        loading: busy,
+        available: () => ctx.canChangeOwner === true,
+        onClick: ctx.onChangeOwner
+          ? () => ctx.onChangeOwner!(agent)
+          : undefined,
+      },
+      // Pause is an everyday, reversible control, so it stays neutral: amber
+      // read as a warning next to Talk and pulled the eye away from it.
+      {
+        id: 'pause',
+        label: 'Pause',
+        icon: 'pause-fill',
+        variant: 'default',
+        loading: busy,
+        tooltip:
+          'Pause this agent. Requests are blocked while paused; Resume restores it without re-onboarding.',
+        available: (item) => !isAgentStopped(item),
+        onClick: ctx.onLifecycle
+          ? () => ctx.onLifecycle!(agent, 'suspend')
+          : undefined,
+      },
+      {
+        id: 'resume',
+        label: 'Resume',
+        icon: 'play-fill',
+        variant: 'success',
+        loading: busy,
+        tooltip:
+          'Resume this agent. Its existing credentials start working again immediately.',
+        available: (item) => isAgentStopped(item),
+        onClick: ctx.onLifecycle
+          ? () => ctx.onLifecycle!(agent, 'resume')
+          : undefined,
+      },
+      // Decommission is the reversible offboard: credentials are revoked but
+      // the agent and its history stay. Remove deletes the record, so the two
+      // are not the same action and both belong here.
+      {
+        id: 'decommission',
+        label: 'Decommission',
+        icon: 'box-arrow-right',
+        variant: 'danger',
+        outline: true,
+        loading: busy,
+        available: (item) => item.lifecycle_state !== 'decommissioned',
+        onClick: ctx.onLifecycle
+          ? () => ctx.onLifecycle!(agent, 'decommission')
+          : undefined,
+      },
+      // Last, outlined, after a gap (DESIGN.md "Destructive actions"): the
+      // one action here that cannot be undone.
+      {
+        id: 'remove',
+        label: 'Remove',
+        icon: 'trash',
+        variant: 'danger',
+        outline: true,
+        separated: true,
+        loading: busy,
+        onClick: ctx.onRemove ? () => ctx.onRemove!(agent) : undefined,
+      },
+    ],
+    ctx
+  );
+}

--- a/frontend/src/actions/approval-actions.test.ts
+++ b/frontend/src/actions/approval-actions.test.ts
@@ -1,0 +1,99 @@
+import { expect } from '@open-wc/testing';
+import type { ApprovalRequest } from '../types';
+import { approvalActions, isDecidableRequest } from './approval-actions';
+import { actionIds, intersectActions } from './registry';
+
+const NOW = Date.parse('2026-09-07T12:00:00Z');
+
+function makeRequest(
+  overrides: Partial<ApprovalRequest> = {}
+): ApprovalRequest {
+  return {
+    id: 'req-1',
+    account_id: 'acc-1',
+    tool_configuration_id: 'tool-1',
+    approval_workflow_id: 'wf-1',
+    execution_id: null,
+    tool_name: 'github.create_pr',
+    tool_args: {},
+    agent_reasoning: null,
+    status: 'pending',
+    requested_at: '2026-09-07T11:59:00Z',
+    resolved_at: null,
+    expires_at: '2026-09-07T12:05:00Z',
+    approver_comment: null,
+    ...overrides,
+  } as ApprovalRequest;
+}
+
+const ctx = {
+  now: NOW,
+  includeDetails: true,
+  onApprove: () => {},
+  onDeny: () => {},
+};
+
+describe('approvalActions', () => {
+  it('offers Approve and Deny on a pending, unexpired request', () => {
+    expect(actionIds(approvalActions(makeRequest(), ctx))).to.deep.equal([
+      'approve',
+      'deny',
+      'details',
+    ]);
+  });
+
+  it('offers no decision once the request expired', () => {
+    expect(
+      actionIds(
+        approvalActions(
+          makeRequest({ expires_at: '2026-09-07T11:00:00Z' }),
+          ctx
+        )
+      )
+    ).to.deep.equal(['details']);
+  });
+
+  it('offers no decision on a request already decided', () => {
+    for (const status of ['approved', 'declined', 'expired', 'cancelled']) {
+      expect(
+        actionIds(
+          approvalActions(
+            makeRequest({ status: status as ApprovalRequest['status'] }),
+            ctx
+          )
+        ),
+        status
+      ).to.deep.equal(['details']);
+    }
+  });
+
+  it('leaves a question to its answer panel', () => {
+    expect(
+      actionIds(approvalActions(makeRequest({ is_question: true }), ctx))
+    ).to.deep.equal(['details']);
+  });
+
+  it('names the link for what the row is for', () => {
+    const waiting = approvalActions(makeRequest(), ctx);
+    expect(waiting.find((a) => a.id === 'details')!.label).to.equal('Details');
+    const settled = approvalActions(makeRequest({ status: 'approved' }), ctx);
+    expect(settled.find((a) => a.id === 'details')!.label).to.equal('View');
+  });
+
+  it('treats a pending request with no expiry as decidable', () => {
+    expect(isDecidableRequest(makeRequest({ expires_at: null }), NOW)).to.equal(
+      true
+    );
+  });
+
+  it('offers a waiting and a decided request only the link', () => {
+    const waiting = approvalActions(makeRequest({ id: 'a' }), ctx);
+    const decided = approvalActions(
+      makeRequest({ id: 'b', status: 'approved' }),
+      ctx
+    );
+    expect(actionIds(intersectActions([waiting, decided]))).to.deep.equal([
+      'details',
+    ]);
+  });
+});

--- a/frontend/src/actions/approval-actions.ts
+++ b/frontend/src/actions/approval-actions.ts
@@ -1,0 +1,87 @@
+/**
+ * What an approval request offers, by status and expiry.
+ *
+ * The list row, the bulk bar and the request page each spelled out "pending,
+ * not expired, not a question" in their own words. The predicate lives here
+ * now; the surfaces keep their own rendering (the request page decides with a
+ * comment box and an "always allow" checkbox, which is a form, not a button
+ * row) but they all ask this module what is on offer.
+ */
+import type { ApprovalRequest } from '../types';
+import { isUnexpiredPendingRequest } from '../utils/approvals';
+import type { ResourceAction } from '../components/resource-actions';
+import { defineActions, type ActionContext } from './registry';
+
+export interface ApprovalActionContext extends ActionContext {
+  /** True while this request's decision is being posted. */
+  busy?: boolean;
+  /** Re-read at click time, so a row cannot decide a request that expired. */
+  now?: number;
+  onApprove?: (request: ApprovalRequest) => void;
+  onDeny?: (request: ApprovalRequest) => void;
+  /** List rows link to the request page; the page itself does not. */
+  includeDetails?: boolean;
+}
+
+/** A question is answered in its own panel, not approved or denied. */
+export function isApprovalQuestion(request: ApprovalRequest): boolean {
+  return request.is_question === true;
+}
+
+/** Pending, unexpired and not a question: the requests a person can decide. */
+export function isDecidableRequest(
+  request: ApprovalRequest,
+  now: number = Date.now()
+): boolean {
+  return (
+    isUnexpiredPendingRequest(request, now) && !isApprovalQuestion(request)
+  );
+}
+
+export function approvalDetailUrl(request: ApprovalRequest): string {
+  return `/console/approval/${encodeURIComponent(request.id)}`;
+}
+
+export function approvalActions(
+  request: ApprovalRequest,
+  ctx: ApprovalActionContext = {}
+): ResourceAction[] {
+  const now = ctx.now ?? Date.now();
+  const busy = ctx.busy === true;
+  return defineActions(
+    request,
+    [
+      {
+        id: 'approve',
+        label: 'Approve',
+        icon: 'check-lg',
+        variant: 'success',
+        loading: busy,
+        disabled: busy,
+        available: (item) => isDecidableRequest(item, now),
+        onClick: ctx.onApprove ? () => ctx.onApprove!(request) : undefined,
+      },
+      // Denying stops the agent, so it confirms first (DESIGN.md).
+      {
+        id: 'deny',
+        label: 'Deny',
+        icon: 'x-lg',
+        variant: 'danger',
+        outline: true,
+        disabled: busy,
+        available: (item) => isDecidableRequest(item, now),
+        onClick: ctx.onDeny ? () => ctx.onDeny!(request) : undefined,
+      },
+      ctx.includeDetails
+        ? {
+            id: 'details',
+            // A waiting request is opened to decide it, a settled one to read
+            // it, and the link says which.
+            label: isUnexpiredPendingRequest(request, now) ? 'Details' : 'View',
+            href: approvalDetailUrl(request),
+          }
+        : null,
+    ],
+    ctx
+  );
+}

--- a/frontend/src/actions/flow-actions.test.ts
+++ b/frontend/src/actions/flow-actions.test.ts
@@ -16,13 +16,10 @@ describe('flowActions', () => {
       'open',
       'run-now',
       'edit',
-      'toggle-enabled',
+      'pause',
       'delete',
     ]);
     expect(actions.find((a) => a.id === 'run-now')!.disabled).to.equal(false);
-    expect(actions.find((a) => a.id === 'toggle-enabled')!.label).to.equal(
-      'Pause'
-    );
   });
 
   it('keeps Run now visible but disabled on a paused flow', () => {
@@ -30,9 +27,8 @@ describe('flowActions', () => {
     const run = actions.find((action) => action.id === 'run-now')!;
     expect(run.disabled).to.equal(true);
     expect(run.tooltip).to.equal('Resume the flow before running it');
-    expect(actions.find((a) => a.id === 'toggle-enabled')!.label).to.equal(
-      'Resume'
-    );
+    expect(actionIds(actions)).to.contain('resume');
+    expect(actionIds(actions)).to.not.contain('pause');
   });
 
   it('links Edit to the flow page in edit mode when no handler is wired', () => {
@@ -65,11 +61,11 @@ describe('flowActions', () => {
   it('offers a paused and a running flow only their common actions', () => {
     const running = flowActions({ id: 'a', is_enabled: true }, ctx);
     const paused = flowActions({ id: 'b', is_enabled: false }, ctx);
-    // Run now survives nothing: it is disabled on the paused flow.
+    // Run now is disabled on the paused flow, and neither Pause nor Resume
+    // suits both, so only what they truly share is left.
     expect(actionIds(intersectActions([running, paused]))).to.deep.equal([
       'open',
       'edit',
-      'toggle-enabled',
       'delete',
     ]);
   });

--- a/frontend/src/actions/flow-actions.test.ts
+++ b/frontend/src/actions/flow-actions.test.ts
@@ -1,0 +1,76 @@
+import { expect } from '@open-wc/testing';
+import { flowActions } from './flow-actions';
+import { actionIds, intersectActions } from './registry';
+
+const ctx = {
+  includeOpen: true,
+  onRun: () => {},
+  onToggleEnabled: () => {},
+  onDelete: () => {},
+};
+
+describe('flowActions', () => {
+  it('offers Run now on an enabled flow', () => {
+    const actions = flowActions({ id: 'f1', is_enabled: true }, ctx);
+    expect(actionIds(actions)).to.deep.equal([
+      'open',
+      'run-now',
+      'edit',
+      'toggle-enabled',
+      'delete',
+    ]);
+    expect(actions.find((a) => a.id === 'run-now')!.disabled).to.equal(false);
+    expect(actions.find((a) => a.id === 'toggle-enabled')!.label).to.equal(
+      'Pause'
+    );
+  });
+
+  it('keeps Run now visible but disabled on a paused flow', () => {
+    const actions = flowActions({ id: 'f1', is_enabled: false }, ctx);
+    const run = actions.find((action) => action.id === 'run-now')!;
+    expect(run.disabled).to.equal(true);
+    expect(run.tooltip).to.equal('Resume the flow before running it');
+    expect(actions.find((a) => a.id === 'toggle-enabled')!.label).to.equal(
+      'Resume'
+    );
+  });
+
+  it('links Edit to the flow page in edit mode when no handler is wired', () => {
+    const [edit] = flowActions({ id: 'f 1', is_enabled: true }, {}).filter(
+      (action) => action.id === 'edit'
+    );
+    expect(edit.href).to.equal('/console/flows/f%201?edit=true');
+  });
+
+  it('drops Open on the flow page itself', () => {
+    expect(
+      actionIds(
+        flowActions(
+          { id: 'f1', is_enabled: true },
+          { ...ctx, includeOpen: false }
+        )
+      )
+    ).to.not.contain('open');
+  });
+
+  it('keeps Delete last, outlined and set apart', () => {
+    const actions = flowActions({ id: 'f1', is_enabled: true }, ctx);
+    const remove = actions[actions.length - 1];
+    expect(remove.id).to.equal('delete');
+    expect(remove.variant).to.equal('danger');
+    expect(remove.outline).to.equal(true);
+    expect(remove.separated).to.equal(true);
+  });
+
+  it('offers a paused and a running flow only their common actions', () => {
+    const running = flowActions({ id: 'a', is_enabled: true }, ctx);
+    const paused = flowActions({ id: 'b', is_enabled: false }, ctx);
+    // Run now survives nothing: it is disabled on the paused flow.
+    expect(actionIds(intersectActions([running, paused]))).to.deep.equal([
+      'open',
+      'edit',
+      'toggle-enabled',
+      'delete',
+    ]);
+  });
+});

--- a/frontend/src/actions/flow-actions.ts
+++ b/frontend/src/actions/flow-actions.ts
@@ -1,0 +1,96 @@
+/**
+ * What a flow offers, by enabled state.
+ *
+ * The list called the same two actions `run-now` and `edit`; the flow page
+ * called them `test-run` and `edit-flow`, so nothing could line them up and
+ * the flow page could not delete the flow it was showing. One declaration,
+ * one set of ids.
+ */
+import type { ResourceAction } from '../components/resource-actions';
+import { defineActions, type ActionContext } from './registry';
+
+/** The little a flow action needs to know, from a list row or a full flow. */
+export interface FlowActionResource {
+  id: string;
+  name?: string;
+  /** False means paused: the flow exists but no trigger starts it. */
+  is_enabled: boolean;
+}
+
+export interface FlowActionContext extends ActionContext {
+  /** True while a call for this flow is in flight. */
+  busy?: boolean;
+  /** Offered on a list row, where the flow page is somewhere else. */
+  includeOpen?: boolean;
+  onRun?: (flow: FlowActionResource) => void;
+  onToggleEnabled?: (flow: FlowActionResource) => void;
+  onDelete?: (flow: FlowActionResource) => void;
+  /** The flow page edits in place; the list links to the page in edit mode. */
+  onEdit?: (flow: FlowActionResource) => void;
+}
+
+export function flowDetailUrl(flow: FlowActionResource): string {
+  return `/console/flows/${encodeURIComponent(flow.id)}`;
+}
+
+export function flowActions(
+  flow: FlowActionResource,
+  ctx: FlowActionContext = {}
+): ResourceAction[] {
+  const busy = ctx.busy === true;
+  return defineActions(
+    flow,
+    [
+      ctx.includeOpen
+        ? {
+            id: 'open',
+            label: 'Open',
+            icon: 'box-arrow-up-right',
+            href: flowDetailUrl(flow),
+          }
+        : null,
+      // Paused keeps Run now on screen, disabled: an operator who paused the
+      // flow this morning should read why it cannot run, not hunt for a
+      // button that quietly left.
+      {
+        id: 'run-now',
+        label: 'Run now',
+        icon: 'play-circle',
+        variant: 'primary',
+        loading: busy,
+        disabled: busy,
+        available: (item) => item.is_enabled,
+        visibleWhenUnavailable: true,
+        unavailableTooltip: 'Resume the flow before running it',
+        onClick: ctx.onRun ? () => ctx.onRun!(flow) : undefined,
+      },
+      {
+        id: 'edit',
+        label: 'Edit',
+        icon: 'pencil',
+        href: ctx.onEdit ? undefined : `${flowDetailUrl(flow)}?edit=true`,
+        onClick: ctx.onEdit ? () => ctx.onEdit!(flow) : undefined,
+      },
+      {
+        id: 'toggle-enabled',
+        label: flow.is_enabled ? 'Pause' : 'Resume',
+        icon: flow.is_enabled ? 'pause-circle' : 'play-circle',
+        variant: flow.is_enabled ? 'default' : 'success',
+        loading: busy,
+        onClick: ctx.onToggleEnabled
+          ? () => ctx.onToggleEnabled!(flow)
+          : undefined,
+      },
+      {
+        id: 'delete',
+        label: 'Delete',
+        icon: 'trash',
+        variant: 'danger',
+        outline: true,
+        separated: true,
+        onClick: ctx.onDelete ? () => ctx.onDelete!(flow) : undefined,
+      },
+    ],
+    ctx
+  );
+}

--- a/frontend/src/actions/flow-actions.ts
+++ b/frontend/src/actions/flow-actions.ts
@@ -71,12 +71,26 @@ export function flowActions(
         href: ctx.onEdit ? undefined : `${flowDetailUrl(flow)}?edit=true`,
         onClick: ctx.onEdit ? () => ctx.onEdit!(flow) : undefined,
       },
+      // Two ids, not one toggle: a bulk bar over a mixed selection can then
+      // say honestly that neither Pause nor Resume suits all of them.
       {
-        id: 'toggle-enabled',
-        label: flow.is_enabled ? 'Pause' : 'Resume',
-        icon: flow.is_enabled ? 'pause-circle' : 'play-circle',
-        variant: flow.is_enabled ? 'default' : 'success',
+        id: 'pause',
+        label: 'Pause',
+        icon: 'pause-circle',
+        variant: 'default',
         loading: busy,
+        available: (item) => item.is_enabled,
+        onClick: ctx.onToggleEnabled
+          ? () => ctx.onToggleEnabled!(flow)
+          : undefined,
+      },
+      {
+        id: 'resume',
+        label: 'Resume',
+        icon: 'play-circle',
+        variant: 'success',
+        loading: busy,
+        available: (item) => !item.is_enabled,
         onClick: ctx.onToggleEnabled
           ? () => ctx.onToggleEnabled!(flow)
           : undefined,

--- a/frontend/src/actions/flow-actions.ts
+++ b/frontend/src/actions/flow-actions.ts
@@ -33,6 +33,20 @@ export function flowDetailUrl(flow: FlowActionResource): string {
   return `/console/flows/${encodeURIComponent(flow.id)}`;
 }
 
+/**
+ * The ids the flows bulk bar can run. Edit is a per-row link with an href
+ * fallback, so it is always wired and would otherwise survive intersection
+ * even though the bar has no handler for it.
+ */
+export const FLOW_BULK_ACTION_IDS: Record<
+  string,
+  'pause' | 'resume' | 'delete'
+> = {
+  pause: 'pause',
+  resume: 'resume',
+  delete: 'delete',
+};
+
 export function flowActions(
   flow: FlowActionResource,
   ctx: FlowActionContext = {}

--- a/frontend/src/actions/flow-execution-actions.test.ts
+++ b/frontend/src/actions/flow-execution-actions.test.ts
@@ -43,6 +43,16 @@ describe('flowExecutionActions', () => {
     ).to.not.contain('open-session');
   });
 
+  it('lets a surface say where Open session goes', () => {
+    const actions = flowExecutionActions(
+      { id: 'e1', status: 'SUCCEEDED', agent_session_reference: 'sess-1' },
+      { ...ctx, sessionHref: (item) => `/runs/${item.id}?tab=transcript` }
+    );
+    expect(actions.find((a) => a.id === 'open-session')!.href).to.equal(
+      '/runs/e1?tab=transcript'
+    );
+  });
+
   it('offers View flow on the execution page only, and only with a flow', () => {
     expect(
       actionIds(

--- a/frontend/src/actions/flow-execution-actions.test.ts
+++ b/frontend/src/actions/flow-execution-actions.test.ts
@@ -1,0 +1,72 @@
+import { expect } from '@open-wc/testing';
+import { flowExecutionActions } from './flow-execution-actions';
+import { actionIds, intersectActions } from './registry';
+
+const ctx = {
+  includeOpen: true,
+  onCancel: () => {},
+  onRetry: () => {},
+};
+
+describe('flowExecutionActions', () => {
+  it('offers Cancel run while the run is going, and no retry', () => {
+    const ids = actionIds(
+      flowExecutionActions({ id: 'e1', status: 'RUNNING' }, ctx)
+    );
+    expect(ids).to.deep.equal(['open', 'cancel']);
+  });
+
+  it('offers Retry run on a failed run, and no cancel', () => {
+    for (const status of ['FAILED', 'STOPPED', 'TIMEOUT', 'CANCELLED']) {
+      const ids = actionIds(flowExecutionActions({ id: 'e1', status }, ctx));
+      expect(ids, status).to.deep.equal(['open', 'retry']);
+    }
+  });
+
+  it('offers neither on a run that succeeded', () => {
+    expect(
+      actionIds(flowExecutionActions({ id: 'e1', status: 'SUCCEEDED' }, ctx))
+    ).to.deep.equal(['open']);
+  });
+
+  it('offers Open session only for a run that opened one', () => {
+    const withSession = flowExecutionActions(
+      { id: 'e1', status: 'SUCCEEDED', agent_session_reference: 'sess-1' },
+      ctx
+    );
+    expect(actionIds(withSession)).to.contain('open-session');
+    expect(
+      withSession.find((action) => action.id === 'open-session')!.href
+    ).to.equal('/console/runtime-sessions?query=e1');
+    expect(
+      actionIds(flowExecutionActions({ id: 'e1', status: 'SUCCEEDED' }, ctx))
+    ).to.not.contain('open-session');
+  });
+
+  it('offers View flow on the execution page only, and only with a flow', () => {
+    expect(
+      actionIds(
+        flowExecutionActions(
+          { id: 'e1', status: 'SUCCEEDED', flow_id: 'flow-1' },
+          { ...ctx, includeOpen: false, includeViewFlow: true }
+        )
+      )
+    ).to.deep.equal(['view-flow']);
+    expect(
+      actionIds(
+        flowExecutionActions(
+          { id: 'e1', status: 'SUCCEEDED' },
+          { ...ctx, includeOpen: false, includeViewFlow: true }
+        )
+      )
+    ).to.deep.equal([]);
+  });
+
+  it('offers a running and a failed run only their common actions', () => {
+    const running = flowExecutionActions({ id: 'a', status: 'RUNNING' }, ctx);
+    const failed = flowExecutionActions({ id: 'b', status: 'FAILED' }, ctx);
+    expect(actionIds(intersectActions([running, failed]))).to.deep.equal([
+      'open',
+    ]);
+  });
+});

--- a/frontend/src/actions/flow-execution-actions.ts
+++ b/frontend/src/actions/flow-execution-actions.ts
@@ -32,6 +32,12 @@ export interface FlowExecutionActionContext extends ActionContext {
   includeOpen?: boolean;
   /** Offered on the execution page, which knows which flow it belongs to. */
   includeViewFlow?: boolean;
+  /**
+   * Where "Open session" goes. The execution page sends the operator to the
+   * session record in the sessions list; a list row sends them to the run's
+   * own transcript, which is the same conversation one page closer.
+   */
+  sessionHref?: (execution: FlowExecutionActionResource) => string;
   onCancel?: (execution: FlowExecutionActionResource) => void;
   onRetry?: (execution: FlowExecutionActionResource) => void;
 }
@@ -90,7 +96,9 @@ export function flowExecutionActions(
         label: 'Open session',
         icon: 'chat-left-text',
         available: (item) => Boolean(item.agent_session_reference),
-        href: executionSessionUrl(execution),
+        href: ctx.sessionHref
+          ? ctx.sessionHref(execution)
+          : executionSessionUrl(execution),
       },
       ctx.includeViewFlow
         ? {

--- a/frontend/src/actions/flow-execution-actions.ts
+++ b/frontend/src/actions/flow-execution-actions.ts
@@ -1,0 +1,121 @@
+/**
+ * What a flow execution offers, by run status.
+ *
+ * The list and the execution page each carried their own copy of the retry
+ * predicate and their own labels ("Retry run" against "Retry"), and the list
+ * offered Open session on runs that never had one, which lands on a search
+ * with no results.
+ */
+import type { ResourceAction } from '../components/resource-actions';
+import { RUNNING_STATUSES } from '../utils/execution';
+import { defineActions, type ActionContext } from './registry';
+
+/** Statuses the retry endpoint accepts. */
+export const RETRYABLE_EXECUTION_STATUSES = new Set([
+  'FAILED',
+  'STOPPED',
+  'TIMEOUT',
+  'CANCELLED',
+]);
+
+export interface FlowExecutionActionResource {
+  id: string;
+  status: string;
+  /** Set once the run opened a runtime session worth linking to. */
+  agent_session_reference?: string | null;
+  flow_id?: string | null;
+}
+
+export interface FlowExecutionActionContext extends ActionContext {
+  busy?: boolean;
+  /** Offered on a list row, where the execution page is somewhere else. */
+  includeOpen?: boolean;
+  /** Offered on the execution page, which knows which flow it belongs to. */
+  includeViewFlow?: boolean;
+  onCancel?: (execution: FlowExecutionActionResource) => void;
+  onRetry?: (execution: FlowExecutionActionResource) => void;
+}
+
+export function isExecutionRunning(
+  execution: FlowExecutionActionResource
+): boolean {
+  return RUNNING_STATUSES.has(execution.status);
+}
+
+export function canRetryExecution(
+  execution: FlowExecutionActionResource
+): boolean {
+  return RETRYABLE_EXECUTION_STATUSES.has(execution.status);
+}
+
+export function executionDetailUrl(
+  execution: FlowExecutionActionResource
+): string {
+  return `/console/flows/executions/${encodeURIComponent(execution.id)}`;
+}
+
+/** The session this run opened, found by id in the sessions list. */
+export function executionSessionUrl(
+  execution: FlowExecutionActionResource
+): string {
+  return `/console/runtime-sessions?query=${encodeURIComponent(execution.id)}`;
+}
+
+export function flowExecutionActions(
+  execution: FlowExecutionActionResource,
+  ctx: FlowExecutionActionContext = {}
+): ResourceAction[] {
+  const busy = ctx.busy === true;
+  return defineActions(
+    execution,
+    [
+      ctx.includeOpen
+        ? {
+            id: 'open',
+            label: 'Open',
+            icon: 'box-arrow-up-right',
+            href: executionDetailUrl(execution),
+          }
+        : null,
+      {
+        id: 'retry',
+        label: 'Retry run',
+        icon: 'arrow-repeat',
+        loading: busy,
+        available: canRetryExecution,
+        onClick: ctx.onRetry ? () => ctx.onRetry!(execution) : undefined,
+      },
+      {
+        id: 'open-session',
+        label: 'Open session',
+        icon: 'chat-left-text',
+        available: (item) => Boolean(item.agent_session_reference),
+        href: executionSessionUrl(execution),
+      },
+      ctx.includeViewFlow
+        ? {
+            id: 'view-flow',
+            label: 'View flow',
+            icon: 'diagram-3',
+            available: (item) => Boolean(item.flow_id),
+            href: `/console/flows/${encodeURIComponent(
+              execution.flow_id || ''
+            )}`,
+          }
+        : null,
+      // Stopping a run destroys work in progress, so it is destructive and
+      // sits apart from the everyday actions.
+      {
+        id: 'cancel',
+        label: 'Cancel run',
+        icon: 'x-circle',
+        variant: 'danger',
+        outline: true,
+        separated: true,
+        available: isExecutionRunning,
+        onClick: ctx.onCancel ? () => ctx.onCancel!(execution) : undefined,
+      },
+    ],
+    ctx
+  );
+}

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -1,0 +1,74 @@
+/**
+ * One entry point for "what can this resource do?".
+ *
+ * A list row calls `actionsFor('agent', row, ctx)`, the bulk bar calls it for
+ * every selected row and intersects the results, and the detail page calls it
+ * with the same type. Adding a type is adding a module and a line here.
+ */
+import type { ResourceAction } from '../components/resource-actions';
+import type { ApprovalRequest, ManagedAgentSummary } from '../types';
+import { agentActions, type AgentActionContext } from './agent-actions';
+import {
+  flowActions,
+  type FlowActionContext,
+  type FlowActionResource,
+} from './flow-actions';
+import {
+  flowExecutionActions,
+  type FlowExecutionActionContext,
+  type FlowExecutionActionResource,
+} from './flow-execution-actions';
+import {
+  runtimeSessionActions,
+  type RuntimeSessionActionContext,
+  type RuntimeSessionActionResource,
+} from './runtime-session-actions';
+import {
+  approvalActions,
+  type ApprovalActionContext,
+} from './approval-actions';
+
+/** The types that declare their actions in `src/actions/`. */
+export interface ResourceActionTypes {
+  agent: { resource: ManagedAgentSummary; ctx: AgentActionContext };
+  flow: { resource: FlowActionResource; ctx: FlowActionContext };
+  'flow-execution': {
+    resource: FlowExecutionActionResource;
+    ctx: FlowExecutionActionContext;
+  };
+  'runtime-session': {
+    resource: RuntimeSessionActionResource;
+    ctx: RuntimeSessionActionContext;
+  };
+  approval: { resource: ApprovalRequest; ctx: ApprovalActionContext };
+}
+
+export type ResourceType = keyof ResourceActionTypes;
+
+const REGISTRY: {
+  [K in ResourceType]: (
+    resource: ResourceActionTypes[K]['resource'],
+    ctx: ResourceActionTypes[K]['ctx']
+  ) => ResourceAction[];
+} = {
+  agent: agentActions,
+  flow: flowActions,
+  'flow-execution': flowExecutionActions,
+  'runtime-session': runtimeSessionActions,
+  approval: approvalActions,
+};
+
+export function actionsFor<K extends ResourceType>(
+  type: K,
+  resource: ResourceActionTypes[K]['resource'],
+  ctx: ResourceActionTypes[K]['ctx'] = {}
+): ResourceAction[] {
+  return REGISTRY[type](resource, ctx);
+}
+
+export * from './registry';
+export * from './agent-actions';
+export * from './flow-actions';
+export * from './flow-execution-actions';
+export * from './runtime-session-actions';
+export * from './approval-actions';

--- a/frontend/src/actions/registry.test.ts
+++ b/frontend/src/actions/registry.test.ts
@@ -1,0 +1,171 @@
+import { expect } from '@open-wc/testing';
+import {
+  actionIds,
+  defineActions,
+  intersectActions,
+  offersAction,
+} from './registry';
+
+interface Thing {
+  state: 'running' | 'stopped';
+}
+
+const noop = () => {};
+
+describe('defineActions', () => {
+  it('drops actions the state does not allow', () => {
+    const actions = defineActions({ state: 'stopped' } as Thing, [
+      {
+        id: 'stop',
+        label: 'Stop',
+        available: (t) => t.state === 'running',
+        onClick: noop,
+      },
+      {
+        id: 'start',
+        label: 'Start',
+        available: (t) => t.state === 'stopped',
+        onClick: noop,
+      },
+      { id: 'rename', label: 'Rename', onClick: noop },
+    ]);
+    expect(actionIds(actions)).to.deep.equal(['start', 'rename']);
+  });
+
+  it('keeps a visibleWhenUnavailable action disabled with its tooltip', () => {
+    const [action] = defineActions({ state: 'stopped' } as Thing, [
+      {
+        id: 'run',
+        label: 'Run now',
+        available: (t) => t.state === 'running',
+        visibleWhenUnavailable: true,
+        unavailableTooltip: 'Resume it first',
+        onClick: noop,
+      },
+    ]);
+    expect(action.id).to.equal('run');
+    expect(action.disabled).to.equal(true);
+    expect(action.tooltip).to.equal('Resume it first');
+  });
+
+  it('drops an action no surface wired a handler for', () => {
+    const actions = defineActions({ state: 'running' } as Thing, [
+      { id: 'talk', label: 'Talk' },
+      { id: 'open', label: 'Open', href: '/somewhere' },
+    ]);
+    expect(actionIds(actions)).to.deep.equal(['open']);
+  });
+
+  it('moves destructive actions to the end whatever the declared order', () => {
+    const actions = defineActions({ state: 'running' } as Thing, [
+      { id: 'remove', label: 'Remove', separated: true, onClick: noop },
+      { id: 'rename', label: 'Rename', onClick: noop },
+    ]);
+    expect(actionIds(actions)).to.deep.equal(['rename', 'remove']);
+  });
+
+  it('skips falsy candidates so surfaces can opt out inline', () => {
+    const actions = defineActions({ state: 'running' } as Thing, [
+      null,
+      false,
+      undefined,
+      { id: 'rename', label: 'Rename', onClick: noop },
+    ]);
+    expect(actionIds(actions)).to.deep.equal(['rename']);
+  });
+
+  it('hides actions the operator has no permission for', () => {
+    const candidates = [
+      {
+        id: 'remove',
+        label: 'Remove',
+        permission: 'manage_agents',
+        onClick: noop,
+      },
+      { id: 'view', label: 'View', href: '/x' },
+    ];
+    expect(
+      actionIds(
+        defineActions({ state: 'running' } as Thing, candidates, {
+          permissions: ['view_agents'],
+        })
+      )
+    ).to.deep.equal(['view']);
+    // RBAC off (null permissions) is unrestricted.
+    expect(
+      actionIds(
+        defineActions({ state: 'running' } as Thing, candidates, {
+          permissions: null,
+        })
+      )
+    ).to.deep.equal(['remove', 'view']);
+  });
+
+  it('explains a permission it keeps on screen', () => {
+    const [action] = defineActions(
+      { state: 'running' } as Thing,
+      [
+        {
+          id: 'remove',
+          label: 'Remove',
+          permission: 'manage_agents',
+          visibleWhenUnavailable: true,
+          onClick: noop,
+        },
+      ],
+      { permissions: ['view_agents'] }
+    );
+    expect(action.disabled).to.equal(true);
+    expect(action.tooltip).to.equal('You need Manage Agents to do this.');
+  });
+
+  it('leaves no registry-only fields on what it returns', () => {
+    const [action] = defineActions({ state: 'running' } as Thing, [
+      { id: 'rename', label: 'Rename', available: () => true, onClick: noop },
+    ]);
+    expect(Object.keys(action).sort()).to.deep.equal([
+      'id',
+      'label',
+      'onClick',
+    ]);
+  });
+});
+
+describe('intersectActions', () => {
+  it('keeps only what every selected resource offers', () => {
+    const running = [
+      { id: 'stop', label: 'Stop' },
+      { id: 'rename', label: 'Rename' },
+    ];
+    const stopped = [
+      { id: 'start', label: 'Start' },
+      { id: 'rename', label: 'Rename' },
+    ];
+    expect(actionIds(intersectActions([running, stopped]))).to.deep.equal([
+      'rename',
+    ]);
+  });
+
+  it('treats a disabled action as not offered', () => {
+    const a = [{ id: 'run', label: 'Run', disabled: true }];
+    const b = [{ id: 'run', label: 'Run' }];
+    expect(intersectActions([b, a])).to.deep.equal([]);
+    expect(intersectActions([a, b])).to.deep.equal([]);
+  });
+
+  it('is empty for an empty selection', () => {
+    expect(intersectActions([])).to.deep.equal([]);
+  });
+});
+
+describe('offersAction', () => {
+  it('answers for enabled actions only', () => {
+    const actions = [
+      { id: 'approve', label: 'Approve' },
+      { id: 'deny', label: 'Deny', disabled: true },
+    ];
+    expect(offersAction(actions, 'approve')).to.equal(true);
+    expect(offersAction(actions, 'deny')).to.equal(false);
+    expect(offersAction(actions, 'nope')).to.equal(false);
+  });
+});

--- a/frontend/src/actions/registry.ts
+++ b/frontend/src/actions/registry.ts
@@ -1,0 +1,177 @@
+/**
+ * The one place that decides which actions a resource offers.
+ *
+ * Every list row, every bulk bar and every detail page asked the same
+ * question ("what can I do with this thing?") and answered it with its own
+ * hand-written array, so the answers drifted: the agents list offered
+ * Decommission and the agent page did not, the flows list called an action
+ * `run-now` and the flow page called the same action `test-run`, and the bulk
+ * bars offered Resume for agents that were already running.
+ *
+ * A type declares its actions once, as candidates carrying a state predicate
+ * (`available`), and this module turns candidates into the plain
+ * `ResourceAction[]` that `resource-actions` renders. Nothing here renders.
+ */
+import type { ResourceAction } from '../components/resource-actions';
+import {
+  hasAnyPermission,
+  hasPermission,
+  humanizePermission,
+  type UserPermissions,
+} from '../permissions';
+
+/** What every action context carries. Types extend it with their handlers. */
+export interface ActionContext {
+  /** From `/auth/users/me`; null or undefined means RBAC is off. */
+  permissions?: UserPermissions;
+}
+
+/**
+ * One action a type can offer, before the state of a particular resource is
+ * taken into account.
+ */
+export interface ActionCandidate<T> extends ResourceAction {
+  /**
+   * Whether this resource, in the state it is in, can be asked to do this.
+   * Omitted means "always", which is the honest answer for Rename or Open.
+   */
+  available?: (resource: T) => boolean;
+  /**
+   * Keep an unavailable action on screen, disabled, instead of dropping it.
+   * Use it where the absence would be a puzzle ("where did Run now go?") and
+   * the tooltip can name the state that has to change first.
+   */
+  visibleWhenUnavailable?: boolean;
+  /** The tooltip shown while the action is unavailable. */
+  unavailableTooltip?: string;
+  /** Permission (or any of several) the operator needs to be offered this. */
+  permission?: string | string[];
+}
+
+/** Candidates may be written inline as `condition && {...}` or `null`. */
+export type ActionCandidateInput<T> =
+  ActionCandidate<T> | null | undefined | false;
+
+const REGISTRY_KEYS = [
+  'available',
+  'visibleWhenUnavailable',
+  'unavailableTooltip',
+  'permission',
+] as const;
+
+function toResourceAction<T>(candidate: ActionCandidate<T>): ResourceAction {
+  const action = { ...candidate } as ActionCandidate<T> &
+    Record<string, unknown>;
+  for (const key of REGISTRY_KEYS) {
+    delete action[key];
+  }
+  return action as ResourceAction;
+}
+
+function permissionAllowed<T>(
+  candidate: ActionCandidate<T>,
+  permissions: UserPermissions
+): boolean {
+  if (!candidate.permission) return true;
+  return Array.isArray(candidate.permission)
+    ? hasAnyPermission(permissions, candidate.permission)
+    : hasPermission(permissions, candidate.permission);
+}
+
+function permissionTooltip<T>(candidate: ActionCandidate<T>): string {
+  const required = Array.isArray(candidate.permission)
+    ? candidate.permission
+    : [candidate.permission as string];
+  return `You need ${required
+    .map((permission) => humanizePermission(permission))
+    .join(' or ')} to do this.`;
+}
+
+/**
+ * An action with no way to run is not an action. A view that wires only some
+ * of a type's handlers (the agents table has no Talk of its own, the card
+ * grid has no Rename) gets the subset it wired, with the same ids as
+ * everywhere else, rather than a button that does nothing.
+ */
+function isWired<T>(candidate: ActionCandidate<T>): boolean {
+  return Boolean(candidate.onClick || candidate.href || candidate.render);
+}
+
+/**
+ * Turn a type's candidates into the actions this resource actually offers.
+ *
+ * Order is the declared order, except that `separated` (destructive) actions
+ * are moved to the end: DESIGN.md "Destructive actions" says Remove sits
+ * last, after a gap, and a type module should not have to remember to declare
+ * it last to get that.
+ */
+export function defineActions<T>(
+  resource: T,
+  candidates: ActionCandidateInput<T>[],
+  ctx: ActionContext = {}
+): ResourceAction[] {
+  const resolved: ResourceAction[] = [];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (!isWired(candidate)) continue;
+
+    const allowed = permissionAllowed(candidate, ctx.permissions);
+    const available = candidate.available
+      ? candidate.available(resource)
+      : true;
+
+    if (allowed && available) {
+      resolved.push(toResourceAction(candidate));
+      continue;
+    }
+    if (!candidate.visibleWhenUnavailable) continue;
+
+    resolved.push({
+      ...toResourceAction(candidate),
+      disabled: true,
+      tooltip: allowed
+        ? candidate.unavailableTooltip || candidate.tooltip
+        : permissionTooltip(candidate),
+    });
+  }
+
+  const everyday = resolved.filter((action) => !action.separated);
+  const destructive = resolved.filter((action) => action.separated);
+  return [...everyday, ...destructive];
+}
+
+/**
+ * What a whole selection can be asked to do: an action survives only if every
+ * selected resource offers it, and offers it enabled.
+ *
+ * This is the same rule `resource-actions` applies to `actionsSets`, kept
+ * here as well because the bulk bar is a different component with its own
+ * button shape and cannot take a set of sets.
+ */
+export function intersectActions(
+  sets: readonly ResourceAction[][]
+): ResourceAction[] {
+  if (sets.length === 0) return [];
+  const [first, ...rest] = sets;
+  return first
+    .filter((action) => !action.disabled)
+    .filter((action) =>
+      rest.every((set) =>
+        set.some((other) => other.id === action.id && !other.disabled)
+      )
+    );
+}
+
+/** Ids only, which is what tests and bulk handlers compare. */
+export function actionIds(actions: readonly ResourceAction[]): string[] {
+  return actions.map((action) => action.id);
+}
+
+/** Whether a resolved set offers this action, enabled. */
+export function offersAction(
+  actions: readonly ResourceAction[],
+  id: string
+): boolean {
+  return actions.some((action) => action.id === id && !action.disabled);
+}

--- a/frontend/src/actions/runtime-session-actions.test.ts
+++ b/frontend/src/actions/runtime-session-actions.test.ts
@@ -23,6 +23,18 @@ describe('runtimeSessionActions', () => {
     ).to.deep.equal(['open']);
   });
 
+  it('drops End session once the status says ended, with no end time', () => {
+    expect(
+      actionIds(runtimeSessionActions({ id: 's1', status: 'ended' }, ctx))
+    ).to.deep.equal(['open']);
+  });
+
+  it('keeps End session on a quiet session that has not ended', () => {
+    expect(
+      actionIds(runtimeSessionActions({ id: 's1', status: 'idle' }, ctx))
+    ).to.deep.equal(['open', 'end-session']);
+  });
+
   it('links to the flow run only when the session came from one', () => {
     const actions = runtimeSessionActions(
       { id: 's1', flow_execution_id: 'exec-1' },

--- a/frontend/src/actions/runtime-session-actions.test.ts
+++ b/frontend/src/actions/runtime-session-actions.test.ts
@@ -1,0 +1,54 @@
+import { expect } from '@open-wc/testing';
+import { runtimeSessionActions } from './runtime-session-actions';
+import { actionIds, intersectActions } from './registry';
+
+const ctx = { includeOpen: true, onOpen: () => {}, onEnd: () => {} };
+
+describe('runtimeSessionActions', () => {
+  it('offers End session while the session is live', () => {
+    expect(actionIds(runtimeSessionActions({ id: 's1' }, ctx))).to.deep.equal([
+      'open',
+      'end-session',
+    ]);
+  });
+
+  it('drops End session once the session ended', () => {
+    expect(
+      actionIds(
+        runtimeSessionActions(
+          { id: 's1', ended_at: '2026-09-01T10:00:00Z' },
+          ctx
+        )
+      )
+    ).to.deep.equal(['open']);
+  });
+
+  it('links to the flow run only when the session came from one', () => {
+    const actions = runtimeSessionActions(
+      { id: 's1', flow_execution_id: 'exec-1' },
+      ctx
+    );
+    expect(actionIds(actions)).to.contain('view-flow-execution');
+    expect(
+      actions.find((action) => action.id === 'view-flow-execution')!.href
+    ).to.equal('/console/flows/executions/exec-1');
+  });
+
+  it('keeps End session outlined and set apart', () => {
+    const actions = runtimeSessionActions({ id: 's1' }, ctx);
+    const end = actions[actions.length - 1];
+    expect(end.id).to.equal('end-session');
+    expect(end.variant).to.equal('danger');
+    expect(end.outline).to.equal(true);
+    expect(end.separated).to.equal(true);
+  });
+
+  it('offers a live and an ended session only their common actions', () => {
+    const live = runtimeSessionActions({ id: 'a' }, ctx);
+    const ended = runtimeSessionActions(
+      { id: 'b', ended_at: '2026-09-01T10:00:00Z' },
+      ctx
+    );
+    expect(actionIds(intersectActions([live, ended]))).to.deep.equal(['open']);
+  });
+});

--- a/frontend/src/actions/runtime-session-actions.ts
+++ b/frontend/src/actions/runtime-session-actions.ts
@@ -1,0 +1,71 @@
+/**
+ * What a runtime session offers, by whether it has ended.
+ *
+ * The sessions list offered nothing at all: ending a session meant opening it
+ * first, and the panel's one button stayed on screen after the session ended,
+ * relabelled "Session ended", which is a status wearing a button's clothes.
+ */
+import type { ResourceAction } from '../components/resource-actions';
+import { defineActions, type ActionContext } from './registry';
+
+export interface RuntimeSessionActionResource {
+  id: string;
+  /** Set once the session is over: nothing left to end. */
+  ended_at?: string | null;
+  flow_execution_id?: string | null;
+}
+
+export interface RuntimeSessionActionContext extends ActionContext {
+  busy?: boolean;
+  /** Offered on a list row, where the session panel is somewhere else. */
+  includeOpen?: boolean;
+  onOpen?: (session: RuntimeSessionActionResource) => void;
+  onEnd?: (session: RuntimeSessionActionResource) => void;
+}
+
+export function isSessionLive(session: RuntimeSessionActionResource): boolean {
+  return !session.ended_at;
+}
+
+export function runtimeSessionActions(
+  session: RuntimeSessionActionResource,
+  ctx: RuntimeSessionActionContext = {}
+): ResourceAction[] {
+  const busy = ctx.busy === true;
+  return defineActions(
+    session,
+    [
+      ctx.includeOpen
+        ? {
+            id: 'open',
+            label: 'Open session',
+            icon: 'box-arrow-up-right',
+            onClick: ctx.onOpen ? () => ctx.onOpen!(session) : undefined,
+          }
+        : null,
+      {
+        id: 'view-flow-execution',
+        label: 'View flow run',
+        icon: 'diagram-3',
+        available: (item) => Boolean(item.flow_execution_id),
+        href: `/console/flows/executions/${encodeURIComponent(
+          session.flow_execution_id || ''
+        )}`,
+      },
+      // Ending a session cuts the agent off mid-conversation, so it is
+      // destructive: outlined, last, and confirmed by the caller.
+      {
+        id: 'end-session',
+        label: 'End session',
+        icon: 'stop-circle',
+        variant: 'danger',
+        outline: true,
+        separated: true,
+        loading: busy,
+        available: isSessionLive,
+        onClick: ctx.onEnd ? () => ctx.onEnd!(session) : undefined,
+      },
+    ],
+    ctx
+  );
+}

--- a/frontend/src/actions/runtime-session-actions.ts
+++ b/frontend/src/actions/runtime-session-actions.ts
@@ -12,6 +12,12 @@ export interface RuntimeSessionActionResource {
   id: string;
   /** Set once the session is over: nothing left to end. */
   ended_at?: string | null;
+  /**
+   * Session summaries carry 'ended', 'active_now' or 'idle' (server side
+   * crud/runtime_session.py, _row_to_summary). Only 'ended' closes a session,
+   * an idle one can still be ended by hand.
+   */
+  status?: string | null;
   flow_execution_id?: string | null;
 }
 
@@ -23,8 +29,16 @@ export interface RuntimeSessionActionContext extends ActionContext {
   onEnd?: (session: RuntimeSessionActionResource) => void;
 }
 
+/**
+ * The one rule for "there is nothing left to end", shared by the session
+ * toolbar and by any list row that offers End session.
+ */
+export function isSessionEnded(session: RuntimeSessionActionResource): boolean {
+  return session.status === 'ended' || Boolean(session.ended_at);
+}
+
 export function isSessionLive(session: RuntimeSessionActionResource): boolean {
-  return !session.ended_at;
+  return !isSessionEnded(session);
 }
 
 export function runtimeSessionActions(

--- a/frontend/src/components/preloop-session-observer.test.ts
+++ b/frontend/src/components/preloop-session-observer.test.ts
@@ -1115,6 +1115,34 @@ describe('PreloopSessionObserver', () => {
       expect(text).to.include('Refresh');
     });
 
+    it('still offers End session on a quiet session that has not ended', async () => {
+      // Registry rule (src/actions/runtime-session-actions.ts): only 'ended'
+      // closes a session. An idle one has stopped streaming, so Follow goes
+      // away, but there is still a session to end.
+      const idleSession = {
+        ...session,
+        id: 'runtime-session-idle',
+        is_active_now: false,
+        activity_status: 'idle',
+      };
+      const el = (await fixture(
+        html`<preloop-session-observer
+          .sessions=${[idleSession]}
+          .features=${{ endSession: true }}
+        ></preloop-session-observer>`
+      )) as PreloopSessionObserver;
+
+      await waitUntil(
+        () => deepText(el.shadowRoot).includes('Build a widget'),
+        '',
+        { timeout: 3000 }
+      );
+
+      const text = toolbarText(el);
+      expect(text).to.not.include('Following live');
+      expect(text).to.include('End session');
+    });
+
     it('asks for confirmation in the console dialog, not window.confirm', async () => {
       const confirmStub = sinon.stub(window, 'confirm').returns(false);
       try {

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -54,6 +54,11 @@ import {
   formatNumber,
   normalizeObservedSessions,
 } from '../utils/session-observer';
+import type { RuntimeSessionActionResource } from '../actions/runtime-session-actions';
+import {
+  isSessionEnded as isRuntimeSessionEnded,
+  runtimeSessionActions,
+} from '../actions/runtime-session-actions';
 import { confirmDialog } from './confirm-dialog';
 import { reducedMotionStyles } from '../styles/reduced-motion';
 import './session-chat-view';
@@ -1729,14 +1734,44 @@ export class PreloopSessionObserver extends LitElement {
     return session.status === 'active_now';
   }
 
+  /**
+   * Whether the session is over. The rule lives in the shared registry
+   * (src/actions/runtime-session-actions.ts) so this toolbar and any list
+   * offering End session cannot drift apart.
+   */
   private isSessionEnded(session: ObservedSession | null): boolean {
     if (!session) return false;
-    return session.status === 'ended' || Boolean(session.endedAt);
+    return isRuntimeSessionEnded(this.sessionActionResource(session));
+  }
+
+  private sessionActionResource(
+    session: ObservedSession
+  ): RuntimeSessionActionResource {
+    return {
+      id: session.id,
+      status: session.status,
+      ended_at: session.endedAt,
+      flow_execution_id: session.flowExecutionId,
+    };
+  }
+
+  /**
+   * The session's End session control, or nothing when the session has
+   * already ended. Availability comes from the registry, not from a
+   * predicate written into the template.
+   */
+  private endSessionAction(session: ObservedSession | null) {
+    if (!session || !session.canLoadEvents) return undefined;
+    if (!this.enabledFeatures.endSession) return undefined;
+    return runtimeSessionActions(this.sessionActionResource(session), {
+      onEnd: () => void this.endActiveSession(),
+    }).find((action) => action.id === 'end-session');
   }
 
   private renderToolbar() {
     const session = this.activeSession;
     const live = this.isSessionLive(session);
+    const endAction = this.endSessionAction(session);
 
     // With no sessions there is nothing to follow, pause, replay, filter or
     // refresh, so the full toolbar is six controls that all do nothing. Show
@@ -1844,20 +1879,19 @@ export class PreloopSessionObserver extends LitElement {
             Refresh
           </sl-button>
           ${
-            this.enabledFeatures.endSession &&
-            session?.canLoadEvents &&
-            !this.isSessionEnded(session)
+            endAction
               ? html`
                   <!-- DESIGN "Destructive actions": danger outline, last in
-                       the row, and gone once there is nothing left to end. -->
+                       the row, and gone once there is nothing left to end.
+                       Shape and availability both come from the registry. -->
                   <sl-button
                     class="destructive"
                     size="small"
-                    variant="danger"
-                    outline
-                    @click=${this.endActiveSession}
+                    variant=${endAction.variant || 'danger'}
+                    ?outline=${endAction.outline !== false}
+                    @click=${() => endAction.onClick?.()}
                   >
-                    End session
+                    ${endAction.label}
                   </sl-button>
                 `
               : nothing

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -568,6 +568,26 @@ describe('AgentDetailView', () => {
     expect(remove.separated, 'Remove is set apart').to.equal(true);
   });
 
+  // The page kept its own action array and quietly lost Decommission, which
+  // the list row has always offered for the same agent.
+  it('offers the same lifecycle moves the agents list offers', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    const ids = ((element as any).agentActions as Array<{ id: string }>).map(
+      (action) => action.id
+    );
+    expect(ids).to.contain('decommission');
+    expect(ids).to.contain('pause');
+    expect(ids).to.not.contain('resume');
+  });
+
   // Wave 4: tags are labels, not states, so they lost the pill and took a
   // leading tag icon instead of the hash.
   it('shows operator tags as text with a leading tag icon', async () => {

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -28,6 +28,12 @@ import '../../components/time-range-select.ts';
 import '../../components/confirm-dialog.ts';
 import { confirmDialog } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
+import { actionsFor } from '../../actions';
+import {
+  AGENT_LIFECYCLE_WORDING,
+  agentLifecycleReason,
+  type AgentLifecycleMove,
+} from '../../actions/agent-actions';
 import {
   fetchWithAuth,
   getApprovalWorkflows,
@@ -1866,22 +1872,23 @@ export class AgentDetailView extends LitElement {
     }
   }
 
+  /**
+   * Pause, resume or decommission, with the same wording the list uses so the
+   * dialog does not change with the page it was opened from.
+   */
   private async updateAgentLifecycle(
-    lifecycleAction: 'suspend' | 'resume'
+    lifecycleAction: AgentLifecycleMove
   ): Promise<void> {
     if (!this.agentId || !this.agent) {
       return;
     }
-    const isSuspend = lifecycleAction === 'suspend';
+    const wording = AGENT_LIFECYCLE_WORDING[lifecycleAction];
     const confirmed = await confirmDialog({
-      title: isSuspend ? 'Pause agent' : 'Resume agent',
-      message: isSuspend
-        ? `Pause ${this.agent.display_name}?`
-        : `Resume ${this.agent.display_name}?`,
-      detail: isSuspend
-        ? 'Requests are blocked while paused. Resume restores the agent without re-onboarding it.'
-        : 'The existing credentials start working again immediately.',
-      confirmLabel: isSuspend ? 'Pause' : 'Resume',
+      title: `${wording.title} agent`,
+      message: `${wording.title} ${this.agent.display_name}?`,
+      detail: wording.detail,
+      confirmLabel: wording.title,
+      variant: lifecycleAction === 'decommission' ? 'danger' : 'primary',
     });
     if (!confirmed) {
       return;
@@ -1890,10 +1897,7 @@ export class AgentDetailView extends LitElement {
     try {
       await updateAccountAgent(this.agentId, {
         lifecycle_action: lifecycleAction,
-        reason:
-          lifecycleAction === 'suspend'
-            ? 'Manually paused by admin'
-            : 'Manually resumed by admin',
+        reason: agentLifecycleReason(lifecycleAction, 'agent page'),
       });
       await this.loadData();
     } catch (error) {
@@ -1935,93 +1939,32 @@ export class AgentDetailView extends LitElement {
     `;
   }
 
+  /**
+   * What this agent offers, from the one registry the agents list reads
+   * (`src/actions/agent-actions.ts`). The page used to keep its own array,
+   * which is how it ended up without Decommission while the list row had it.
+   */
   private get agentActions(): ResourceAction[] {
     if (!this.agent) return [];
-
-    const actions: ResourceAction[] = [
-      {
-        id: 'rename',
-        label: 'Rename',
-        icon: 'pencil',
-        onClick: () => this.promptRename(),
+    return actionsFor('agent', this.agent, {
+      busy: this.actionLoading,
+      canChangeOwner: this.featureFlags.user_management === true,
+      renderTalk: (agent) => html`
+        <talk-button
+          .agent=${agent}
+          source-context="agent-detail-view"
+        ></talk-button>
+      `,
+      onRename: () => this.promptRename(),
+      onEditTags: () => this.promptEditTags(),
+      onChangeOwner: () => this.promptChangeOwner(),
+      onLifecycle: (_agent, move) => {
+        void this.updateAgentLifecycle(move);
       },
-      {
-        id: 'edit-tags',
-        label: 'Edit tags',
-        icon: 'tag',
-        onClick: () => this.promptEditTags(),
+      onRemove: () => {
+        void this.removeAgent();
       },
-    ];
-
-    if (this.featureFlags.user_management) {
-      actions.push({
-        id: 'change-owner',
-        label: 'Change owner',
-        icon: 'person-gear',
-        onClick: () => this.promptChangeOwner(),
-      });
-    }
-
-    const isSuspendedOrDecommissioned =
-      this.agent.lifecycle_state === 'suspended' ||
-      this.agent.lifecycle_state === 'decommissioned';
-
-    // Resume is a green "start it again"; Pause is an everyday, reversible
-    // control, so it stays neutral. Amber read as a warning next to Talk and
-    // pulled the eye away from the action people actually came for.
-    if (isSuspendedOrDecommissioned) {
-      actions.push({
-        id: 'resume',
-        label: 'Resume',
-        variant: 'success',
-        icon: 'play-fill',
-        loading: this.actionLoading,
-        onClick: () => this.updateAgentLifecycle('resume'),
-        tooltip:
-          'Resume this agent. Its existing credentials start working again immediately.',
-      });
-    } else {
-      actions.push({
-        id: 'pause',
-        label: 'Pause',
-        variant: 'default',
-        icon: 'pause-fill',
-        loading: this.actionLoading,
-        onClick: () => this.updateAgentLifecycle('suspend'),
-        tooltip:
-          'Pause this agent. Requests are blocked while paused; Resume restores it without re-onboarding.',
-      });
-    }
-
-    const controlState = getAgentControlState(this.agent);
-    if (controlState.visible) {
-      actions.push({
-        id: 'talk',
-        label: 'Talk',
-        render: () => html`
-          <talk-button
-            .agent=${this.agent}
-            source-context="agent-detail-view"
-          ></talk-button>
-        `,
-      });
-    }
-
-    // Remove goes last, set apart from the everyday actions and outlined
-    // rather than solid: it is the one action on this page you cannot undo,
-    // and a solid red block next to Rename invites a mis-click.
-    actions.push({
-      id: 'remove',
-      label: 'Remove',
-      icon: 'trash',
-      variant: 'danger',
-      outline: true,
-      separated: true,
-      loading: this.actionLoading,
-      onClick: () => this.removeAgent(),
     });
-
-    return actions;
   }
 
   private handleSshKeyDown(e: KeyboardEvent) {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -29,6 +29,13 @@ import '../../components/confirm-dialog.ts';
 import '../../components/token-figures.ts';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
+import { actionsFor, intersectActions } from '../../actions';
+import {
+  AGENT_LIFECYCLE_ACTION_IDS,
+  type AgentLifecycleMove,
+  AGENT_LIFECYCLE_WORDING,
+  agentLifecycleReason,
+} from '../../actions/agent-actions';
 import {
   ListSelectionController,
   confirmBulkAction,
@@ -144,47 +151,11 @@ const VIEW_MODE_KEY = 'preloop.agents.view_mode';
  */
 const RELATIVE_TIME_DAYS = 90;
 
-/** The lifecycle moves the list offers, one at a time or over a selection. */
-export type AgentLifecycleAction = 'suspend' | 'resume' | 'decommission';
-
 /**
- * One wording per lifecycle move, so a confirmation on the row and the same
- * confirmation over seven rows say the same thing about consequences.
+ * The lifecycle moves the list offers, one at a time or over a selection.
+ * Re-exported from the action registry, which is where they are declared.
  */
-const AGENT_LIFECYCLE_WORDING: Record<
-  AgentLifecycleAction,
-  {
-    title: string;
-    verb: string;
-    verbPast: string;
-    detail: string;
-    reason: string;
-  }
-> = {
-  suspend: {
-    title: 'Pause',
-    verb: 'pause',
-    verbPast: 'paused',
-    detail:
-      'Requests are blocked while paused. Resume restores the agent without re-onboarding it.',
-    reason: 'Manually paused from managed agents view',
-  },
-  resume: {
-    title: 'Resume',
-    verb: 'resume',
-    verbPast: 'resumed',
-    detail: 'The existing credentials start working again immediately.',
-    reason: 'Manually resumed from managed agents view',
-  },
-  decommission: {
-    title: 'Decommission',
-    verb: 'decommission',
-    verbPast: 'decommissioned',
-    detail:
-      "Decommissioning revokes the agent's runtime credentials. The agent and its history stay in the list, and resuming it restores its own unexpired keys.",
-    reason: 'Manually decommissioned from managed agents view',
-  },
-};
+export type AgentLifecycleAction = AgentLifecycleMove;
 
 export type AgentListSortKey =
   | 'agent'
@@ -2716,7 +2687,7 @@ export class AgentsView extends LitElement {
     if (!confirmed) return;
     await this.updateAgent(agent, {
       lifecycle_action: lifecycleAction,
-      reason: wording.reason,
+      reason: agentLifecycleReason(lifecycleAction, 'managed agents view'),
     });
   }
 
@@ -2986,18 +2957,34 @@ export class AgentsView extends LitElement {
     this.navigateToCardTarget(url);
   }
 
-  /** Pause, resume and decommission, the same ids the row kebab uses. */
+  /**
+   * What the whole selection can be asked to do.
+   *
+   * The bar used to offer Resume, Pause and Decommission whatever was
+   * selected, so it offered Resume for running agents and Decommission for
+   * agents already decommissioned. It now asks the registry for each selected
+   * agent and keeps what all of them offer, which is the rule the row kebab
+   * has always followed; the bar carries the lifecycle moves only, since
+   * Rename and Remove have no bulk handler behind them.
+   */
   private get bulkActions(): BulkAction[] {
-    return [
-      { id: 'resume', label: 'Resume', icon: 'play-fill', variant: 'success' },
-      { id: 'suspend', label: 'Pause', icon: 'pause-fill', variant: 'warning' },
-      {
-        id: 'decommission',
-        label: 'Decommission',
-        icon: 'box-arrow-right',
-        variant: 'danger',
-      },
-    ];
+    const sets = this.selection.selectedItems.map((row) =>
+      actionsFor('agent', row.source, { onLifecycle: () => {} })
+    );
+    return intersectActions(sets)
+      .filter((action) => action.id in AGENT_LIFECYCLE_ACTION_IDS)
+      .map((action) => ({
+        // The bar posts the lifecycle move, which is `suspend` where the
+        // kebab says Pause.
+        id: AGENT_LIFECYCLE_ACTION_IDS[action.id],
+        label: action.label,
+        icon: action.icon,
+        // Pause reads neutral beside Talk on the agent page; in a bar of two
+        // buttons over a selection it is the amber one.
+        variant: (action.variant === 'default'
+          ? 'warning'
+          : action.variant) as BulkAction['variant'],
+      }));
   }
 
   private renderBulkBar() {
@@ -3053,13 +3040,18 @@ export class AgentsView extends LitElement {
       (item) =>
         updateAccountAgent(item.id, {
           lifecycle_action: action,
-          reason: wording.reason,
+          reason: agentLifecycleReason(action, 'managed agents view'),
         }),
       { verb: wording.verb, verbPast: wording.verbPast, noun: 'agent' }
     );
     await this.loadAgents();
   }
 
+  /**
+   * What this agent offers, from the one registry both this list and the
+   * agent page read (`src/actions/agent-actions.ts`). The canvas mixes flow
+   * nodes into the same grid; those carry no actions here.
+   */
   private getCardActions(
     item: any,
     options: { includeTalk?: boolean } = {}
@@ -3071,112 +3063,27 @@ export class AgentsView extends LitElement {
     }
 
     const agent = item as ManagedAgentSummary;
-    const actions: ResourceAction[] = [];
-
-    // The table has no room for a Talk button per row, so the kebab carries it
-    // there. Cards and canvas nodes show the button itself and would otherwise
-    // offer the same action twice.
-    if (options.includeTalk && getAgentControlState(agent).visible) {
-      const control = getAgentControlState(agent);
-      actions.push({
-        id: 'talk',
-        label: 'Talk',
-        icon: 'chat-dots',
-        disabled: !control.enabled,
-        // Runs inside the menu item's click handler, so the window still opens
-        // on the user gesture.
-        onClick: () => {
-          openTalkWindow(agent, undefined, { sourceContext: 'agents-list' });
-        },
-      });
-    }
-
-    actions.push(
-      {
-        id: 'rename',
-        label: 'Rename',
-        icon: 'pencil',
-        loading: this.actionAgentId === agent.id,
-        onClick: () => this.promptRenameAgent(agent),
+    return actionsFor('agent', agent, {
+      busy: this.actionAgentId === agent.id,
+      canChangeOwner:
+        this.featureFlags.user_management && this.availableUsers.length > 0,
+      // The table has no room for a Talk button per row, so the kebab carries
+      // it there. Cards and canvas nodes show the button itself and would
+      // otherwise offer the same action twice.
+      onTalk: options.includeTalk
+        ? (target) =>
+            openTalkWindow(target, undefined, { sourceContext: 'agents-list' })
+        : undefined,
+      onRename: (target) => this.promptRenameAgent(target),
+      onEditTags: (target) => this.promptEditAgentTags(target),
+      onChangeOwner: (target) => this.promptChangeAgentOwner(target),
+      onLifecycle: (target, move) => {
+        void this.updateAgentLifecycle(target, move);
       },
-      {
-        id: 'edit-tags',
-        label: 'Edit tags',
-        icon: 'tags',
-        loading: this.actionAgentId === agent.id,
-        onClick: () => this.promptEditAgentTags(agent),
-      }
-    );
-
-    if (this.featureFlags.user_management && this.availableUsers.length > 0) {
-      actions.push({
-        id: 'change-owner',
-        label: 'Change owner',
-        icon: 'person-gear',
-        loading: this.actionAgentId === agent.id,
-        onClick: () => this.promptChangeAgentOwner(agent),
-      });
-    }
-
-    const isSuspendedOrDecommissioned =
-      agent.lifecycle_state === 'suspended' ||
-      agent.lifecycle_state === 'decommissioned';
-    // Play/pause toggle in warning (amber) tones; danger red is reserved for
-    // the destructive Remove action below.
-    actions.push(
-      isSuspendedOrDecommissioned
-        ? {
-            id: 'resume',
-            label: 'Resume',
-            icon: 'play-fill',
-            variant: 'success',
-            loading: this.actionAgentId === agent.id,
-            onClick: () => {
-              void this.updateAgentLifecycle(agent, 'resume');
-            },
-          }
-        : {
-            id: 'pause',
-            label: 'Pause',
-            icon: 'pause-fill',
-            variant: 'warning',
-            loading: this.actionAgentId === agent.id,
-            onClick: () => {
-              void this.updateAgentLifecycle(agent, 'suspend');
-            },
-          }
-    );
-
-    // Decommission is the reversible offboard: credentials are revoked but
-    // the agent and its history stay. Remove deletes the record, so the two
-    // are not the same action and both belong in the menu.
-    if (agent.lifecycle_state !== 'decommissioned') {
-      actions.push({
-        id: 'decommission',
-        label: 'Decommission',
-        icon: 'box-arrow-right',
-        variant: 'danger',
-        outline: true,
-        separated: true,
-        loading: this.actionAgentId === agent.id,
-        onClick: () => {
-          void this.updateAgentLifecycle(agent, 'decommission');
-        },
-      });
-    }
-
-    actions.push({
-      id: 'remove',
-      label: 'Remove',
-      icon: 'trash',
-      variant: 'danger',
-      loading: this.actionAgentId === agent.id,
-      onClick: () => {
-        void this.removeAgent(agent);
+      onRemove: (target) => {
+        void this.removeAgent(target);
       },
     });
-
-    return actions;
   }
 
   /**

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -1290,6 +1290,17 @@ describe('ApprovalView', () => {
       expect(element.shadowRoot?.querySelector('.decision-bar')).to.not.exist;
     });
 
+    it('ignores the decision keys on a question', async () => {
+      // Same registry rule as the hidden decision bar: a question is
+      // answered in its panel, so there is no Approve to reach for.
+      await renderQuestion();
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      await aTimeout(0);
+      expect(decisionCall('approve'), 'a key approved a question').to.be
+        .undefined;
+    });
+
     it('submits selected_option when an option is clicked', async () => {
       const { element, panel } = await renderQuestion();
 

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -28,6 +28,7 @@ import {
   millisUntilExpiry,
   normalizeApprovalRequest,
 } from '../../utils/approvals';
+import { isDecidableRequest } from '../../actions/approval-actions';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import { formatRelativeTime } from '../../utils/date';
 import {
@@ -548,8 +549,22 @@ export class ApprovalView extends AuthedElement {
     );
   }
 
+  /**
+   * Whether Approve and Deny are on offer at all: pending, unexpired and not
+   * a question. One rule, from the shared registry, used by the decision bar
+   * and by the keyboard shortcuts that stand in for it.
+   */
+  private get canDecide(): boolean {
+    return (
+      !!this.approvalRequest &&
+      isDecidableRequest(this.approvalRequest, this.nowMs)
+    );
+  }
+
   private handleKeyDown = (event: KeyboardEvent) => {
-    if (!this.isLive || this.isQuestion || this.submitting) return;
+    // The keys reach for the same actions the decision bar shows, so they
+    // ask the registry the same question (src/actions/approval-actions.ts).
+    if (!this.canDecide || this.submitting) return;
     // A confirmation is a question in its own right: answer it with the mouse
     // or the dialog's own keys, not with the page shortcuts underneath it.
     if (this.confirming) return;
@@ -1266,7 +1281,7 @@ export class ApprovalView extends AuthedElement {
 
       ${this.decisionTaken ? this.renderPostDecision() : ''}
       ${
-        isPending && !isQuestion
+        isDecidableRequest(request, this.nowMs)
           ? this.renderDecisionBar(request, countdown, expiringSoon)
           : ''
       }

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -889,6 +889,26 @@ describe('ApprovalsView', () => {
       ).to.equal('2 selected');
     });
 
+    it('offers only what every selected request still offers', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(2) }),
+        baseRequest({ id: 'ar-2', expires_at: inMinutes(30) }),
+      ]);
+
+      await select(element, ['ar-1', 'ar-2']);
+      const ids = () =>
+        ((element as any).bulkActions as Array<{ id: string }>).map(
+          (action) => action.id
+        );
+      expect(ids()).to.deep.equal(['approve', 'deny']);
+
+      // ar-1 has run out of time. The bar is the intersection of what the
+      // selected rows offer (src/actions/approval-actions.ts), so it empties
+      // rather than offering a decision one of them can no longer take.
+      (element as any).nowMs = Date.now() + 5 * 60_000;
+      expect(ids()).to.deep.equal([]);
+    });
+
     it('approves the selection with one call after naming the requests', async () => {
       const element = await renderList([
         baseRequest({

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -24,6 +24,13 @@ import {
   normalizeApprovalRequest,
   partitionApprovalRequests,
 } from '../../utils/approvals';
+import {
+  approvalActions,
+  isApprovalQuestion,
+  isDecidableRequest,
+} from '../../actions/approval-actions';
+import { intersectActions, offersAction } from '../../actions/registry';
+import type { ResourceAction } from '../../components/resource-actions';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import {
   ListSelectionController,
@@ -481,7 +488,9 @@ export class ApprovalsView extends AuthedElement {
    * of the selection by itself.
    */
   private get selectableRequests(): ApprovalRequest[] {
-    return this.waitingRequests.filter((request) => !this.isQuestion(request));
+    return this.waitingRequests.filter((request) =>
+      isDecidableRequest(request, this.nowMs)
+    );
   }
 
   /** Ids of requests this browser has already shown, oldest dropped first. */
@@ -594,7 +603,7 @@ export class ApprovalsView extends AuthedElement {
     // The buttons go disabled while a decision is in flight; the keys have to
     // do the same, or two quick presses POST the same decision twice.
     if (this.decidingId) return false;
-    if (this.isQuestion(request)) return false;
+    if (!isDecidableRequest(request, this.nowMs)) return false;
     return this.waitingRequests.some((waiting) => waiting.id === request.id);
   }
 
@@ -913,7 +922,23 @@ export class ApprovalsView extends AuthedElement {
   }
 
   private isQuestion(request: ApprovalRequest): boolean {
-    return request.is_question === true;
+    return isApprovalQuestion(request);
+  }
+
+  /**
+   * What this row offers, from the shared registry
+   * (src/actions/approval-actions.ts). The row, the bulk bar, the keyboard
+   * and the request page all read the same predicate, so none of them can
+   * offer Approve on a request the others call settled.
+   */
+  private requestActions(request: ApprovalRequest): ResourceAction[] {
+    return approvalActions(request, {
+      busy: this.decidingId === request.id,
+      now: this.nowMs,
+      onApprove: (target) => void this.handleRowApprove(target),
+      onDeny: (target) => void this.handleRowDeny(target),
+      includeDetails: true,
+    });
   }
 
   private questionText(request: ApprovalRequest): string {
@@ -948,7 +973,7 @@ export class ApprovalsView extends AuthedElement {
    */
   private ensureStillWaiting(request: ApprovalRequest): boolean {
     this.nowMs = Date.now();
-    if (isUnexpiredPendingRequest(request, this.nowMs)) return true;
+    if (isDecidableRequest(request, this.nowMs)) return true;
     this.applyFilters();
     return false;
   }
@@ -1008,16 +1033,27 @@ export class ApprovalsView extends AuthedElement {
   }
 
   /**
-   * The bulk bar's two actions.
+   * The bulk bar offers what every selected request offers, and nothing else:
+   * one expired row in the selection takes Approve and Deny off the bar
+   * rather than posting a decision the backend refuses.
    *
    * The bar disables its own buttons while a run is in flight, so there is
    * nothing per action to say here.
    */
   private get bulkActions(): BulkAction[] {
-    return [
-      { id: 'approve', label: 'Approve', icon: 'check-lg', variant: 'success' },
-      { id: 'deny', label: 'Deny', icon: 'x-lg', variant: 'danger' },
-    ];
+    const common = intersectActions(
+      this.selection.selectedItems.map((request) =>
+        this.requestActions(request)
+      )
+    );
+    return common
+      .filter((action) => action.id === 'approve' || action.id === 'deny')
+      .map((action) => ({
+        id: action.id,
+        label: action.label,
+        icon: action.icon,
+        variant: action.variant as BulkAction['variant'],
+      }));
   }
 
   /** Bulk items carry the tool name, which is what a confirm or toast says. */
@@ -1436,7 +1472,11 @@ export class ApprovalsView extends AuthedElement {
     index: number
   ) {
     const focused = this.focusedIndex === index;
-    const selectable = waiting && !this.isQuestion(request);
+    const actions = this.requestActions(request);
+    const detailsAction = actions.find((action) => action.id === 'details');
+    // Only a row that can actually be decided is worth selecting: the bulk
+    // bar has nothing to offer for the others.
+    const selectable = waiting && offersAction(actions, 'approve');
     const selected = this.selection.isSelected(request.id);
     const isNew = waiting && this.newIds.includes(request.id);
     return html`
@@ -1617,34 +1657,25 @@ export class ApprovalsView extends AuthedElement {
             }
           </div>
           <div class="approval-actions">
-            ${
-              waiting && !this.isQuestion(request)
-                ? html`
-                    <sl-button
-                      class="row-approve"
-                      size="small"
-                      variant="success"
-                      ?loading=${this.decidingId === request.id}
-                      ?disabled=${this.decidingId === request.id}
-                      @click=${() => this.handleRowApprove(request)}
-                    >
-                      Approve
-                    </sl-button>
-                    <sl-button
-                      class="row-deny"
-                      size="small"
-                      variant="danger"
-                      outline
-                      ?disabled=${this.decidingId === request.id}
-                      @click=${() => this.handleRowDeny(request)}
-                    >
-                      Deny
-                    </sl-button>
-                  `
-                : ''
-            }
-            <a class="row-details" href="/console/approval/${request.id}"
-              >${waiting ? 'Details' : 'View'}</a
+            ${actions
+              .filter((action) => action.id !== 'details')
+              .map(
+                (action) => html`
+                  <sl-button
+                    class=${`row-${action.id === 'approve' ? 'approve' : 'deny'}`}
+                    size="small"
+                    variant=${action.variant || 'default'}
+                    ?outline=${action.outline === true}
+                    ?loading=${action.loading === true}
+                    ?disabled=${action.disabled === true}
+                    @click=${() => action.onClick?.()}
+                  >
+                    ${action.label}
+                  </sl-button>
+                `
+              )}
+            <a class="row-details" href=${detailsAction?.href ?? '#'}
+              >${detailsAction?.label ?? 'View'}</a
             >
           </div>
         </div>

--- a/frontend/src/views/authed/flow-execution-view.test.ts
+++ b/frontend/src/views/authed/flow-execution-view.test.ts
@@ -1303,19 +1303,26 @@ describe('FlowExecutionView', () => {
         element.shadowRoot!.querySelectorAll('.header-actions sl-menu-item')
       ).map((item) => (item.textContent || '').trim());
 
-      // "View flow" is in the menu for the phone layout, where the header
-      // has no room for it; CSS hides it on a wide screen.
-      expect(items).to.eql([
-        'View flow',
-        'Copy execution id',
-        'Copy session id',
-      ]);
+      // The run's own actions are in resource-actions beside this kebab,
+      // which now carries the two copy commands only: they are about the
+      // page, not about the run.
+      expect(items).to.eql(['Copy execution id', 'Copy session id']);
       // exec-1 has no session reference, so that item cannot be clicked.
       expect(
         element
-          .shadowRoot!.querySelectorAll('.header-actions sl-menu-item')[2]
+          .shadowRoot!.querySelectorAll('.header-actions sl-menu-item')[1]
           .hasAttribute('disabled')
       ).to.equal(true);
+    });
+
+    it('offers the run actions the executions list offers, by status', async () => {
+      const element = await load('exec-1');
+      const actions = element.shadowRoot!.querySelector(
+        '.header-actions resource-actions'
+      ) as HTMLElement & { actions: Array<{ id: string }> };
+
+      // exec-1 succeeded and has no session, so only the flow link is left.
+      expect(actions.actions.map((action) => action.id)).to.eql(['view-flow']);
     });
   });
 

--- a/frontend/src/views/authed/flow-execution-view.ts
+++ b/frontend/src/views/authed/flow-execution-view.ts
@@ -27,6 +27,9 @@ import {
   parseUTCDate,
 } from '../../utils/date';
 import { RUNNING_STATUSES, executionDurationText } from '../../utils/execution';
+import { actionsFor } from '../../actions';
+import { canRetryExecution } from '../../actions/flow-execution-actions';
+import '../../components/resource-actions.ts';
 import {
   executionSubjectCss,
   isSubjectFallback,
@@ -660,16 +663,7 @@ export class FlowExecutionView extends LitElement {
       }
       /* The two navigations are buttons on a desktop and menu items on a
          phone, where the header only has room for the primary action. */
-      .header-actions sl-menu-item.narrow-action {
-        display: none;
-      }
       @media (max-width: 700px) {
-        .header-actions .secondary-action {
-          display: none;
-        }
-        .header-actions sl-menu-item.narrow-action {
-          display: block;
-        }
         .summary-strip {
           gap: 8px 20px;
         }
@@ -2746,69 +2740,29 @@ ${execution.resolved_input_prompt}</pre>
     `;
   }
 
-  private renderHeaderActions(execution: FlowExecution, running: boolean) {
+  /**
+   * The run's actions, from the one registry the executions list reads
+   * (`src/actions/flow-execution-actions.ts`). The page used to spell out its
+   * own Cancel and Retry with its own copy of the retry predicate, and its
+   * own labels ("Retry" against the list's "Retry run").
+   *
+   * `resource-actions` folds what does not fit into its own overflow menu, so
+   * the phone-only duplicates of View flow and Open session are gone; the
+   * kebab beside it carries the two copy commands, which are about the page
+   * rather than about the run.
+   */
+  private renderHeaderActions(execution: FlowExecution) {
     const sessionReference = execution.agent_session_reference;
     return html`
       <div slot="main-column" class="header-actions">
-        ${
-          running
-            ? html`
-                <sl-button
-                  size="small"
-                  variant="danger"
-                  outline
-                  @click=${this.stopExecution}
-                >
-                  <sl-icon slot="prefix" name="x-circle"></sl-icon> Cancel
-                </sl-button>
-              `
-            : ''
-        }
-        ${
-          this.canRetry()
-            ? html`
-                <sl-button
-                  size="small"
-                  variant="default"
-                  ?loading=${this.isRetrying}
-                  @click=${this.retryExecution}
-                >
-                  <sl-icon slot="prefix" name="arrow-repeat"></sl-icon> Retry
-                </sl-button>
-              `
-            : ''
-        }
-        ${
-          sessionReference
-            ? html`
-                <sl-button
-                  class="secondary-action"
-                  size="small"
-                  variant="default"
-                  href="/console/runtime-sessions?query=${encodeURIComponent(
-                    execution.id
-                  )}"
-                >
-                  <sl-icon slot="prefix" name="chat-left-text"></sl-icon> Open
-                  session
-                </sl-button>
-              `
-            : ''
-        }
-        ${
-          this.flow
-            ? html`
-                <sl-button
-                  class="secondary-action"
-                  size="small"
-                  variant="default"
-                  href="/console/flows/${this.flow.id}"
-                >
-                  <sl-icon slot="prefix" name="diagram-3"></sl-icon> View flow
-                </sl-button>
-              `
-            : ''
-        }
+        <resource-actions
+          .actions=${actionsFor('flow-execution', execution, {
+            includeViewFlow: true,
+            busy: this.isRetrying,
+            onCancel: () => void this.stopExecution(),
+            onRetry: () => void this.retryExecution(),
+          })}
+        ></resource-actions>
         <sl-dropdown hoist>
           <sl-icon-button
             slot="trigger"
@@ -2816,35 +2770,6 @@ ${execution.resolved_input_prompt}</pre>
             label="More actions"
           ></sl-icon-button>
           <sl-menu>
-            ${
-              // On a phone the header has room for the primary action only,
-              // so the two navigations move into the menu rather than
-              // stacking a column of buttons next to the title.
-              sessionReference
-                ? html`<sl-menu-item
-                    class="narrow-action"
-                    @click=${() =>
-                      Router.go(
-                        `/console/runtime-sessions?query=${encodeURIComponent(
-                          execution.id
-                        )}`
-                      )}
-                  >
-                    Open session
-                  </sl-menu-item>`
-                : ''
-            }
-            ${
-              this.flow
-                ? html`<sl-menu-item
-                    class="narrow-action"
-                    @click=${() =>
-                      this.flow && Router.go(`/console/flows/${this.flow.id}`)}
-                  >
-                    View flow
-                  </sl-menu-item>`
-                : ''
-            }
             <sl-menu-item
               @click=${() =>
                 this.copyToClipboard(execution.id, 'Execution id copied')}
@@ -2965,7 +2890,7 @@ ${execution.resolved_input_prompt}</pre>
               </div>`
             : ''
         }
-        ${this.renderHeaderActions(execution, running)}
+        ${this.renderHeaderActions(execution)}
       </view-header>
       <div class="column-layout wide">
         <div class="main-column">
@@ -3221,10 +3146,10 @@ ${log.payload.content}</pre>
     }
   }
 
+  /** The retry predicate lives with the actions; this is the page's view of it. */
   canRetry(): boolean {
     if (!this.execution) return false;
-    const retryableStatuses = ['FAILED', 'STOPPED', 'TIMEOUT', 'CANCELLED'];
-    return retryableStatuses.includes(this.execution.status);
+    return canRetryExecution(this.execution);
   }
 
   async retryExecution() {

--- a/frontend/src/views/authed/flow-executions-view.test.ts
+++ b/frontend/src/views/authed/flow-executions-view.test.ts
@@ -23,6 +23,7 @@ const EXECUTIONS = [
     start_time: '2026-03-09T10:00:00Z',
     end_time: '2026-03-09T10:05:00Z',
     tool_calls_count: 3,
+    agent_session_reference: 'session-aaaaaaaa-1',
   },
   {
     id: 'exec-bbbbbbbb-2',
@@ -769,6 +770,19 @@ describe('FlowExecutionsView', () => {
       expect(menus[0].actions[1].href).to.contain('?tab=transcript');
       const running = menus[1].actions.map((action) => action.id);
       expect(running).to.contain('cancel');
+    });
+
+    // The running row carries no session reference, and a link to a session
+    // that does not exist lands on a search with no results.
+    it('offers no session link for a run that never opened one', async () => {
+      const el = await renderRows(EXECUTIONS);
+      const menus = Array.from(
+        el.shadowRoot?.querySelectorAll('tbody resource-actions') || []
+      ) as Array<HTMLElement & { actions: Array<{ id: string }> }>;
+
+      expect(menus[1].actions.map((action) => action.id)).to.not.contain(
+        'open-session'
+      );
     });
 
     it('offers retry on a failed run', async () => {

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -51,6 +51,7 @@ import '../../components/list-toolbar.ts';
 import '../../components/time-range-select.ts';
 import '../../components/token-figures.ts';
 import type { ResourceAction } from '../../components/resource-actions';
+import { actionsFor } from '../../actions';
 
 interface FlowExecution {
   id: string;
@@ -867,44 +868,21 @@ export class FlowExecutionsView extends AuthedElement {
     window.location.href = this.executionUrl(execution);
   }
 
-  /** Row menu: open, open the conversation, and the two run controls. */
+  /**
+   * What this run offers, from the one registry the execution page reads
+   * (`src/actions/flow-execution-actions.ts`). Open session used to be on
+   * every row, including runs that never opened one, which lands on a search
+   * with no results.
+   */
   private getRowActions(execution: FlowExecution): ResourceAction[] {
-    const url = this.executionUrl(execution);
-    const actions: ResourceAction[] = [
-      { id: 'open', label: 'Open', icon: 'box-arrow-up-right', href: url },
-      {
-        id: 'open-session',
-        label: 'Open session',
-        icon: 'chat-left-text',
-        href: `${url}?tab=transcript`,
-      },
-    ];
-    if (RUNNING_STATUSES.has(execution.status)) {
-      actions.push({
-        id: 'cancel',
-        label: 'Cancel run',
-        icon: 'x-circle',
-        variant: 'danger',
-        separated: true,
-        onClick: () => void this.cancelExecution(execution),
-      });
-    } else if (this.canRetry(execution)) {
-      actions.push({
-        id: 'retry',
-        label: 'Retry run',
-        icon: 'arrow-repeat',
-        separated: true,
-        onClick: () => void this.retryExecution(execution),
-      });
-    }
-    return actions;
-  }
-
-  /** Statuses the retry endpoint accepts (mirrors the execution page). */
-  private canRetry(execution: FlowExecution): boolean {
-    return ['FAILED', 'STOPPED', 'TIMEOUT', 'CANCELLED'].includes(
-      execution.status
-    );
+    return actionsFor('flow-execution', execution, {
+      includeOpen: true,
+      // From the list, the run's own transcript is the conversation, one page
+      // closer than the sessions list.
+      sessionHref: () => `${this.executionUrl(execution)}?tab=transcript`,
+      onCancel: () => void this.cancelExecution(execution),
+      onRetry: () => void this.retryExecution(execution),
+    });
   }
 
   /**

--- a/frontend/src/views/authed/flow-view.test.ts
+++ b/frontend/src/views/authed/flow-view.test.ts
@@ -197,19 +197,30 @@ describe('FlowView detail page language', () => {
   it('uses the list verbs in the header actions', async () => {
     // The header said "Edit Flow / Disable / Test Run" for the three commands
     // the list kebab calls Edit, Pause and Run now, and "Test Run" implied a
-    // rehearsal of a run that spends real money.
+    // rehearsal of a run that spends real money. Both surfaces now read the
+    // same registry, so the page can also delete the flow it is showing.
     const element = await renderDetail();
     try {
       const labels = element
         .getFlowActions()
         .map((action: any) => action.label);
-      expect(labels).to.eql(['Edit', 'Pause', 'Run now']);
+      expect(labels).to.eql(['Run now', 'Edit', 'Pause', 'Delete']);
 
       const paused = await renderDetail({ is_enabled: false });
       try {
-        expect(
-          paused.getFlowActions().map((action: any) => action.label)
-        ).to.eql(['Edit', 'Resume', 'Run now']);
+        const pausedActions = paused.getFlowActions();
+        expect(pausedActions.map((action: any) => action.label)).to.eql([
+          'Run now',
+          'Edit',
+          'Resume',
+          'Delete',
+        ]);
+        // Run now stays on screen, disabled, and says what has to change.
+        const run = pausedActions.find(
+          (action: any) => action.id === 'run-now'
+        );
+        expect(run.disabled).to.equal(true);
+        expect(run.tooltip).to.equal('Resume the flow before running it');
       } finally {
         paused.remove();
       }

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -6,6 +6,7 @@ import {
   getFlow,
   createFlow,
   updateFlow,
+  deleteFlow,
   getTrackers,
   getAIModels,
   listOrganizations,
@@ -47,6 +48,8 @@ import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '../../components/icon-selector.ts';
 import '../../components/resource-actions.ts';
 import type { ResourceAction } from '../../components/resource-actions.ts';
+import { actionsFor } from '../../actions';
+import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import { getTrackerEventOptions } from '../../constants/tracker-event-types';
 import type { Flow } from '../../types';
@@ -517,38 +520,54 @@ export class FlowView extends LitElement {
   }
 
   /**
-   * The three commands, named as the list's kebab names them.
+   * What this flow offers, from the one registry the flows list reads
+   * (`src/actions/flow-actions.ts`).
    *
-   * The header used to say "Edit Flow / Disable / Test Run" for what the list
-   * calls "Edit / Pause / Run now". "Test Run" was the worst of the three: it
-   * suggests a rehearsal, and it starts a real execution that spends real
-   * money, from the same dialog the list's Run now opens.
+   * The page used to name the same two actions `edit-flow` and `test-run`
+   * where the list said `edit` and `run-now` ("Test Run" was the worst of the
+   * two: it suggests a rehearsal, and it starts a real run that spends real
+   * money), and it could not delete the flow it was showing.
    */
   private getFlowActions(): ResourceAction[] {
-    const actions: ResourceAction[] = [
+    return actionsFor(
+      'flow',
       {
-        id: 'edit-flow',
-        label: 'Edit',
-        icon: 'pencil',
-        href: `/console/flows/${this.flowId}?edit=true`,
+        id: this.flowId || '',
+        name: this.flow?.name,
+        is_enabled: !!this.flow?.is_enabled,
       },
       {
-        id: 'toggle-enabled',
-        label: this.flow.is_enabled ? 'Pause' : 'Resume',
-        variant: this.flow.is_enabled ? 'default' : 'success',
-        icon: this.flow.is_enabled ? 'pause-circle' : 'play-circle',
-        onClick: () => this.toggleFlowEnabled(),
-      },
-      {
-        id: 'test-run',
-        label: 'Run now',
-        variant: 'primary',
-        icon: 'play-circle',
-        disabled: !this.flow.is_enabled,
-        onClick: () => this.testRun(),
-      },
-    ];
-    return actions;
+        onRun: () => void this.testRun(),
+        onToggleEnabled: () => void this.toggleFlowEnabled(),
+        onDelete: () => void this.deleteFlow(),
+      }
+    );
+  }
+
+  /** Deletes the flow this page is showing, then goes back to the list. */
+  private async deleteFlow(): Promise<void> {
+    if (!this.flowId) return;
+    const confirmed = await confirmDialog({
+      title: 'Delete flow',
+      message: `Delete "${this.flow?.name || 'this flow'}"?`,
+      detail:
+        'The flow and its trigger stop immediately. Past runs stay in the executions list. This cannot be undone.',
+      confirmLabel: 'Delete flow',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    try {
+      await deleteFlow(this.flowId);
+      showToast(`Deleted ${this.flow?.name || 'the flow'}.`, 'success');
+      Router.go('/console/flows');
+    } catch (error) {
+      showToast(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Could not delete the flow. Try again.',
+        'danger'
+      );
+    }
   }
 
   render() {

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -197,6 +197,60 @@ describe('FlowsView', () => {
     resetConfirmDialogForTests();
   });
 
+  it('keeps Edit off the bulk bar so it cannot pause the selection', async () => {
+    const mockFlows = [
+      { id: 'flow-1', name: 'Nightly sweep', is_enabled: true },
+      { id: 'flow-2', name: 'PR reviewer', is_enabled: true },
+    ];
+    fetchStub = createFetchStub(mockFlows, []);
+    const element = (await fixture(
+      html`<flows-view></flows-view>`
+    )) as FlowsView;
+    await waitUntil(
+      () => (element as any).flows?.length === 2,
+      'Flows did not load'
+    );
+    await element.updateComplete;
+
+    const rowLink = (id: string) =>
+      element.shadowRoot!.querySelector<HTMLElement>(
+        `tr[data-selection-id="${id}"] a.row-link`
+      )!;
+    rowLink('flow-1').dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'x',
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+    await element.updateComplete;
+    rowLink('flow-2').dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'X',
+        shiftKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+    await element.updateComplete;
+
+    const ids = ((element as any).bulkActions as Array<{ id: string }>).map(
+      (action) => action.id
+    );
+    expect(ids).to.deep.equal(['pause', 'delete']);
+    expect(
+      ids,
+      'Edit is a per-row link and has no bulk handler'
+    ).to.not.contain('edit');
+
+    const bar = element.shadowRoot!.querySelector('list-bulk-bar')!;
+    expect(bar.shadowRoot!.querySelector('[data-action="edit"]')).to.equal(
+      null
+    );
+  });
+
   it('names the flows it is about to delete and clears with Escape', async () => {
     const mockFlows = [
       { id: 'flow-1', name: 'Nightly sweep', is_enabled: true },

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -29,7 +29,10 @@ import {
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
 import { actionsFor, intersectActions } from '../../actions';
-import type { FlowActionResource } from '../../actions/flow-actions';
+import {
+  FLOW_BULK_ACTION_IDS,
+  type FlowActionResource,
+} from '../../actions/flow-actions';
 import {
   ListSelectionController,
   confirmBulkAction,
@@ -1274,7 +1277,9 @@ export class FlowsView extends LitElement {
    * a selection of paused flows was still offered Pause. It now keeps only
    * what every selected flow offers, which for a mixed selection is Delete:
    * "resume all" over a mix has to be a selection of the paused ones, and the
-   * filter bar is one click away.
+   * filter bar is one click away. The bar carries pause, resume and delete
+   * only: Edit is a per-row link with an href fallback, so it would otherwise
+   * survive the intersection and fall through to pause.
    */
   private get bulkActions(): BulkAction[] {
     const sets = this.selection.selectedItems.map((row) =>
@@ -1283,15 +1288,17 @@ export class FlowsView extends LitElement {
         onDelete: () => {},
       })
     );
-    return intersectActions(sets).map((action) => ({
-      id: action.id,
-      label: action.label,
-      icon: action.icon,
-      // Pause is neutral on a row, amber in a bar of two over a selection.
-      variant: (action.id === 'pause'
-        ? 'warning'
-        : action.variant) as BulkAction['variant'],
-    }));
+    return intersectActions(sets)
+      .filter((action) => action.id in FLOW_BULK_ACTION_IDS)
+      .map((action) => ({
+        id: action.id,
+        label: action.label,
+        icon: action.icon,
+        // Pause is neutral on a row, amber in a bar of two over a selection.
+        variant: (action.id === 'pause'
+          ? 'warning'
+          : action.variant) as BulkAction['variant'],
+      }));
   }
 
   private renderSelectCheckbox(row: FlowListRow) {

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -28,6 +28,8 @@ import {
 } from '../../api';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
+import { actionsFor, intersectActions } from '../../actions';
+import type { FlowActionResource } from '../../actions/flow-actions';
 import {
   ListSelectionController,
   confirmBulkAction,
@@ -157,6 +159,11 @@ export interface FlowListRow {
   /** True when runs, failed and cost all come from the server's window. */
   countsFromServer: boolean;
   source: FlowListItem;
+}
+
+/** The little the action registry needs to know about a flow row. */
+function flowActionResource(row: FlowListRow): FlowActionResource {
+  return { id: row.id, name: row.name, is_enabled: row.status !== 'paused' };
 }
 
 const FLOW_STATUS_LABELS: Record<FlowStatus, string> = {
@@ -1202,47 +1209,18 @@ export class FlowsView extends LitElement {
 
   // --- Row actions ---
 
+  /**
+   * What this flow offers, from the one registry the flow page reads
+   * (`src/actions/flow-actions.ts`).
+   */
   private getRowActions(row: FlowListRow): ResourceAction[] {
-    const paused = row.status === 'paused';
-    const actions: ResourceAction[] = [
-      {
-        id: 'open',
-        label: 'Open',
-        icon: 'box-arrow-up-right',
-        href: row.detailUrl,
-      },
-      {
-        id: 'run-now',
-        label: 'Run now',
-        icon: 'play-circle',
-        disabled: paused || this.triggeringFlowId === row.id,
-        loading: this.triggeringFlowId === row.id,
-        tooltip: paused ? 'Resume the flow before running it' : undefined,
-        onClick: () => void this.triggerRun(row),
-      },
-      {
-        id: 'edit',
-        label: 'Edit',
-        icon: 'pencil',
-        href: `${row.detailUrl}?edit=true`,
-      },
-      {
-        id: 'toggle-enabled',
-        label: paused ? 'Resume' : 'Pause',
-        icon: paused ? 'play-circle' : 'pause-circle',
-        onClick: () => void this.toggleFlowEnabled(row),
-      },
-      {
-        id: 'delete',
-        label: 'Delete',
-        icon: 'trash',
-        variant: 'danger',
-        outline: true,
-        separated: true,
-        onClick: () => void this.deleteFlowHandler(row),
-      },
-    ];
-    return actions;
+    return actionsFor('flow', flowActionResource(row), {
+      includeOpen: true,
+      busy: this.triggeringFlowId === row.id,
+      onRun: () => void this.triggerRun(row),
+      onToggleEnabled: () => void this.toggleFlowEnabled(row),
+      onDelete: () => void this.deleteFlowHandler(row),
+    });
   }
 
   private async triggerRun(row: FlowListRow) {
@@ -1290,22 +1268,30 @@ export class FlowsView extends LitElement {
   }
 
   /**
-   * What a set of flows can be asked to do. Pause and resume are offered
-   * whatever the mix: a selection of five paused and two running is exactly
-   * when an operator reaches for "resume all", and the run reports the ones
-   * that were already there as successes.
+   * What the whole selection can be asked to do.
+   *
+   * The bar used to offer Pause, Resume and Delete whatever was selected, so
+   * a selection of paused flows was still offered Pause. It now keeps only
+   * what every selected flow offers, which for a mixed selection is Delete:
+   * "resume all" over a mix has to be a selection of the paused ones, and the
+   * filter bar is one click away.
    */
   private get bulkActions(): BulkAction[] {
-    return [
-      {
-        id: 'resume',
-        label: 'Resume',
-        icon: 'play-circle',
-        variant: 'success',
-      },
-      { id: 'pause', label: 'Pause', icon: 'pause-circle', variant: 'warning' },
-      { id: 'delete', label: 'Delete', icon: 'trash', variant: 'danger' },
-    ];
+    const sets = this.selection.selectedItems.map((row) =>
+      actionsFor('flow', flowActionResource(row), {
+        onToggleEnabled: () => {},
+        onDelete: () => {},
+      })
+    );
+    return intersectActions(sets).map((action) => ({
+      id: action.id,
+      label: action.label,
+      icon: action.icon,
+      // Pause is neutral on a row, amber in a bar of two over a selection.
+      variant: (action.id === 'pause'
+        ? 'warning'
+        : action.variant) as BulkAction['variant'],
+    }));
   }
 
   private renderSelectCheckbox(row: FlowListRow) {


### PR DESCRIPTION
## Why

From production: "The actions that appear do not match the type and the state of the
resource. We need a generic way of mapping actions to resource types and states and only
displaying the available actions in the lists and in the single resource views."

The audit that started this is in the report. A sample of what was true before:

- The agents bulk bar offered Pause, Resume and Decommission on any selection, whatever state
  the selected agents were in (`agents-view.ts:2990-3001`, a static array).
- The agent page could not decommission an agent the list could decommission
  (`agent-detail-view.ts:1938-2025`).
- The flow page could not delete a flow the list could delete.
- Every flow execution row offered "Open session", including runs that never opened one.
- The flow execution page hand-rolled its buttons with a second copy of the retry predicate
  and different labels from the row's.
- Approvals spelled out "pending, unexpired, not a question" in four places (row, bulk
  selection, keyboard, request page).

## What

`frontend/src/actions/` is one registry. Each type declares its candidate actions with an
`available(resource)` predicate, and `defineActions` (`actions/registry.ts`) filters, orders,
puts destructive actions last with the DESIGN.md gap, and checks permissions. Lists and detail
pages call the same `actionsFor(type, resource, ctx)`; bulk bars pass the selection through
`intersectActions`, so only what every selected row offers survives.

No new rendering component: `resource-actions` stays the single renderer and its public API is
unchanged (the registry strips its own keys before returning plain `ResourceAction`s).

Migrated: agents, flows, flow executions, runtime sessions, approvals. Tools, AI models, API
keys, trackers, policies and runners are audited with call sites in the report and left as
mechanical follow-ups to keep this reviewable.

Deliberate deviations, argued in the report: approvals keep their own row buttons and decision
form (a comment box and an "always allow" checkbox are a form, not a button row) and take only
availability from the registry; the flows bulk bar no longer offers Pause and Resume together
on a mixed selection.

## Numbers

- `npm test`: 174 files, 2126 passed, 0 failed. Baseline `a7104a9b`: 168 files, 2055 passed.
- 54 new `it` blocks by hand: 48 registry unit tests plus 6 view tests.
- `npm run build` passes. Bundle 3,085.68 kB (gzip 701.06 kB) against 3,083.88 kB
  (gzip 699.71 kB) on the base: +1.80 kB raw, +1.35 kB gzip.
- `npx tsc --noEmit`: 108 errors, the same 108 the untouched tree emits. None in
  `src/actions/`.
- 29 files, +1988 / -531.

Report: `/tmp/preloop-reports/ux6-actions-registry.md`

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Medium Risk]**
> Changes to important, product-critical logic (agent lifecycle, approval decisions, flow deletion). No security issues found. The one HIGH-severity defect from the prior review (the flows bulk-bar `edit` leak) is fixed in `65aea04b`.
>
> **Overview**
> Introduces a single `src/actions/` registry mapping actions to resource type and state, shared by list rows, bulk bars, and detail pages for agents, flows, flow executions, runtime sessions, and approvals. Consolidates previously duplicated predicates and labels, and adds the missing flow-page delete and session/flow-execution action parity.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 65aea04b. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
