### PR TITLE
PR reviewer: judge whether the PR addresses the issue it references

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ AI Agent → Preloop → [Policy]  → Allow / Deny / Require Approval → Execu
 
 [Automated issue implementation](docs/guide/flows/durable-implementation-feedback.md) can resume its PR branch and native agent conversation after review or CI feedback, with durable turn budgets and current-head gates.
 
-Connect GitHub, GitLab, or Jira as flow triggers and issue tools. Automations ship as presets, including the [Issue Triage Assistant](./docs/guide/flows/issue-triage.md), [Pull Request Reviewer](./backend/presets/002-pull-request-reviewer.yaml) and [Observe / Eval](./backend/presets/003-observe-eval.yaml). Or write your own.
+Connect GitHub, GitLab, or Jira as flow triggers and issue tools. Automations ship as presets, including the [Issue Triage Assistant](./docs/guide/flows/issue-triage.md), [Pull Request Reviewer](./docs/guide/flows/pull-request-review.md) and [Observe / Eval](./backend/presets/003-observe-eval.yaml). Or write your own.
 
 ### Policy-as-code
 

--- a/backend/preloop/services/issue_references.py
+++ b/backend/preloop/services/issue_references.py
@@ -190,13 +190,14 @@ def _scan_keywords(
 ) -> None:
     for match in pattern.finditer(text):
         position = match.end()
-        while match is not None:
-            jira = match.group("jira")
+        chain = match
+        while chain is not None:
+            jira = chain.group("jira")
             if jira:
                 _add(found, key=jira, kind=kind, source=source, url=None)
             else:
-                path = match.group("path") or repo_path
-                number = match.group("number")
+                path = chain.group("path") or repo_path
+                number = chain.group("number")
                 if path:
                     _add(
                         found,
@@ -206,9 +207,9 @@ def _scan_keywords(
                         url=_issue_url(host, path, number, platform),
                     )
             # "Closes #12, #13 and #14": the keyword governs the whole list.
-            match = _CHAIN_RE.match(text, position)
-            if match is not None:
-                position = match.end()
+            chain = _CHAIN_RE.match(text, position)
+            if chain is not None:
+                position = chain.end()
 
 
 def extract_issue_references(

--- a/backend/preloop/services/issue_references.py
+++ b/backend/preloop/services/issue_references.py
@@ -77,13 +77,20 @@ def _keyword_pattern(keywords: Iterable[str]) -> re.Pattern[str]:
         sorted((re.escape(k) for k in keywords), key=len, reverse=True)
     )
     return re.compile(
-        rf"(?<![A-Za-z0-9])(?:{alternatives})\b\s*:?\s+{_KEYWORD_TARGET}",
+        # The optional "[" catches "Closes [#12](url)", a common body form.
+        rf"(?<![A-Za-z0-9])(?:{alternatives})\b\s*:?\s+\[?{_KEYWORD_TARGET}",
         re.IGNORECASE,
     )
 
 
 _CLOSING_RE = _keyword_pattern(_CLOSING_KEYWORDS)
 _REFERENCE_RE = _keyword_pattern(_REFERENCE_KEYWORDS)
+
+# Continuation of a keyword list: "Closes #12, #13 and #14".
+_CHAIN_RE = re.compile(
+    rf"\s*(?:,|and|&|\+)\s*{_KEYWORD_TARGET}",
+    re.IGNORECASE,
+)
 
 # Bare "#123" or "org/repo#123" with no keyword in front of it.
 _BARE_RE = re.compile(
@@ -182,21 +189,26 @@ def _scan_keywords(
     found: List[IssueReference],
 ) -> None:
     for match in pattern.finditer(text):
-        jira = match.group("jira")
-        if jira:
-            _add(found, key=jira, kind=kind, source=source, url=None)
-            continue
-        path = match.group("path") or repo_path
-        number = match.group("number")
-        if not path:
-            continue
-        _add(
-            found,
-            key=f"{path}#{number}",
-            kind=kind,
-            source=source,
-            url=_issue_url(host, path, number, platform),
-        )
+        position = match.end()
+        while match is not None:
+            jira = match.group("jira")
+            if jira:
+                _add(found, key=jira, kind=kind, source=source, url=None)
+            else:
+                path = match.group("path") or repo_path
+                number = match.group("number")
+                if path:
+                    _add(
+                        found,
+                        key=f"{path}#{number}",
+                        kind=kind,
+                        source=source,
+                        url=_issue_url(host, path, number, platform),
+                    )
+            # "Closes #12, #13 and #14": the keyword governs the whole list.
+            match = _CHAIN_RE.match(text, position)
+            if match is not None:
+                position = match.end()
 
 
 def extract_issue_references(

--- a/backend/preloop/services/issue_references.py
+++ b/backend/preloop/services/issue_references.py
@@ -1,0 +1,403 @@
+"""Parse issue references out of pull-request text and branch names.
+
+The Pull Request Reviewer preset judges whether a PR addresses the issue it
+references. Nothing in the tracker payload carries that relation: the GitHub
+``get_pull_request`` mapping (``preloop/sync/trackers/github.py``) and the
+GitLab merge-request mapping (``preloop/api/endpoints/mcp.py``) both return a
+fixed field list with no ``closes_issues``. So the reference has to be read
+off the PR itself: closing keywords in the body, plain issue URLs, and the
+branch name.
+
+Doing it here rather than in the prompt keeps it deterministic and testable,
+and hands the agent identifiers that ``get_issue`` already accepts (a full
+issue URL, ``org/repo#123``, or a Jira key).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+# Kind ranks: a closing keyword is a promise, a plain mention is a hint, and a
+# branch number is a guess. Stronger kinds win when the same issue is found
+# twice and are listed first.
+KIND_CLOSES = "closes"
+KIND_REFERENCE = "reference"
+KIND_BRANCH = "branch"
+
+_KIND_RANK = {KIND_CLOSES: 0, KIND_REFERENCE: 1, KIND_BRANCH: 2}
+
+# Upper bound on the PR text scanned for references.
+MAX_SCANNED_CHARS = 50_000
+
+# GitHub's closing keywords plus GitLab's "implement" family.
+_CLOSING_KEYWORDS = (
+    "close",
+    "closes",
+    "closed",
+    "closing",
+    "fix",
+    "fixes",
+    "fixed",
+    "fixing",
+    "resolve",
+    "resolves",
+    "resolved",
+    "resolving",
+    "implement",
+    "implements",
+    "implemented",
+)
+
+# Weaker phrases that still name an issue this PR is about.
+_REFERENCE_KEYWORDS = (
+    "ref",
+    "refs",
+    "references",
+    "related to",
+    "relates to",
+    "part of",
+    "addresses",
+    "towards",
+    "see",
+)
+
+_JIRA_KEY = r"[A-Z][A-Z0-9]{1,9}-\d{1,6}"
+# Project paths: "org/repo" for GitHub, "group/sub/project" for GitLab.
+_PATH = r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+"
+_NUMBER = r"\d{1,7}"
+
+_KEYWORD_TARGET = rf"(?:(?P<path>{_PATH})?#(?P<number>{_NUMBER})|(?P<jira>{_JIRA_KEY}))"
+
+
+def _keyword_pattern(keywords: Iterable[str]) -> re.Pattern[str]:
+    alternatives = "|".join(
+        sorted((re.escape(k) for k in keywords), key=len, reverse=True)
+    )
+    return re.compile(
+        rf"(?<![A-Za-z0-9])(?:{alternatives})\b\s*:?\s+{_KEYWORD_TARGET}",
+        re.IGNORECASE,
+    )
+
+
+_CLOSING_RE = _keyword_pattern(_CLOSING_KEYWORDS)
+_REFERENCE_RE = _keyword_pattern(_REFERENCE_KEYWORDS)
+
+# Bare "#123" or "org/repo#123" with no keyword in front of it.
+_BARE_RE = re.compile(
+    rf"(?<![A-Za-z0-9/#-])(?P<path>{_PATH})?#(?P<number>{_NUMBER})(?![0-9])"
+)
+
+# Issue URLs: GitHub /o/r/issues/12, GitLab /g/p/-/issues/12, Jira /browse/KEY-1.
+_URL_RE = re.compile(
+    r"https?://(?P<host>[A-Za-z0-9.:-]+)/(?P<rest>[^\s)>\]\"']+)",
+    re.IGNORECASE,
+)
+
+_BRANCH_PATTERNS = (
+    # 123-slug, 123
+    re.compile(rf"^(?P<number>{_NUMBER})(?:[-_]|$)"),
+    # issue-123, issues/123, gh-123, #123 forms inside a branch path
+    re.compile(
+        rf"(?:^|/)(?:issue|issues|gh|bug)[-_/]?(?P<number>{_NUMBER})(?:[-_/]|$)",
+        re.IGNORECASE,
+    ),
+    # fix/123-slug, feature/123
+    re.compile(rf"(?:^|/)[A-Za-z]+/(?P<number>{_NUMBER})(?:[-_]|$)"),
+)
+
+# Jira-style branch: feature/PROJ-123-slug. Uppercase only, so "fix/abc-1"
+# stays a slug rather than becoming a fake project key.
+_BRANCH_JIRA_RE = re.compile(rf"(?:^|[/_-])(?P<jira>{_JIRA_KEY})(?:[/_-]|$)")
+
+
+@dataclass(frozen=True)
+class IssueReference:
+    """One issue named by a pull request."""
+
+    key: str
+    kind: str
+    source: str
+    url: Optional[str] = None
+
+    def identifier(self) -> str:
+        """The value to hand to the ``get_issue`` tool."""
+        return self.url or self.key
+
+
+def _issue_url(
+    host: Optional[str], path: Optional[str], number: str, platform: Optional[str]
+) -> Optional[str]:
+    """Build a canonical issue URL when host, path, and platform are known."""
+    if not host or not path or not platform:
+        return None
+    scheme = (
+        "http" if host.startswith("localhost") or host.startswith("127.") else "https"
+    )
+    if platform == "github":
+        return f"{scheme}://{host}/{path}/issues/{number}"
+    if platform == "gitlab":
+        return f"{scheme}://{host}/{path}/-/issues/{number}"
+    return None
+
+
+def _parse_issue_url(host: str, rest: str) -> Optional[tuple[str, str]]:
+    """Return (key, normalized_url) for a tracker issue URL, else None."""
+    path = "/" + rest.rstrip("/").rstrip(".,;")
+    match = re.match(r"^/(?P<path>.+?)/-/issues/(?P<number>\d+)$", path)
+    if match:
+        key = f"{match.group('path')}#{match.group('number')}"
+        return key, f"https://{host}{path}"
+    match = re.match(r"^/(?P<path>[^/]+/[^/]+)/issues/(?P<number>\d+)$", path)
+    if match:
+        key = f"{match.group('path')}#{match.group('number')}"
+        return key, f"https://{host}{path}"
+    match = re.match(rf"^/browse/(?P<jira>{_JIRA_KEY})$", path)
+    if match:
+        return match.group("jira"), f"https://{host}{path}"
+    return None
+
+
+def _add(
+    found: List[IssueReference],
+    *,
+    key: str,
+    kind: str,
+    source: str,
+    url: Optional[str],
+) -> None:
+    found.append(IssueReference(key=key, kind=kind, source=source, url=url))
+
+
+def _scan_keywords(
+    text: str,
+    pattern: re.Pattern[str],
+    kind: str,
+    source: str,
+    repo_path: Optional[str],
+    host: Optional[str],
+    platform: Optional[str],
+    found: List[IssueReference],
+) -> None:
+    for match in pattern.finditer(text):
+        jira = match.group("jira")
+        if jira:
+            _add(found, key=jira, kind=kind, source=source, url=None)
+            continue
+        path = match.group("path") or repo_path
+        number = match.group("number")
+        if not path:
+            continue
+        _add(
+            found,
+            key=f"{path}#{number}",
+            kind=kind,
+            source=source,
+            url=_issue_url(host, path, number, platform),
+        )
+
+
+def extract_issue_references(
+    *,
+    description: Optional[str] = None,
+    title: Optional[str] = None,
+    branch: Optional[str] = None,
+    repo_path: Optional[str] = None,
+    host: Optional[str] = None,
+    platform: Optional[str] = None,
+    self_number: Optional[Any] = None,
+    limit: int = 5,
+) -> List[IssueReference]:
+    """Extract issue references from a pull request's text and branch.
+
+    ``repo_path``/``host``/``platform`` describe the PR's own repository and
+    are used to expand same-repo references (``#12``) into keys and URLs.
+    ``self_number`` drops a PR's reference to itself (squash-merge titles
+    routinely carry ``(#45)``).
+    """
+
+    found: List[IssueReference] = []
+    # PR bodies can carry a whole changelog. Scanning the head of the text is
+    # enough for references and keeps the regex work bounded.
+    body = (description or "")[:MAX_SCANNED_CHARS]
+
+    for text, source in ((body, "body"), (title or "", "title")):
+        if not text:
+            continue
+        _scan_keywords(
+            text, _CLOSING_RE, KIND_CLOSES, source, repo_path, host, platform, found
+        )
+        _scan_keywords(
+            text,
+            _REFERENCE_RE,
+            KIND_REFERENCE,
+            source,
+            repo_path,
+            host,
+            platform,
+            found,
+        )
+
+    # Plain issue URLs anywhere in the body count as references.
+    for match in _URL_RE.finditer(body):
+        parsed = _parse_issue_url(match.group("host"), match.group("rest"))
+        if parsed:
+            key, url = parsed
+            _add(found, key=key, kind=KIND_REFERENCE, source="body", url=url)
+
+    # Bare "#12" / "org/repo#12" in the body, no keyword.
+    for match in _BARE_RE.finditer(body):
+        path = match.group("path") or repo_path
+        if not path:
+            continue
+        number = match.group("number")
+        _add(
+            found,
+            key=f"{path}#{number}",
+            kind=KIND_REFERENCE,
+            source="body",
+            url=_issue_url(host, path, number, platform),
+        )
+
+    if branch:
+        jira_match = _BRANCH_JIRA_RE.search(branch)
+        if jira_match:
+            _add(
+                found,
+                key=jira_match.group("jira"),
+                kind=KIND_BRANCH,
+                source="branch",
+                url=None,
+            )
+        for pattern in _BRANCH_PATTERNS:
+            match = pattern.search(branch)
+            if not match or not repo_path:
+                continue
+            number = match.group("number")
+            _add(
+                found,
+                key=f"{repo_path}#{number}",
+                kind=KIND_BRANCH,
+                source="branch",
+                url=_issue_url(host, repo_path, number, platform),
+            )
+            break
+
+    return _dedupe(found, repo_path=repo_path, self_number=self_number, limit=limit)
+
+
+def _dedupe(
+    refs: List[IssueReference],
+    *,
+    repo_path: Optional[str],
+    self_number: Optional[Any],
+    limit: int,
+) -> List[IssueReference]:
+    """Keep the strongest kind per issue, strongest kinds first, capped."""
+    self_key = None
+    if repo_path and self_number not in (None, ""):
+        self_key = f"{repo_path}#{self_number}".lower()
+
+    best: Dict[str, tuple[int, int, IssueReference]] = {}
+    for order, ref in enumerate(refs):
+        key = ref.key.lower()
+        if self_key and key == self_key:
+            continue
+        rank = _KIND_RANK.get(ref.kind, len(_KIND_RANK))
+        current = best.get(key)
+        if current is None or rank < current[0]:
+            # Keep the earliest position so equal kinds stay in document order.
+            position = current[1] if current else order
+            merged = ref if current is None else _merge(ref, current[2])
+            best[key] = (rank, position, merged)
+    ordered = sorted(best.values(), key=lambda item: (item[0], item[1]))
+    return [item[2] for item in ordered][:limit]
+
+
+def _merge(winner: IssueReference, loser: IssueReference) -> IssueReference:
+    """Keep the winner's kind but do not lose a URL the loser had."""
+    if winner.url or not loser.url:
+        return winner
+    return IssueReference(
+        key=winner.key, kind=winner.kind, source=winner.source, url=loser.url
+    )
+
+
+NO_REFERENCES = "none detected"
+
+
+def format_issue_references(refs: Iterable[IssueReference]) -> str:
+    """One prompt-safe line, or ``none detected``."""
+    parts = [
+        f"{ref.key} [{ref.kind}, from {ref.source}]"
+        + (f" {ref.url}" if ref.url else "")
+        for ref in refs
+    ]
+    return "; ".join(parts) if parts else NO_REFERENCES
+
+
+def _payload_repo_path_and_host(
+    payload: Dict[str, Any], attrs: Dict[str, Any]
+) -> tuple[Optional[str], Optional[str]]:
+    """Derive "org/repo" and the tracker host from a trigger payload."""
+    url = attrs.get("url") or ""
+    host: Optional[str] = None
+    repo_path: Optional[str] = None
+    if isinstance(url, str) and url.startswith("http"):
+        parsed = urlparse(url)
+        host = parsed.netloc or None
+        path = parsed.path.rstrip("/")
+        match = re.match(r"^/(?P<path>.+?)/-/merge_requests/\d+$", path) or re.match(
+            r"^/(?P<path>[^/]+/[^/]+)/(?:pull|pulls)/\d+$", path
+        )
+        if match:
+            repo_path = match.group("path")
+    if not repo_path:
+        repository = payload.get("repository")
+        if isinstance(repository, dict):
+            candidate = repository.get("full_name") or repository.get(
+                "path_with_namespace"
+            )
+            if isinstance(candidate, str) and candidate:
+                repo_path = candidate
+        project = payload.get("project")
+        if not repo_path and isinstance(project, dict):
+            candidate = project.get("path_with_namespace")
+            if isinstance(candidate, str) and candidate:
+                repo_path = candidate
+    return repo_path, host
+
+
+def _payload_platform(
+    payload: Dict[str, Any], source: str, host: Optional[str]
+) -> Optional[str]:
+    if "pull_request" in payload:
+        return "github"
+    if payload.get("object_kind") == "merge_request":
+        return "gitlab"
+    if source in ("github", "gitlab"):
+        return source
+    if host and "gitlab" in host:
+        return "gitlab"
+    if host and "github" in host:
+        return "github"
+    return None
+
+
+def references_from_trigger_payload(
+    payload: Dict[str, Any], attrs: Dict[str, Any], source: str = ""
+) -> List[IssueReference]:
+    """Extract references for a normalized PR/MR trigger payload."""
+    repo_path, host = _payload_repo_path_and_host(payload, attrs)
+    platform = _payload_platform(payload, (source or "").lower(), host)
+    return extract_issue_references(
+        description=attrs.get("description"),
+        title=attrs.get("title"),
+        branch=attrs.get("source_branch"),
+        repo_path=repo_path,
+        host=host,
+        platform=platform,
+        self_number=attrs.get("number") or attrs.get("iid"),
+    )

--- a/backend/preloop/services/prompt_resolvers/trigger_event.py
+++ b/backend/preloop/services/prompt_resolvers/trigger_event.py
@@ -3,6 +3,12 @@
 import logging
 from typing import Any, Dict, Optional
 
+from preloop.services.issue_references import (
+    NO_REFERENCES,
+    format_issue_references,
+    references_from_trigger_payload,
+)
+
 from .base import PromptResolver, ResolverContext
 
 logger = logging.getLogger(__name__)
@@ -62,6 +68,36 @@ def _alias_object_attribute_ids(attrs: Dict[str, Any]) -> None:
         attrs["number"] = iid
     if iid is None and number is not None:
         attrs["iid"] = number
+
+
+def _attach_referenced_issues(
+    payload: Dict[str, Any], attrs: Dict[str, Any], source: str
+) -> None:
+    """Add ``object_attributes.referenced_issues`` for pull/merge requests.
+
+    Neither GitHub nor GitLab hands the reviewer a linked-issue relation on
+    the PR read, so the Pull Request Reviewer preset needs the references
+    parsed off the PR body, title, and branch. Parsing here (deterministic,
+    unit-tested) beats asking the model to run regexes in its head, and the
+    resulting identifiers are exactly what the ``get_issue`` tool accepts.
+    """
+    if not isinstance(attrs, dict) or attrs.get("referenced_issues"):
+        return
+    is_pull_request = (
+        "pull_request" in payload
+        or payload.get("object_kind") == "merge_request"
+        or bool(attrs.get("source_branch"))
+    )
+    if not is_pull_request:
+        return
+    try:
+        refs = references_from_trigger_payload(payload, attrs, source)
+        attrs["referenced_issues"] = format_issue_references(refs)
+    except Exception:  # pragma: no cover - never fail prompt resolution
+        logger.warning(
+            "Failed to parse issue references from PR payload", exc_info=True
+        )
+        attrs["referenced_issues"] = NO_REFERENCES
 
 
 def _lift_gitlab_noteable_ids(payload: Dict[str, Any], attrs: Dict[str, Any]) -> None:
@@ -136,6 +172,7 @@ class TriggerEventResolver(PromptResolver):
                 _lift_gitlab_noteable_ids(payload, attrs)
                 _alias_object_attribute_ids(attrs)
                 _enrich_object_attributes(payload, attrs)
+                _attach_referenced_issues(payload, attrs, source)
             return normalized
 
         # For GitHub, create object_attributes from pull_request or issue
@@ -157,6 +194,7 @@ class TriggerEventResolver(PromptResolver):
                     "iid": pr.get("number"),  # GitLab uses iid
                 }
                 payload["object_attributes"] = object_attributes
+                _attach_referenced_issues(payload, object_attributes, source)
                 self.logger.debug(
                     f"Normalized GitHub PR to object_attributes: {object_attributes.get('title')}"
                 )

--- a/backend/presets/002-pull-request-reviewer.yaml
+++ b/backend/presets/002-pull-request-reviewer.yaml
@@ -4,7 +4,9 @@ description: >-
   Automatically review pull requests for code quality, potential bugs, security
   issues, and best practices. Works with both GitHub PRs and GitLab MRs.
   Supports stateful review management - updates previous comments and resolves addressed issues.
-  Maintains a Changes Summary in the PR body that updates on each review.
+  Reads the issue the PR references (closing keywords, issue URLs, branch name)
+  and reports whether the PR addresses it in full or in part, with gaps and
+  follow-ups. Maintains a Changes Summary in the PR body that updates on each review.
 icon: code-square
 trigger_event_source: null
 # Event types use underscore notation (e.g., pull_request_opened, pull_request_updated)
@@ -26,6 +28,7 @@ prompt_template: |
   - URL: {{trigger_event.payload.object_attributes.url}}
   - Source Branch: {{trigger_event.payload.object_attributes.source_branch}}
   - Target Branch: {{trigger_event.payload.object_attributes.target_branch}}
+  - Referenced issues (parsed by Preloop): {{trigger_event.payload.object_attributes.referenced_issues}}
   - Trigger: {{trigger_event.type}}
 
   ═══════════════════════════════════════════════════════════
@@ -156,6 +159,48 @@ prompt_template: |
   sample files beyond that cap. (Verification reads for specific findings in
   Step 2.3 have their own budget and don't count against this cap.) Match the
   project's conventions rather than imposing generic ones.
+
+  **Step 1.6: Identify the Referenced Issue(s)** *(runs in every scope)*
+
+  A PR usually exists to answer an issue. Reviewing the diff without reading
+  that issue answers "is this code good" but never "does this do what was
+  asked", which is the question the author's team actually has.
+
+  Preloop pre-parses the PR body, title, and branch name and hands you the
+  result in the **Referenced issues** field above, as
+  `key [kind, from source] url` entries separated by `; `:
+  - `closes`: a closing keyword pointed at an issue (`Closes #12`,
+    `Fixes org/repo#12`, `Resolves PROJ-7`). The strongest signal.
+  - `reference`: a plain mention or an issue URL in the body.
+  - `branch`: a number recovered from the branch name (`123-slug`,
+    `fix/issue-123`, `feature/PROJ-7-slug`). The weakest signal, a guess.
+
+  That list is a starting point, not gospel. Check it against the PR
+  description you already fetched in Step 1.1 and add anything it missed
+  (an issue named only in prose, a tracker link in a table). Drop entries the
+  description clearly uses as context rather than as this PR's purpose.
+
+  If the field says `none detected` and the description names no issue, this
+  PR has **no referenced issue**: skip Step 2.8, omit the Issue Coverage
+  section from the summary entirely, and say nothing about coverage anywhere
+  in the review. Do not speculate about which issue it might have meant.
+
+  Otherwise read the issues, `closes` entries first, then `reference`, then
+  `branch`. Call `get_issue` with the entry's URL when it has one, else its
+  key (`org/repo#12`, `PROJ-7`). **Hard budget: at most 2 issues read and at
+  most 3 `get_issue` calls per run.** If more issues are referenced, judge the
+  ones you read and name the rest as "not assessed in this review".
+
+  `get_issue` reads Preloop's synced copy of the tracker. When it returns
+  "not found" (the issue lives in a repository this account does not sync, or
+  sync has not caught up yet), do NOT reconstruct the issue from the PR
+  description: the author's summary of the issue is exactly the thing under
+  review. Record that reference as UNREADABLE and report it in Step 2.8 as
+  verdict UNCLEAR with the reason.
+
+  On INCREMENTAL runs, if the previous summary already carries an Issue
+  Coverage section for the same issue key, reuse the criteria recorded there
+  and skip the `get_issue` call.
 
   ═══════════════════════════════════════════════════════════
   PHASE 2: ANALYZE CODE CHANGES
@@ -306,6 +351,47 @@ prompt_template: |
   (clear description), recommendation (specific fix), and code_snippet (the
   problematic code, if short).
 
+  **Step 2.8: Issue Coverage Judgement** *(only when Step 1.6 found an issue)*
+
+  For each issue you read (at most 2), judge what this diff actually does
+  against what the issue actually asks. Judge the FULL PR diff here even in
+  INCREMENTAL scope: coverage is a property of the whole branch, not of the
+  latest push.
+
+  1. **Take the acceptance criteria from the issue text, not from your own
+     standards.** Prefer, in this order: an explicit "Acceptance criteria" /
+     "Definition of done" / requirements checklist; numbered or bulleted
+     asks; otherwise the concrete asks stated in prose. Quote the issue where
+     you can, keep each criterion to one line, at most 8 of them.
+     **Never invent a criterion the issue does not state.** Tests, docs,
+     telemetry, and refactors are NOT criteria unless the issue asks for
+     them; they are ordinary findings from Steps 2.4 and 2.6 and belong
+     there. If the issue states no criteria at all (a one-line bug report, a
+     link dump), say so plainly and judge against its single stated ask.
+  2. **Map each criterion to the diff**: name the hunk that satisfies it
+     (`file.ext:line`), or record that nothing does. The Step 2.3 discipline
+     applies: if you cannot point at code, the criterion is not satisfied,
+     and a criterion you cannot check either way is `unknown`, not `met`.
+  3. **Pick exactly ONE verdict per issue**, with one line of reasoning:
+     - `FULL`: every stated criterion is satisfied by this PR.
+     - `PARTIAL`: some criteria are satisfied and at least one is not.
+     - `NOT ADDRESSED`: none of the criteria are satisfied. Normal for a PR
+       that merely mentions a related issue: say that is what happened.
+     - `UNCLEAR`: the issue could not be read (Step 1.6 UNREADABLE), or its
+       asks are too vague to map onto code. Say which of the two it is.
+  4. **List the gaps**: one line per unmet criterion saying what the issue
+     asks and what this diff does not do, with a `file.ext:line` pointer when
+     the place it belongs is visible in the diff.
+  5. **Phrase every gap as a follow-up item** someone can paste into a new
+     issue: an imperative title plus one sentence of context.
+
+  **Coverage is not a code-review finding.** A PARTIAL or NOT ADDRESSED
+  verdict does not create findings, does not change the review action from
+  Step 4.1, and never blocks a merge on its own: authors split work across
+  PRs deliberately and the issue may be closed by a later one. Report it,
+  do not police it. (A criterion the diff claims to satisfy but demonstrably
+  breaks is a different thing: that is a normal finding, severitied normally.)
+
   ═══════════════════════════════════════════════════════════
   PHASE 3: COMPARE WITH PREVIOUS REVIEW
   ═══════════════════════════════════════════════════════════
@@ -379,6 +465,30 @@ prompt_template: |
   Plan the comment management: NEW findings → new comments; ADDRESSED issues →
   resolve (update_comment with resolved=true); PERSISTING issues → update;
   already-resolved, unchanged, or out-of-scope comments → leave untouched.
+
+  **Step 3.4: Carry Issue Coverage Forward** *(skip when there is no referenced issue)*
+
+  If the previous summary comment has an Issue Coverage section (find it by
+  the `<!-- preloop-review:issue-coverage -->` marker), it already holds the
+  criteria list for that issue. Reuse those criteria verbatim instead of
+  deriving a differently-worded set: the criteria come from the issue and the
+  issue rarely changes between pushes, so a reworded list looks like the
+  review changed its mind when nothing changed.
+
+  For each criterion that was unchecked, decide from the CURRENT code (the
+  Step 3.2 rules apply: read, do not remember) whether later commits satisfy
+  it now. When one does, check it off and delete its gap and follow-up lines.
+  In INCREMENTAL scope, re-check only criteria whose file appears in the
+  changed-files list; the rest keep their previous checkbox exactly.
+
+  Never uncheck a criterion a previous review checked unless the code that
+  satisfied it is gone from the branch, and say so when you do. Never
+  silently drop a criterion: if you no longer think it belongs, keep the line
+  and explain in one clause why. Recompute the verdict from the checkbox
+  tally you just derived; never restate the previous verdict.
+
+  A newly checked criterion is progress worth showing: keep it in the list as
+  `- [x]`, do not move it out of sight.
 
   ═══════════════════════════════════════════════════════════
   PHASE 4: DETERMINE REVIEW ACTION & SUBMIT
@@ -522,7 +632,9 @@ prompt_template: |
   When updating the summary, preserve the checked state of any checkboxes the user has
   manually checked. If a previous summary had `- [x] **Security**: SQL injection risk`,
   keep it as `- [x]` in the updated summary (move to "Resolved Issues" section if appropriate).
-  Never reset a checked checkbox to unchecked.
+  Never reset a checked checkbox to unchecked. This applies to the Issue
+  Coverage criteria too (Step 3.4): they are the same contract, one summary,
+  updated in place.
 
   ```markdown
   <!-- preloop-review:flow-id:pr-reviewer -->
@@ -544,6 +656,34 @@ prompt_template: |
   ### ✅ What Looks Good
   - [Positive aspects — include this section ONLY when the review action is
     approve or comment; omit it entirely when requesting changes]
+
+  ---
+
+  ### 🎯 Issue Coverage
+
+  <!-- preloop-review:issue-coverage -->
+
+  [Omit this whole section, marker included, when Step 1.6 found no
+  referenced issue. One block per issue judged in Step 2.8, at most 2.]
+
+  **[`{issue_key}`]({issue_url}): {issue title}** (verdict: **FULL | PARTIAL | NOT ADDRESSED | UNCLEAR**)
+
+  [One line of reasoning for that verdict.]
+
+  Acceptance criteria as this review reads them (quoted from the issue):
+  - [x] [Criterion the diff satisfies] - `file.ext:line`
+  - [ ] [Criterion the diff does not satisfy]
+
+  Gaps:
+  - [What the issue asks that this PR does not do] - `file.ext:line` when the place is visible
+
+  Follow-ups (ready to file as issues):
+  - **[Imperative title]**: [one sentence of context]
+
+  [Omit the Gaps and Follow-ups lists when the verdict is FULL. When the
+  verdict is UNCLEAR because the issue could not be read, print only the
+  reason line and no criteria list. Coverage never changes the Review Status
+  above.]
 
   ---
 
@@ -761,8 +901,20 @@ prompt_template: |
     "review_posted": true | false,
     "risk_level": "low" | "medium" | "high",
     "findings_count": <total issues reported in this review>,
-    "review_action": "approve" | "request_changes" | "comment" | null
+    "review_action": "approve" | "request_changes" | "comment" | null,
+    "issue_coverage": [
+      {
+        "issue": "<issue key or URL you read>",
+        "verdict": "full" | "partial" | "not_addressed" | "unclear",
+        "criteria_total": <number of criteria you listed>,
+        "criteria_met": <number you checked off>,
+        "gaps": <number of open gaps>
+      }
+    ]
   }
+
+  Set "issue_coverage" to [] when the PR references no issue. Its counts must
+  match the checkboxes you published; never report coverage you did not judge.
 
   Use "status": "success" when the run completed — whether the review was
   submitted (review_posted: true, Step 4.4) or you deliberately decided not
@@ -796,6 +948,15 @@ prompt_template: |
   - DO flag documentation gaps as findings (MEDIUM or LOW severity)
   - DO NOT create or modify documentation files directly
   - Documentation updates are the PR author's responsibility
+
+  ⚠️ **ISSUE COVERAGE**
+  - Judge the PR against the issue's OWN stated asks. Never invent a
+    criterion the issue does not state, and quote the issue where you can.
+  - When the issue cannot be read, say UNCLEAR and why. Never reconstruct the
+    issue from the PR description.
+  - A PARTIAL verdict is information, not a blocker: it never changes the
+    review action and never blocks a merge.
+  - No referenced issue means no Issue Coverage section at all.
 
   ⚠️ **APPROVAL CRITERIA**
   - NEVER approve if there are unaddressed CRITICAL issues
@@ -840,6 +1001,11 @@ agent_config:
   enable_auto_lint: true
 allowed_mcp_servers: []
 allowed_mcp_tools:
+  # get_issue is read-only and is what makes Step 2.8 (issue coverage)
+  # possible: neither platform returns the linked issue on a PR read.
+  # No create_issue/update_issue: follow-ups are proposed in the review for a
+  # human to file, the reviewer never writes to the tracker.
+  - name: get_issue
   - name: get_pull_request
   - name: update_pull_request
   - name: add_comment

--- a/backend/tests/services/prompt_resolvers/test_trigger_event.py
+++ b/backend/tests/services/prompt_resolvers/test_trigger_event.py
@@ -421,3 +421,118 @@ class TestWorkspaceFilesRedaction:
             execution_id="exec-1",
         )
         assert await resolver.resolve("payload.run", context) == "smoke-1"
+
+
+class TestReferencedIssues:
+    """PR/MR payloads carry a parsed issue-reference hint for the reviewer."""
+
+    @pytest.mark.asyncio
+    async def test_github_pull_request(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "github",
+                "payload": {
+                    "repository": {"full_name": "org/repo"},
+                    "pull_request": {
+                        "number": 45,
+                        "title": "Add widget",
+                        "body": "Closes #123",
+                        "html_url": "https://github.com/org/repo/pull/45",
+                        "head": {"ref": "123-add-widget"},
+                        "base": {"ref": "main"},
+                        "user": {"login": "dev"},
+                    },
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+        value = await resolver.resolve(
+            "payload.object_attributes.referenced_issues", context
+        )
+        assert value == (
+            "org/repo#123 [closes, from body] https://github.com/org/repo/issues/123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_gitlab_merge_request(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "gitlab",
+                "payload": {
+                    "object_kind": "merge_request",
+                    "project": {"path_with_namespace": "grp/proj"},
+                    "object_attributes": {
+                        "iid": 12,
+                        "title": "Add widget",
+                        "description": "Closes #7",
+                        "url": "https://gitlab.example.com/grp/proj/-/merge_requests/12",
+                        "source_branch": "feature/add-widget",
+                        "target_branch": "main",
+                    },
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+        value = await resolver.resolve(
+            "payload.object_attributes.referenced_issues", context
+        )
+        assert value.startswith("grp/proj#7 [closes, from body]")
+
+    @pytest.mark.asyncio
+    async def test_pull_request_without_a_reference_says_none_detected(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "github",
+                "payload": {
+                    "repository": {"full_name": "org/repo"},
+                    "pull_request": {
+                        "number": 45,
+                        "title": "Tidy the console shell",
+                        "body": "Pure refactor, no issue.",
+                        "html_url": "https://github.com/org/repo/pull/45",
+                        "head": {"ref": "chore/console-shell"},
+                        "base": {"ref": "main"},
+                        "user": {"login": "dev"},
+                    },
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+        value = await resolver.resolve(
+            "payload.object_attributes.referenced_issues", context
+        )
+        assert value == "none detected"
+
+    @pytest.mark.asyncio
+    async def test_issue_payloads_get_no_reference_field(self):
+        """Only pull/merge requests need the hint; issue flows are untouched."""
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "github",
+                "payload": {
+                    "issue": {
+                        "number": 9,
+                        "title": "Broken search",
+                        "body": "Relates to #8",
+                        "html_url": "https://github.com/org/repo/issues/9",
+                    }
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+        value = await resolver.resolve(
+            "payload.object_attributes.referenced_issues", context
+        )
+        assert value is None

--- a/backend/tests/services/test_issue_references.py
+++ b/backend/tests/services/test_issue_references.py
@@ -45,6 +45,18 @@ class TestGitHubForms:
         assert refs[0].kind == KIND_CLOSES
         assert refs[0].url == "https://github.com/org/repo/issues/123"
 
+    def test_keyword_governs_a_whole_list(self):
+        refs = extract_issue_references(description="Closes #12, #13 and #14", **GITHUB)
+        assert keys(refs) == ["org/repo#12", "org/repo#13", "org/repo#14"]
+        assert {ref.kind for ref in refs} == {KIND_CLOSES}
+
+    def test_markdown_linked_reference(self):
+        refs = extract_issue_references(
+            description="Closes [#12](https://github.com/org/repo/issues/12)", **GITHUB
+        )
+        assert keys(refs) == ["org/repo#12"]
+        assert refs[0].kind == KIND_CLOSES
+
     def test_cross_repo_reference(self):
         refs = extract_issue_references(description="Fixes other-org/other#7", **GITHUB)
         assert keys(refs) == ["other-org/other#7"]

--- a/backend/tests/services/test_issue_references.py
+++ b/backend/tests/services/test_issue_references.py
@@ -1,0 +1,230 @@
+"""Tests for the pull-request issue-reference parser.
+
+The Pull Request Reviewer preset judges whether a PR addresses the issue it
+references, so the reference has to be found reliably: closing keywords,
+cross-repo forms, issue URLs, branch names, and (importantly) nothing at all
+when the PR references nothing.
+"""
+
+import pytest
+
+from preloop.services.issue_references import (
+    KIND_BRANCH,
+    KIND_CLOSES,
+    KIND_REFERENCE,
+    NO_REFERENCES,
+    extract_issue_references,
+    format_issue_references,
+    references_from_trigger_payload,
+)
+
+GITHUB = dict(repo_path="org/repo", host="github.com", platform="github")
+GITLAB = dict(repo_path="grp/sub/proj", host="gitlab.example.com", platform="gitlab")
+
+
+def keys(refs):
+    return [ref.key for ref in refs]
+
+
+class TestGitHubForms:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Closes #123",
+            "closes #123",
+            "This fixes #123 for good",
+            "Fixed #123",
+            "Resolves: #123",
+            "resolved #123",
+            "Implements #123",
+        ],
+    )
+    def test_closing_keywords(self, body):
+        refs = extract_issue_references(description=body, **GITHUB)
+        assert keys(refs) == ["org/repo#123"]
+        assert refs[0].kind == KIND_CLOSES
+        assert refs[0].url == "https://github.com/org/repo/issues/123"
+
+    def test_cross_repo_reference(self):
+        refs = extract_issue_references(description="Fixes other-org/other#7", **GITHUB)
+        assert keys(refs) == ["other-org/other#7"]
+        assert refs[0].url == "https://github.com/other-org/other/issues/7"
+
+    def test_full_issue_url_in_body(self):
+        refs = extract_issue_references(
+            description="Context: https://github.com/acme/tools/issues/42", **GITHUB
+        )
+        assert keys(refs) == ["acme/tools#42"]
+        assert refs[0].kind == KIND_REFERENCE
+        assert refs[0].url == "https://github.com/acme/tools/issues/42"
+
+    def test_bare_mention_is_a_weaker_reference(self):
+        refs = extract_issue_references(description="Follows on from #9", **GITHUB)
+        assert keys(refs) == ["org/repo#9"]
+        assert refs[0].kind == KIND_REFERENCE
+
+    def test_closing_keyword_outranks_bare_mention_of_same_issue(self):
+        refs = extract_issue_references(description="See #5. Closes #5", **GITHUB)
+        assert keys(refs) == ["org/repo#5"]
+        assert refs[0].kind == KIND_CLOSES
+
+    def test_closes_entries_are_listed_before_weaker_ones(self):
+        refs = extract_issue_references(
+            description="Related to #2\n\nCloses #3", branch="4-slug", **GITHUB
+        )
+        assert keys(refs) == ["org/repo#3", "org/repo#2", "org/repo#4"]
+        assert [ref.kind for ref in refs] == [KIND_CLOSES, KIND_REFERENCE, KIND_BRANCH]
+
+    def test_self_reference_is_dropped(self):
+        refs = extract_issue_references(
+            description="Squashed from (#45)", self_number=45, **GITHUB
+        )
+        assert refs == []
+
+    def test_commit_sha_and_anchors_are_not_issues(self):
+        refs = extract_issue_references(
+            description="see file.py#L12 and heading ##Notes", **GITHUB
+        )
+        assert refs == []
+
+
+class TestGitLabForms:
+    def test_closes_in_merge_request_description(self):
+        refs = extract_issue_references(description="Closes #7", **GITLAB)
+        assert keys(refs) == ["grp/sub/proj#7"]
+        assert refs[0].url == "https://gitlab.example.com/grp/sub/proj/-/issues/7"
+
+    def test_subgroup_issue_url(self):
+        refs = extract_issue_references(
+            description="https://gitlab.example.com/grp/sub/other/-/issues/31", **GITLAB
+        )
+        assert keys(refs) == ["grp/sub/other#31"]
+        assert refs[0].url == "https://gitlab.example.com/grp/sub/other/-/issues/31"
+
+    def test_cross_project_key(self):
+        refs = extract_issue_references(description="Closes grp/other#8", **GITLAB)
+        assert keys(refs) == ["grp/other#8"]
+
+
+class TestJiraForms:
+    def test_keyword_plus_jira_key(self):
+        refs = extract_issue_references(description="Fixes PROJ-123", **GITHUB)
+        assert keys(refs) == ["PROJ-123"]
+        assert refs[0].kind == KIND_CLOSES
+        assert refs[0].url is None
+        assert refs[0].identifier() == "PROJ-123"
+
+    def test_jira_key_in_branch(self):
+        refs = extract_issue_references(branch="feature/PROJ-7-add-widget", **GITHUB)
+        assert keys(refs) == ["PROJ-7"]
+        assert refs[0].kind == KIND_BRANCH
+
+    def test_lowercase_branch_slug_is_not_a_jira_key(self):
+        # "abc-123" in a branch is a slug, not project ABC issue 123, and the
+        # number is not in an issue-number position either. Guessing here
+        # would send the reviewer to read an unrelated issue.
+        assert extract_issue_references(branch="fix/abc-123-thing", **GITHUB) == []
+
+
+class TestBranchPatterns:
+    @pytest.mark.parametrize(
+        "branch,expected",
+        [
+            ("123-add-widget", "org/repo#123"),
+            ("123", "org/repo#123"),
+            ("fix/issue-123", "org/repo#123"),
+            ("feature/123-add-widget", "org/repo#123"),
+            ("issues/123", "org/repo#123"),
+            ("gh-123-thing", "org/repo#123"),
+        ],
+    )
+    def test_number_recovered_from_branch(self, branch, expected):
+        refs = extract_issue_references(branch=branch, **GITHUB)
+        assert keys(refs) == [expected]
+        assert refs[0].kind == KIND_BRANCH
+        assert refs[0].source == "branch"
+
+    @pytest.mark.parametrize(
+        "branch", ["main", "release/2.0", "feat/add-widget", "dependabot/npm/lit-3.1.0"]
+    )
+    def test_branches_without_an_issue_number(self, branch):
+        assert extract_issue_references(branch=branch, **GITHUB) == []
+
+
+class TestNoReferences:
+    def test_empty_inputs(self):
+        assert extract_issue_references() == []
+
+    def test_prose_without_a_reference(self):
+        refs = extract_issue_references(
+            description="Refactor the console shell. No issue for this one.",
+            branch="chore/console-shell",
+            **GITHUB,
+        )
+        assert refs == []
+
+    def test_format_says_none_detected(self):
+        assert format_issue_references([]) == NO_REFERENCES
+
+
+class TestFormatting:
+    def test_line_shape(self):
+        refs = extract_issue_references(description="Closes #12", **GITHUB)
+        assert (
+            format_issue_references(refs)
+            == "org/repo#12 [closes, from body] https://github.com/org/repo/issues/12"
+        )
+
+    def test_entries_are_semicolon_separated(self):
+        refs = extract_issue_references(
+            description="Closes #12 and closes #13", **GITHUB
+        )
+        assert format_issue_references(refs).count("; ") == 1
+
+    def test_cap_keeps_the_strongest_references(self):
+        body = " ".join(f"see #{n}" for n in range(20, 40)) + " Closes #99"
+        refs = extract_issue_references(description=body, **GITHUB)
+        assert len(refs) == 5
+        assert refs[0].key == "org/repo#99"
+
+
+class TestTriggerPayloads:
+    def test_github_pull_request_payload(self):
+        payload = {
+            "pull_request": {"number": 45},
+            "repository": {"full_name": "org/repo"},
+        }
+        attrs = {
+            "title": "Add widget",
+            "description": "Closes #123",
+            "url": "https://github.com/org/repo/pull/45",
+            "source_branch": "123-add-widget",
+            "number": 45,
+        }
+        refs = references_from_trigger_payload(payload, attrs, "github")
+        assert keys(refs) == ["org/repo#123"]
+        assert refs[0].url == "https://github.com/org/repo/issues/123"
+
+    def test_gitlab_merge_request_payload(self):
+        payload = {
+            "object_kind": "merge_request",
+            "project": {"path_with_namespace": "grp/sub/proj"},
+        }
+        attrs = {
+            "title": "Add widget",
+            "description": "Closes #7",
+            "url": "https://gitlab.example.com/grp/sub/proj/-/merge_requests/12",
+            "source_branch": "fix/issue-8",
+            "iid": 12,
+        }
+        refs = references_from_trigger_payload(payload, attrs, "gitlab")
+        assert keys(refs) == ["grp/sub/proj#7", "grp/sub/proj#8"]
+
+    def test_repository_path_falls_back_to_payload_when_url_is_odd(self):
+        payload = {"pull_request": {"number": 1}, "repository": {"full_name": "o/r"}}
+        attrs = {"description": "Closes #4", "url": "not-a-url", "source_branch": "x"}
+        refs = references_from_trigger_payload(payload, attrs, "github")
+        assert keys(refs) == ["o/r#4"]
+        # No host means no URL, but the key is still resolvable by get_issue.
+        assert refs[0].url is None
+        assert refs[0].identifier() == "o/r#4"

--- a/backend/tests/test_pull_request_reviewer_preset.py
+++ b/backend/tests/test_pull_request_reviewer_preset.py
@@ -1,0 +1,382 @@
+"""Tests for the Pull Request Reviewer preset.
+
+Covers the identity/tool contract and the Issue Coverage slice: the preset
+must read the issue a PR references and say whether the PR addresses it in
+full or in part, without inventing criteria and without letting that verdict
+change the review action.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from preloop.services.issue_references import (
+    extract_issue_references,
+)
+from preloop.services.prompt_resolvers.base import ResolverContext
+from preloop.services.prompt_resolvers.trigger_event import TriggerEventResolver
+
+PRESET_FILE = "002-pull-request-reviewer.yaml"
+PRESETS_DIR = Path(__file__).resolve().parents[1] / "presets"
+
+EXPECTED_TOOLS = [
+    "get_issue",
+    "get_pull_request",
+    "update_pull_request",
+    "add_comment",
+    "update_comment",
+]
+
+FORBIDDEN_TOOLS = {
+    "create_issue": "follow-ups are proposed in the review, a human files them",
+    "update_issue": "the reviewer never writes to the tracker",
+    "search_issues": "references come from the PR, not from a tracker search",
+    "create_pull_request": "a reviewer does not open pull requests",
+}
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace so asserts survive YAML line wrapping."""
+    return " ".join(text.split())
+
+
+@pytest.fixture(scope="module")
+def preset() -> dict:
+    path = PRESETS_DIR / PRESET_FILE
+    assert path.exists(), f"Missing preset file: {path}"
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+@pytest.fixture(scope="module")
+def template(preset: dict) -> str:
+    return preset["prompt_template"]
+
+
+@pytest.fixture(scope="module")
+def prompt(template: str) -> str:
+    return _norm(template)
+
+
+class TestPresetIdentity:
+    def test_name_and_slug(self, preset: dict) -> None:
+        assert preset["name"] == "Pull Request Reviewer"
+        assert preset["slug"] == "pull-request-reviewer"
+        assert preset["is_preset"] is True
+
+    def test_trigger_types_are_normalized_underscore_names(self, preset: dict) -> None:
+        assert preset["trigger_event_types"] == ["pull_request_opened"]
+
+    def test_description_mentions_issue_coverage(self, preset: dict) -> None:
+        assert "in full or in part" in _norm(preset["description"])
+
+
+class TestToolAllowlist:
+    def test_exact_allowlist(self, preset: dict) -> None:
+        names = [tool["name"] for tool in preset["allowed_mcp_tools"]]
+        assert names == EXPECTED_TOOLS
+
+    def test_issue_read_is_granted(self, preset: dict) -> None:
+        """The smallest grant that makes issue coverage possible."""
+        names = {tool["name"] for tool in preset["allowed_mcp_tools"]}
+        assert "get_issue" in names
+
+    @pytest.mark.parametrize("tool,reason", sorted(FORBIDDEN_TOOLS.items()))
+    def test_forbidden_tool_absent(self, preset: dict, tool: str, reason: str) -> None:
+        names = {tool["name"] for tool in preset["allowed_mcp_tools"]}
+        assert tool not in names, f"{tool} must stay out of the allowlist: {reason}"
+
+
+class TestIssueDiscoveryContract:
+    def test_prompt_embeds_the_parsed_reference_field(self, template: str) -> None:
+        assert (
+            "{{trigger_event.payload.object_attributes.referenced_issues}}" in template
+        )
+
+    def test_discovery_step_exists(self, prompt: str) -> None:
+        assert "Step 1.6: Identify the Referenced Issue(s)" in prompt
+
+    def test_discovery_names_every_reference_kind(self, prompt: str) -> None:
+        for kind in ("closes", "reference", "branch"):
+            assert f"`{kind}`" in prompt
+
+    def test_no_reference_means_no_section(self, prompt: str) -> None:
+        assert "none detected" in prompt
+        assert "no referenced issue" in prompt
+        assert "omit the Issue Coverage section" in prompt
+
+    def test_issue_read_budget_is_bounded(self, prompt: str) -> None:
+        assert "at most 2 issues read" in prompt
+        assert "at most 3 `get_issue` calls per run" in prompt
+
+    def test_unreadable_issue_falls_back_instead_of_guessing(self, prompt: str) -> None:
+        assert "UNREADABLE" in prompt
+        assert "do NOT reconstruct the issue from the PR description" in prompt
+
+
+class TestCoverageJudgementContract:
+    def test_step_exists(self, prompt: str) -> None:
+        assert "Step 2.8: Issue Coverage Judgement" in prompt
+
+    @pytest.mark.parametrize("verdict", ["FULL", "PARTIAL", "NOT ADDRESSED", "UNCLEAR"])
+    def test_all_four_verdicts_are_defined(self, prompt: str, verdict: str) -> None:
+        assert f"`{verdict}`" in prompt
+
+    def test_criteria_come_from_the_issue_only(self, prompt: str) -> None:
+        assert "Never invent a criterion the issue does not state" in prompt
+        assert "Quote the issue where you can" in prompt
+
+    def test_gaps_and_follow_ups_are_required(self, prompt: str) -> None:
+        assert "List the gaps" in prompt
+        assert "Phrase every gap as a follow-up item" in prompt
+
+    def test_coverage_does_not_change_the_review_action(self, prompt: str) -> None:
+        assert "Coverage is not a code-review finding" in prompt
+        assert "never blocks a merge" in prompt
+
+    def test_result_json_reports_coverage(self, prompt: str) -> None:
+        assert '"issue_coverage"' in prompt
+        assert '"verdict": "full" | "partial" | "not_addressed" | "unclear"' in prompt
+
+
+class TestStatefulSection:
+    def test_section_has_its_own_marker(self, template: str) -> None:
+        assert "<!-- preloop-review:issue-coverage -->" in template
+
+    def test_summary_template_carries_the_section(self, template: str) -> None:
+        assert "### 🎯 Issue Coverage" in template
+        assert "Acceptance criteria as this review reads them" in template
+        assert "Follow-ups (ready to file as issues):" in template
+
+    def test_carry_forward_step_exists(self, prompt: str) -> None:
+        assert "Step 3.4: Carry Issue Coverage Forward" in prompt
+
+    def test_previous_criteria_are_reused_not_reworded(self, prompt: str) -> None:
+        assert "Reuse those criteria verbatim" in prompt
+
+    def test_checked_criteria_are_never_unchecked_silently(self, prompt: str) -> None:
+        assert (
+            "Never uncheck a criterion a previous review checked unless the code that satisfied it is gone"
+            in prompt
+        )
+
+    def test_incremental_scope_keeps_out_of_scope_criteria(self, prompt: str) -> None:
+        assert (
+            "In INCREMENTAL scope, re-check only criteria whose file appears in the changed-files list"
+            in prompt
+        )
+
+
+class FakeTracker:
+    """Minimal stand-in for the tracker behind the `get_issue` MCP tool.
+
+    Keyed the way `_find_issue_by_identifier` resolves identifiers: by issue
+    URL and by `org/repo#123` key.
+    """
+
+    def __init__(self, issues: dict[str, dict]):
+        self._issues = issues
+        self.calls: list[str] = []
+
+    def get_issue(self, identifier: str) -> dict:
+        self.calls.append(identifier)
+        try:
+            return self._issues[identifier]
+        except KeyError:
+            raise LookupError(f"Issue not found: {identifier}")
+
+
+ISSUE_123 = {
+    "key": "org/repo#123",
+    "title": "Widget picker loses the last selection",
+    "url": "https://github.com/org/repo/issues/123",
+    "description": (
+        "## Acceptance criteria\n"
+        "- The picker restores the last selection after a reload\n"
+        "- The restore is covered by a test\n"
+        "- The behaviour is documented in the widget guide\n"
+    ),
+}
+
+
+VERDICTS = ("FULL", "PARTIAL", "NOT ADDRESSED", "UNCLEAR")
+
+# One Issue Coverage section as a review would publish it for ISSUE_123 after
+# a PR that restores the selection but ships neither test nor docs.
+GOOD_SECTION = (
+    "### 🎯 Issue Coverage\n\n"
+    "<!-- preloop-review:issue-coverage -->\n\n"
+    f"**[`{ISSUE_123['key']}`]({ISSUE_123['url']}): {ISSUE_123['title']}**"
+    " (verdict: **PARTIAL**)\n\n"
+    "Restores the selection but ships no test and no doc update.\n\n"
+    "Acceptance criteria as this review reads them (quoted from the issue):\n"
+    "- [x] The picker restores the last selection after a reload"
+    " - `src/widget-picker.ts:88`\n"
+    "- [ ] The restore is covered by a test\n"
+    "- [ ] The behaviour is documented in the widget guide\n\n"
+    "Gaps:\n"
+    "- No test covers the restore path - `src/widget-picker.test.ts`\n"
+    "- The widget guide still describes the old behaviour\n\n"
+    "Follow-ups (ready to file as issues):\n"
+    "- **Cover widget picker restore with a test**: the reload path is untested.\n"
+    "- **Document the widget picker restore**: the guide predates it.\n"
+)
+
+
+def section_shape_problems(section: str) -> list[str]:
+    """Check a published Issue Coverage section against the preset's shape."""
+    problems: list[str] = []
+    if "<!-- preloop-review:issue-coverage -->" not in section:
+        problems.append("missing the issue-coverage marker")
+
+    verdicts = re.findall(r"\(verdict: \*\*([A-Z ]+)\*\*\)", section)
+    if len(verdicts) != 1:
+        problems.append(f"expected exactly one verdict, found {len(verdicts)}")
+    for verdict in verdicts:
+        if verdict not in VERDICTS:
+            problems.append(f"verdict must be one of {VERDICTS}, got {verdict!r}")
+
+    criteria = re.findall(r"^- \[[ x]\] ", section, re.MULTILINE)
+    if verdicts and verdicts[0] != "UNCLEAR" and not criteria:
+        problems.append("no acceptance criteria checkboxes")
+
+    has_gaps = "\nGaps:\n" in section
+    has_follow_ups = "\nFollow-ups (ready to file as issues):\n" in section
+    if verdicts and verdicts[0] in ("PARTIAL", "NOT ADDRESSED"):
+        if not has_gaps:
+            problems.append("a partial verdict must list gaps")
+        if has_gaps and not has_follow_ups:
+            problems.append("gaps listed with no follow-ups")
+    if verdicts and verdicts[0] == "FULL" and (has_gaps or has_follow_ups):
+        problems.append("a full verdict must not list gaps or follow-ups")
+    return problems
+
+
+def mutate_section(section: str, mutation: str) -> str:
+    """Break one rule of the section shape, for the negative tests."""
+    if mutation == "drop_marker":
+        return section.replace("<!-- preloop-review:issue-coverage -->\n\n", "")
+    if mutation == "invent_verdict":
+        return section.replace("**PARTIAL**", "**MOSTLY DONE**")
+    if mutation == "drop_criteria":
+        return re.sub(r"^- \[[ x]\] .*\n", "", section, flags=re.MULTILINE)
+    if mutation == "gaps_without_followups":
+        return section[: section.index("Follow-ups (ready to file as issues):")]
+    raise AssertionError(f"unknown mutation: {mutation}")
+
+
+def _render_preset_prompt(template: str, trigger_event_data: dict) -> str:
+    """Resolve every {{trigger_event...}} placeholder in the preset prompt."""
+    resolver = TriggerEventResolver()
+    context = ResolverContext(
+        db=MagicMock(),
+        trigger_event_data=trigger_event_data,
+        flow_id="flow-1",
+        execution_id="exec-1",
+    )
+    rendered = template
+    for placeholder in set(re.findall(r"\{\{(trigger_event[^}]*)\}\}", template)):
+        path = placeholder[len("trigger_event") :].lstrip(".")
+        value = asyncio.run(resolver.resolve(path, context))
+        if value is not None:
+            rendered = rendered.replace("{{" + placeholder + "}}", value)
+    return rendered
+
+
+class TestEndToEndWithFakeTracker:
+    """A PR that closes an issue, from webhook payload to section shape."""
+
+    @pytest.fixture
+    def trigger_event_data(self) -> dict:
+        return {
+            "source": "github",
+            "type": "pull_request_opened",
+            "payload": {
+                "repository": {"full_name": "org/repo"},
+                "pull_request": {
+                    "number": 45,
+                    "title": "Restore the widget picker selection",
+                    "body": "Closes #123\n\nRestores the selection on reload.",
+                    "html_url": "https://github.com/org/repo/pull/45",
+                    "head": {"ref": "123-restore-selection"},
+                    "base": {"ref": "main"},
+                    "user": {"login": "dev"},
+                },
+            },
+        }
+
+    def test_reference_reaches_the_prompt(
+        self, template: str, trigger_event_data: dict
+    ) -> None:
+        rendered = _render_preset_prompt(template, trigger_event_data)
+        assert "org/repo#123 [closes, from body]" in rendered
+        assert "https://github.com/org/repo/issues/123" in rendered
+        assert "{{trigger_event." not in rendered
+
+    def test_the_identifier_in_the_prompt_resolves_against_the_tracker(
+        self, trigger_event_data: dict
+    ) -> None:
+        tracker = FakeTracker({ISSUE_123["url"]: ISSUE_123})
+        pr = trigger_event_data["payload"]["pull_request"]
+        refs = extract_issue_references(
+            description=pr["body"],
+            title=pr["title"],
+            branch=pr["head"]["ref"],
+            repo_path="org/repo",
+            host="github.com",
+            platform="github",
+            self_number=pr["number"],
+        )
+        assert [ref.key for ref in refs] == ["org/repo#123"]
+        issue = tracker.get_issue(refs[0].identifier())
+        assert issue["title"] == ISSUE_123["title"]
+        assert tracker.calls == ["https://github.com/org/repo/issues/123"]
+
+    def test_missing_issue_is_reported_not_invented(
+        self, prompt: str, trigger_event_data: dict
+    ) -> None:
+        tracker = FakeTracker({})
+        with pytest.raises(LookupError):
+            tracker.get_issue("https://github.com/org/repo/issues/123")
+        # The prompt tells the reviewer exactly what to do with that failure.
+        assert "verdict UNCLEAR with the reason" in prompt
+
+    def test_section_shape_a_review_can_fill_in(
+        self, template: str, trigger_event_data: dict
+    ) -> None:
+        """The published section shape, filled with the fake tracker's issue."""
+        rendered = _render_preset_prompt(template, trigger_event_data)
+        start = rendered.index("### 🎯 Issue Coverage")
+        section = rendered[start : rendered.index("### ⚠️ Issues Found", start)]
+
+        # Marker first: the section is updated in place like the rest.
+        assert "<!-- preloop-review:issue-coverage -->" in section
+        # Issue identity, one verdict, reasoning, criteria, gaps, follow-ups.
+        assert "{issue_key}" in section and "{issue_url}" in section
+        assert "FULL | PARTIAL | NOT ADDRESSED | UNCLEAR" in section
+        assert "One line of reasoning" in section
+        assert "- [x]" in section and "- [ ]" in section
+        assert "Gaps:" in section
+        assert "Follow-ups (ready to file as issues):" in section
+
+    def test_a_filled_section_satisfies_the_shape(self) -> None:
+        """What a review would publish for the fake tracker's issue."""
+        assert section_shape_problems(GOOD_SECTION) == []
+
+    @pytest.mark.parametrize(
+        "mutation,problem",
+        [
+            ("drop_marker", "missing the issue-coverage marker"),
+            ("invent_verdict", "verdict must be one of"),
+            ("drop_criteria", "no acceptance criteria checkboxes"),
+            ("gaps_without_followups", "gaps listed with no follow-ups"),
+        ],
+    )
+    def test_broken_sections_are_caught(self, mutation: str, problem: str) -> None:
+        broken = mutate_section(GOOD_SECTION, mutation)
+        assert any(problem in item for item in section_shape_problems(broken))

--- a/docs/guide/flows/pull-request-review.md
+++ b/docs/guide/flows/pull-request-review.md
@@ -1,0 +1,160 @@
+# Pull Request Reviewer preset
+
+Reviews a GitHub pull request or a GitLab merge request: security, quality,
+performance, tests, documentation impact, and (since this slice) whether the
+PR actually does what the issue it references asked for.
+
+The preset ships as `backend/presets/002-pull-request-reviewer.yaml`
+(slug `pull-request-reviewer`).
+
+The review is **stateful**. One summary comment carries HTML markers
+(`<!-- preloop-review:flow-id:pr-reviewer -->`,
+`<!-- preloop-review:reviewed-sha:SHA -->`) and is rewritten in place on each
+push; inline comments are resolved when their finding is fixed; checkboxes a
+user ticks are never re-raised.
+
+## Issue coverage
+
+A diff review answers "is this code good". It does not answer "does this do
+what was asked", which is the question the author's team actually has. So the
+review reads the referenced issue and publishes one **Issue Coverage** section
+in the same summary comment.
+
+### 1. Finding the reference
+
+Neither platform hands the reviewer a linked-issue relation on a PR read: the
+GitHub mapping in `backend/preloop/sync/trackers/github.py` and the GitLab
+mapping in `backend/preloop/api/endpoints/mcp.py` both return a fixed field
+list with no `closes_issues`. Preloop therefore parses the reference off the
+PR itself, in `backend/preloop/services/issue_references.py`, and exposes it
+to the prompt as `{{trigger_event.payload.object_attributes.referenced_issues}}`:
+
+| Kind | Recognized from | Examples |
+| --- | --- | --- |
+| `closes` | a closing keyword in the PR body or title | `Closes #12`, `Fixes org/repo#12`, `Resolves PROJ-7`, `Implements #12` |
+| `reference` | a plain mention or an issue URL in the body | `#12`, `Related to #12`, `https://gitlab.example.com/grp/proj/-/issues/12` |
+| `branch` | the branch name | `123-slug`, `fix/issue-123`, `gh-123-slug`, `feature/PROJ-7-slug` |
+
+Cross-repo (`other-org/other#7`) and GitLab subgroup paths
+(`grp/sub/proj#7`) resolve; the PR's own number is dropped (squash-merge
+titles routinely carry `(#45)`); a same-issue hit from two sources keeps the
+strongest kind; the list is capped at 5 entries, strongest first. When
+nothing matches, the field reads `none detected` and the review omits the
+Issue Coverage section entirely rather than speculating.
+
+The parser is a hint, not the verdict: the prompt tells the reviewer to
+confirm it against the PR description it already fetched and to add anything
+stated only in prose.
+
+### 2. Reading the issue
+
+The preset's tool allowlist gained exactly one entry, the read-only
+`get_issue`:
+
+```yaml
+allowed_mcp_tools:
+  - name: get_issue          # new: issue coverage
+  - name: get_pull_request
+  - name: update_pull_request
+  - name: add_comment
+  - name: update_comment
+```
+
+`get_issue` accepts the identifiers the parser produces (an issue URL, an
+`org/repo#123` key, or a Jira key) and reads Preloop's synced copy of the
+tracker. Budget: at most 2 issues read and at most 3 calls per run.
+
+**Graceful fallback.** The issue may live in a repository the account does
+not sync, or sync may not have caught up. `get_issue` then returns "not
+found", and the review reports verdict `UNCLEAR` naming that reason. It is
+explicitly forbidden from reconstructing the issue's asks out of the PR
+description: the author's summary of the issue is the thing under review.
+No `create_issue` or `update_issue` is granted, so follow-ups are proposed
+for a human to file, never written to the tracker.
+
+### 3. The verdict
+
+Criteria come from the issue's own text (an "Acceptance criteria" or
+"Definition of done" section, numbered asks, otherwise the concrete asks in
+prose), quoted where possible, at most 8, and **never invented**: tests,
+docs, and telemetry are ordinary review findings unless the issue asks for
+them. Each criterion is mapped to a hunk (`file.ext:line`) or recorded as
+unmet.
+
+| Verdict | Meaning |
+| --- | --- |
+| `FULL` | every stated criterion is satisfied by this PR |
+| `PARTIAL` | some are, at least one is not |
+| `NOT ADDRESSED` | none are (normal when a PR merely mentions a related issue) |
+| `UNCLEAR` | the issue could not be read, or its asks cannot be mapped to code |
+
+Published shape, inside the one summary comment:
+
+```markdown
+### 🎯 Issue Coverage
+
+<!-- preloop-review:issue-coverage -->
+
+**[`org/repo#123`](https://github.com/org/repo/issues/123): Widget picker loses the last selection** (verdict: **PARTIAL**)
+
+Restores the selection but ships no test and no doc update.
+
+Acceptance criteria as this review reads them (quoted from the issue):
+- [x] The picker restores the last selection after a reload - `src/widget-picker.ts:88`
+- [ ] The restore is covered by a test
+- [ ] The behaviour is documented in the widget guide
+
+Gaps:
+- No test covers the restore path - `src/widget-picker.test.ts`
+- The widget guide still describes the old behaviour
+
+Follow-ups (ready to file as issues):
+- **Cover widget picker restore with a test**: the reload path is untested.
+- **Document the widget picker restore**: the guide predates it.
+```
+
+**Coverage never blocks a merge.** A `PARTIAL` verdict creates no findings
+and does not change the review action (approve / comment / request_changes)
+decided from finding severity. Authors split work across PRs on purpose and
+a later PR may close the issue. The review reports, it does not police.
+
+### 4. Across pushes
+
+The section is stateful like the rest of the review. On the next push the
+reviewer finds it by its `<!-- preloop-review:issue-coverage -->` marker,
+reuses the recorded criteria verbatim (rewording them would look like the
+review changed its mind), re-checks the unchecked ones against the current
+code, ticks off the ones later commits satisfy, and drops their gap and
+follow-up lines. A criterion a previous review checked is never unchecked
+unless the code that satisfied it left the branch, and never silently
+dropped. The verdict is recomputed from the checkbox tally, never restated.
+In `INCREMENTAL` scope only criteria whose file appears in the delta are
+re-checked; the rest keep their checkbox untouched.
+
+`result.json` carries the machine form:
+
+```json
+{
+  "status": "success",
+  "review_posted": true,
+  "risk_level": "medium",
+  "findings_count": 3,
+  "review_action": "comment",
+  "issue_coverage": [
+    {"issue": "org/repo#123", "verdict": "partial",
+     "criteria_total": 3, "criteria_met": 1, "gaps": 2}
+  ]
+}
+```
+
+`issue_coverage` is `[]` when the PR references no issue.
+
+## Not in this slice
+
+- No tracker-side relation read (GitLab's `/merge_requests/:iid/closes_issues`
+  endpoint is not wired into the tracker client, so the body and branch are
+  the only sources).
+- No cross-tracker resolution: an issue in a repository this account does not
+  sync reads as `UNCLEAR`.
+- No follow-up issue creation. The section is written so its follow-up lines
+  can be pasted into a new issue by a human.

--- a/docs/guide/flows/repo-review-presets.md
+++ b/docs/guide/flows/repo-review-presets.md
@@ -1,7 +1,7 @@
 # Full-repo review presets (architecture-strategy, code health, standards walk)
 
 These flow presets review a **whole repository** rather than a diff. They
-complement the diff-scoped Pull Request Reviewer preset: PR review runs
+complement the diff-scoped [Pull Request Reviewer preset](pull-request-review.md): PR review runs
 on every change and stays cheap; these run rarely (per release, on a
 schedule, or on demand), sample the repository deterministically, and
 declare exactly what they covered. Each run is a single execution that


### PR DESCRIPTION
The PR reviewer read the diff and never the issue, so it could tell you the
code was good but not whether it did what was asked. This adds an Issue
Coverage judgement to the review.

## What it does

For a PR that references an issue, the review now publishes one extra
section in its existing summary comment:

```markdown
### 🎯 Issue Coverage

<!-- preloop-review:issue-coverage -->

**[`org/repo#123`](https://github.com/org/repo/issues/123): Widget picker loses the last selection** (verdict: **PARTIAL**)

Restores the selection but ships no test and no doc update.

Acceptance criteria as this review reads them (quoted from the issue):
- [x] The picker restores the last selection after a reload - `src/widget-picker.ts:88`
- [ ] The restore is covered by a test
- [ ] The behaviour is documented in the widget guide

Gaps:
- No test covers the restore path - `src/widget-picker.test.ts`

Follow-ups (ready to file as issues):
- **Cover widget picker restore with a test**: the reload path is untested.
```

Verdicts are FULL / PARTIAL / NOT ADDRESSED / UNCLEAR, one per issue, with a
line of reasoning. Criteria come from the issue's own text, quoted where
possible; the prompt forbids inventing criteria the issue does not state
(tests, docs, and telemetry stay ordinary review findings unless the issue
asks for them).

## How the issue is found

Neither platform hands the reviewer a linked-issue relation on a PR read:
the GitHub mapping in `sync/trackers/github.py` and the GitLab mapping in
`api/endpoints/mcp.py` both return a fixed field list with no
`closes_issues`. So the reference is parsed off the PR itself, in code
rather than in the prompt, and exposed on the normalized trigger payload as
`object_attributes.referenced_issues`:

- `closes`: closing keywords in the body or title, including lists
  (`Closes #12, #13 and #14`), markdown links, cross-repo (`org/other#7`),
  GitLab subgroups, and Jira keys (`Fixes PROJ-7`).
- `reference`: plain mentions and issue URLs.
- `branch`: `123-slug`, `fix/issue-123`, `gh-123`, `feature/PROJ-7-slug`.

The PR's own number is dropped (squash titles carry `(#45)`), the strongest
kind wins per issue, the list is capped at 5, and when nothing matches the
field reads `none detected` and the section is omitted entirely.

## Stateful, and never a blocker

The section carries its own marker and is updated in place like the rest of
the review: on the next push the reviewer reuses the recorded criteria
verbatim, re-checks the unchecked ones against current code, ticks off what
later commits satisfy, drops their gaps and follow-ups, and recomputes the
verdict from the tally. Checked criteria are never silently unchecked; in
INCREMENTAL scope only criteria whose file is in the delta are re-checked.

A PARTIAL verdict creates no findings and does not change the review action.
Authors split work across PRs on purpose.

## Tool access

One grant added, read-only `get_issue`, which resolves an issue by URL,
`org/repo#123` key, or Jira key across GitHub, GitLab, and Jira. No
`create_issue`/`update_issue`: follow-ups are printed for a human to file.
When the issue is not synced into Preloop, `get_issue` returns not found and
the review must say UNCLEAR with that reason; reconstructing the issue from
the PR description (the thing under review) is explicitly forbidden.

## Tests

- `backend/tests/services/test_issue_references.py`: 41 parser tests
  (GitHub, GitLab, Jira, cross-repo, branches, no reference, formatting,
  trigger payloads).
- `backend/tests/test_pull_request_reviewer_preset.py`: 39 tests, new file
  (identity, allowlist including forbidden tools, discovery/verdict/stateful
  prompt contracts, and an end-to-end block that renders the real preset
  prompt from a GitHub webhook payload and resolves the identifier against a
  fake tracker).
- `backend/tests/services/prompt_resolvers/test_trigger_event.py`: +4 for the
  payload field.

`pytest tests/services` before and after: 43 failed / 674 errors on both
(pre-existing, no database in this environment), 3334 passed before and 3377
after, the difference being the new tests.

## Docs

New guide page `docs/guide/flows/pull-request-review.md` (the preset had
none; README linked the raw YAML), linked from README and from the full-repo
review presets page.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Additive, well-tested feature: a deterministic issue-reference parser, one read-only `get_issue` grant, and prompt wiring; no security-sensitive changes.
>
> **Overview**
> Adds an "Issue Coverage" judgement to the Pull Request Reviewer preset, recovering the referenced issue from the PR body/title/branch, reading it via `get_issue`, and publishing a non-blocking verdict with quoted criteria, gaps, and follow-ups. Fully unit-tested and documented with a new guide page.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9b7a7890. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->