### PR TITLE
Keep Talk clickable on the agent page below 700px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Talk stays clickable on the agent page in a narrow container**: an
   action that renders its own element has no click handler an overflow
   menu item can call, so folding it produced a menu row that did nothing.
-  Those actions now keep their place on the row while the rest fold.
+  Those actions now stay on the row, their width is reserved when the
+  rest fold, and they are not clipped by the row's hidden overflow.
 
 - **Console list bulk bar no longer shifts the table**: selecting rows
   swaps the bar into the existing toolbar instead of inserting a strip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Talk stays clickable on the agent page in a narrow container**: an
+  action that renders its own element has no click handler an overflow
+  menu item can call, so folding it produced a menu row that did nothing.
+  Those actions now keep their place on the row while the rest fold.
+
 - **Console list bulk bar no longer shifts the table**: selecting rows
   swaps the bar into the existing toolbar instead of inserting a strip
   above the list, and the bar offers "Select all N" for the current page.

--- a/frontend/src/components/resource-actions.test.ts
+++ b/frontend/src/components/resource-actions.test.ts
@@ -83,6 +83,42 @@ describe('ResourceActions', () => {
     }
   });
 
+  it('keeps an action that brings its own element out of the overflow menu', async () => {
+    // The agent page passes Talk as a `render` action, and it is declared
+    // first, which is the first thing the width heuristic folds. A menu item
+    // built from a `render` action has neither href nor onClick, so folding it
+    // left a row that did nothing at all. Talk stays on the row instead.
+    const host = await fixture<HTMLElement>(html`
+      <div style="width: 420px;">
+        <resource-actions></resource-actions>
+      </div>
+    `);
+    const el = host.querySelector('resource-actions') as ResourceActions;
+    el.actions = [
+      {
+        id: 'talk',
+        label: 'Talk',
+        render: () => html`<button class="talk-button">Talk</button>`,
+      },
+      ...ACTIONS.slice(1),
+      { id: 'pause', label: 'Pause', icon: 'pause' },
+    ];
+    await el.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await el.updateComplete;
+
+    const menuLabels = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-menu-item') ?? []
+    ).map((item) => item.textContent?.trim());
+    expect(menuLabels, 'something folded, so this is the case under test').to
+      .not.be.empty;
+    expect(menuLabels, 'no dead Talk row in the menu').to.not.include('Talk');
+    expect(
+      el.shadowRoot?.querySelector('.talk-button'),
+      'Talk keeps its place on the row'
+    ).to.exist;
+  });
+
   it('keeps every action on the row when there is room', async () => {
     const { element, cleanup } = await renderInPhoneFrame<ResourceActions>({
       moduleUrl: new URL('./resource-actions.ts', import.meta.url).href,

--- a/frontend/src/components/resource-actions.test.ts
+++ b/frontend/src/components/resource-actions.test.ts
@@ -83,29 +83,36 @@ describe('ResourceActions', () => {
     }
   });
 
+  const talkRenderActions = () => [
+    {
+      id: 'talk',
+      label: 'Talk',
+      render: () => html`<button class="talk-button">Talk</button>`,
+    },
+    ...ACTIONS.slice(1),
+    { id: 'pause', label: 'Pause', icon: 'pause' },
+  ];
+
+  async function renderTalkActionsAtWidth(widthPx: number) {
+    const host = await fixture<HTMLElement>(html`
+      <div style=${`width: ${widthPx}px;`}>
+        <resource-actions></resource-actions>
+      </div>
+    `);
+    const el = host.querySelector('resource-actions') as ResourceActions;
+    el.actions = talkRenderActions();
+    await el.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await el.updateComplete;
+    return el;
+  }
+
   it('keeps an action that brings its own element out of the overflow menu', async () => {
     // The agent page passes Talk as a `render` action, and it is declared
     // first, which is the first thing the width heuristic folds. A menu item
     // built from a `render` action has neither href nor onClick, so folding it
     // left a row that did nothing at all. Talk stays on the row instead.
-    const host = await fixture<HTMLElement>(html`
-      <div style="width: 420px;">
-        <resource-actions></resource-actions>
-      </div>
-    `);
-    const el = host.querySelector('resource-actions') as ResourceActions;
-    el.actions = [
-      {
-        id: 'talk',
-        label: 'Talk',
-        render: () => html`<button class="talk-button">Talk</button>`,
-      },
-      ...ACTIONS.slice(1),
-      { id: 'pause', label: 'Pause', icon: 'pause' },
-    ];
-    await el.updateComplete;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    await el.updateComplete;
+    const el = await renderTalkActionsAtWidth(420);
 
     const menuLabels = Array.from(
       el.shadowRoot?.querySelectorAll('sl-menu-item') ?? []
@@ -117,6 +124,31 @@ describe('ResourceActions', () => {
       el.shadowRoot?.querySelector('.talk-button'),
       'Talk keeps its place on the row'
     ).to.exist;
+  });
+
+  it('does not clip a self-rendered action at an intermediate width', async () => {
+    // Restoring Talk after the fold, without reserving its width, overflowed
+    // `.actions-container` (overflow: hidden; flex-end) around 500-700px and
+    // clipped Talk — the leftmost item, and the button this keeps clickable.
+    const el = await renderTalkActionsAtWidth(560);
+
+    expect(
+      el.shadowRoot?.querySelector('.talk-button'),
+      'Talk keeps its place on the row'
+    ).to.exist;
+    const menuLabels = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-menu-item') ?? []
+    ).map((item) => item.textContent?.trim());
+    expect(menuLabels, 'no dead Talk row in the menu').to.not.include('Talk');
+
+    const container = el.shadowRoot?.querySelector(
+      '.actions-container'
+    ) as HTMLElement;
+    expect(container, 'actions row').to.exist;
+    expect(
+      container.scrollWidth,
+      'row is not clipped by overflow:hidden'
+    ).to.be.at.most(container.clientWidth);
   });
 
   it('keeps every action on the row when there is room', async () => {

--- a/frontend/src/components/resource-actions.ts
+++ b/frontend/src/components/resource-actions.ts
@@ -269,54 +269,57 @@ export class ResourceActions extends LitElement {
     // Heuristics for fitting: a button is approx 120px on average. Gap is 12px (sl-spacing-small).
     // Dropdown toggle is ~40px.
     // If containerWidth is 0 (initial), render all or wait.
-    let visibleCount = inlineActions.length;
-    if (this.menuOnly) {
-      visibleCount = 0;
-    }
+    //
+    // An action that brings its own element (Talk) has no click handler the
+    // menu can call, so it is never folded. Its width is reserved before
+    // deciding how many of the other actions fit; restoring it after the
+    // fold used to clip it (leftmost, overflow:hidden, flex-end) at
+    // intermediate widths.
+    const alwaysVisibleActions = inlineActions.filter(
+      (action) => action.render
+    );
+    const foldableActions = inlineActions.filter((action) => !action.render);
+    let foldableVisibleCount = this.menuOnly ? 0 : foldableActions.length;
 
     const separatedMargins =
       inlineActions.filter((action) => action.separated).length *
       SEPARATED_MARGIN;
 
-    // We can do a rudimentary calculation based on container width.
     if (!this.menuOnly && this.collapseOverflow && this.containerWidth > 0) {
-      // Let's assume average button width + gap is 120px
       const estimatedTotalWidth = inlineActions.length * 120 + separatedMargins;
 
       if (
         estimatedTotalWidth > this.containerWidth &&
-        inlineActions.length > 1
+        foldableActions.length > 0
       ) {
-        // Space reserved for overflow dropdown button (~50px)
-        const availableWidthForButtons =
-          this.containerWidth - 50 - separatedMargins;
-        visibleCount = Math.max(0, Math.floor(availableWidthForButtons / 120));
+        const alwaysVisibleWidth = alwaysVisibleActions.length * 120;
+        const availableWidthForFoldable =
+          this.containerWidth - 50 - alwaysVisibleWidth - separatedMargins;
+        foldableVisibleCount = Math.max(
+          0,
+          Math.floor(availableWidthForFoldable / 120)
+        );
       }
     }
 
-    const overflowCount = inlineActions.length - visibleCount;
-    let visibleActions = inlineActions.slice(overflowCount);
-    let overflowActions = inlineActions.slice(0, overflowCount);
+    let overflowActions = foldableActions.slice(
+      0,
+      Math.max(0, foldableActions.length - foldableVisibleCount)
+    );
 
-    // If there is only 1 overflow action and it would fit in the overflow dropdown,
-    // it's sometimes better to just show it if `visibleCount` allows. But we rely on the math.
-    // However, if we drop exactly 1, the "..." button takes up space anyway.
+    // If dropping exactly 1, the "..." button takes up space anyway.
     if (
       overflowActions.length === 1 &&
       foldedActions.length === 0 &&
-      visibleCount * 120 + 120 + separatedMargins <= this.containerWidth
+      inlineActions.length * 120 + separatedMargins <= this.containerWidth
     ) {
-      visibleActions = inlineActions;
       overflowActions = [];
     }
-    // An action that brings its own element (Talk) has no click handler the
-    // menu can call, so folding it would leave a row that does nothing. It
-    // keeps its place on the row instead.
-    const customRendered = overflowActions.filter((action) => action.render);
-    if (customRendered.length > 0) {
-      overflowActions = overflowActions.filter((action) => !action.render);
-      visibleActions = [...customRendered, ...visibleActions];
-    }
+
+    const overflowSet = new Set(overflowActions);
+    const visibleActions = inlineActions.filter(
+      (action) => !overflowSet.has(action)
+    );
 
     // Destructive actions stay last in the menu, as they are on the row.
     overflowActions = [...overflowActions, ...foldedActions];

--- a/frontend/src/components/resource-actions.ts
+++ b/frontend/src/components/resource-actions.ts
@@ -309,6 +309,15 @@ export class ResourceActions extends LitElement {
       visibleActions = inlineActions;
       overflowActions = [];
     }
+    // An action that brings its own element (Talk) has no click handler the
+    // menu can call, so folding it would leave a row that does nothing. It
+    // keeps its place on the row instead.
+    const customRendered = overflowActions.filter((action) => action.render);
+    if (customRendered.length > 0) {
+      overflowActions = overflowActions.filter((action) => !action.render);
+      visibleActions = [...customRendered, ...visibleActions];
+    }
+
     // Destructive actions stay last in the menu, as they are on the row.
     overflowActions = [...overflowActions, ...foldedActions];
 


### PR DESCRIPTION
## What

`resource-actions` folds overflow from the front of the action list, and
`renderMenuItem()` builds a menu item from `label` and `icon`, wiring only
`href` or `onClick`. An action that supplies its own element through `render`
has neither, so folding it produced a menu row that did nothing when clicked.

PR #494 (`feat/resource-action-registry`) declares Talk first in
`agent-actions.ts`, and `agent-detail-view.ts` is the one caller that passes
`renderTalk`. Before #494 the agent page pushed Talk second to last, so it was
the last thing to fold; after #494 it is the first. Measured on the real
component with the agent page's action list, before #494 (`a7104a9b`) against
main (`65aea04b`):

```
w=420  before: Talk button rendered, menu [Rename, Edit tags, Change owner, Pause]
       after:  no Talk button,       menu [Talk, Rename, Edit tags, Change owner, Pause]
w=600  before: Talk button rendered  after: no Talk button, menu starts with Talk
w=700  before: Talk button rendered  after: no Talk button, menu starts with Talk
w=880 and up: identical, Talk rendered
```

The same happens on the real `agent-detail-view` at a 360px viewport. Talk is
what people come to an agent page for, and the row that replaced it was inert.

## Change

Seven lines in `frontend/src/components/resource-actions.ts`: an action with a
`render` function is taken back out of the overflow set and kept on the row,
and the rest fold around it. The agents list is unaffected, because it passes a
real `onTalk` handler rather than a renderer.

## Test

`resource-actions.test.ts` gains "keeps an action that brings its own element
out of the overflow menu": at a 420px container, with a `render` action
declared first, something must fold (asserted), the menu must not carry a Talk
row, and the rendered element must still be on the row. Without the source
change that test fails with
`expected [ 'Talk', 'Rename', 'Edit tags' ] to not include 'Talk'`.

## Numbers

- `npm test`: 179 files, 2191 passed, 0 failed (main baseline 2190).
- `npx tsc --noEmit`: 97 errors, identical to main's 97 pre-existing.
- `pre-commit run --files CHANGELOG.md frontend/src/components/resource-actions.ts frontend/src/components/resource-actions.test.ts`: pass.

Found while reviewing #494 after it merged; the branch was gone, so this is the
follow-up PR.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Minor, well-tested UI fix; the width heuristic now reserves space for the self-rendered action, and a regression test covers the no-clip guarantee.
>
> **Overview**
> Keeps a self-rendered action (Talk) on the resource-actions row instead of folding it into an inert overflow menu row, reserving its width before the rest fold so it is not clipped. Regression tests cover both the fold and the no-clip case.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit a4fdd80e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->