### PR TITLE
Typecheck the token fixtures added by #492

### DIFF
--- a/frontend/src/components/token-figures.test.ts
+++ b/frontend/src/components/token-figures.test.ts
@@ -246,9 +246,12 @@ describe('token-figures', () => {
   });
 
   it('adds the directions up where the endpoint reported no total', () => {
-    expect(totalTokensOf({ input_tokens: 400, output_tokens: 100 })).to.equal(
-      500
-    );
+    expect(
+      totalTokensOf({
+        input_tokens: 400,
+        output_tokens: 100,
+      } as GatewayTokenUsage)
+    ).to.equal(500);
     expect(totalTokensOf(USAGE)).to.equal(15500);
     expect(totalTokensOf(null)).to.equal(0);
   });

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -1382,12 +1382,18 @@ describe('sortAgentListRows', () => {
       makeRow({
         id: 'small',
         name: 'Small',
-        tokenUsage: { total_tokens: 15500, input_tokens: 12400 },
+        tokenUsage: {
+          total_tokens: 15500,
+          input_tokens: 12400,
+        } as AgentListRow['tokenUsage'],
       }),
       makeRow({
         id: 'large',
         name: 'Large',
-        tokenUsage: { total_tokens: 900000, input_tokens: 100 },
+        tokenUsage: {
+          total_tokens: 900000,
+          input_tokens: 100,
+        } as AgentListRow['tokenUsage'],
       }),
       makeRow({
         id: 'split',

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -1171,7 +1171,7 @@ describe('FlowsView', () => {
     });
 
     it('sorts tokens by the total the cell states', () => {
-      // The list cell shows one total, and the column sorts by it — including
+      // The list cell shows one total, and the column sorts by it, including
       // the in+out fallback when the payload has directions and no total.
       const rows = [
         makeRow({


### PR DESCRIPTION
Follow-up to #492 (merged). The new test fixtures in token-figures.test.ts and agents-view.test.ts passed object literals where GatewayTokenUsage requires prompt_tokens, completion_tokens and total_tokens, so tsc --noEmit went from 99 to 102 errors on main. This casts them the same way the sibling fixture already does, and replaces one em dash in flows-view.test.ts with a comma.

Measured: tsc back to the main baseline of 99; the three touched suites 111 passed, 0 failed; pre-commit clean.

Found by the round 6 review pass (report: SHOULD-1). Two report-only notes from the same pass, not in this PR: the Overview Inventory and executions list still show the three-part token breakdown (agents/flows now show the total), and the bell hit target is 38px (D24 asks 44px on coarse pointers).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Test-only type casts and a comment punctuation fix; no functional, security, or performance changes.
>
> **Overview**
> Follow-up to #492 that type-checks the token test fixtures by casting them the same way the sibling `USAGE` fixture already does, plus a one-character comment punctuation fix. No issues found; changes are correct and consistent.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 6741979. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->