### PR TITLE
Re-render the flow form when trigger events change

### DIFF
--- a/frontend/src/components/preloop-flow-form-notifications.test.ts
+++ b/frontend/src/components/preloop-flow-form-notifications.test.ts
@@ -256,15 +256,32 @@ describe('PreloopFlowForm PR-dependent sections', () => {
   });
 
   it('reveals the issue comment when an issue event is added to the trigger', async () => {
+    // Driven through the Events select the user actually operates: the form
+    // mutates `flow` in place, so the reveal only works if the handler asks
+    // for an update.
     const element = await mount(
       sampleFlow({ trigger: 'pull_request', createPullRequest: true })
     );
     expect(query(element, '[data-notifications-card]')).to.not.exist;
 
-    element.flow.trigger_event_types = ['pull_request_opened', 'issue_opened'];
-    (element as any).requestUpdate();
+    const events = Array.from(
+      element.shadowRoot!.querySelectorAll('sl-select')
+    ).find((select) => select.getAttribute('label') === 'Events') as any;
+    expect(events, 'Events select').to.exist;
+    events.value = ['pull_request_opened', 'issue_opened'];
+    events.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
     await element.updateComplete;
+
+    expect(element.flow.trigger_event_types).to.deep.equal([
+      'pull_request_opened',
+      'issue_opened',
+    ]);
     expect(query(element, '[data-notifications-card]')).to.exist;
+
+    events.value = ['pull_request_opened'];
+    events.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+    expect(query(element, '[data-notifications-card]')).to.not.exist;
   });
 
   it('renders and submits a saved issue comment when it applies', async () => {

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -2265,6 +2265,11 @@ export class PreloopFlowForm extends LitElement {
                         .value=${this.flow.trigger_event_types || []}
                         @sl-change=${(e: any) => {
                           this.flow.trigger_event_types = e.target.value;
+                          // The issue comment section is gated on these event
+                          // types. `flow` is mutated in place, so without this
+                          // the section only appears after some unrelated
+                          // update happens to re-render the form.
+                          this.requestUpdate();
                         }}
                       >
                         ${this.getEventOptions().map(


### PR DESCRIPTION
Follow-up to #501 (merged). The Events select handler in preloop-flow-form.ts mutated flow.trigger_event_types in place without requestUpdate(), so the issue-comment section did not appear when an issue event was added to the trigger (nor disappear when removed) until an unrelated update re-rendered the form. The create-PR half of the condition already called requestUpdate; only the trigger half was broken. The matrix test missed it because it called requestUpdate itself.

Fix: one requestUpdate() in the handler; the matrix test now drives the real sl-select and asserts the section hides again when the issue event is removed.

Measured: the new test fails against main (27 passed, 1 failed) and passes with the fix (28 passed); pre-commit clean. Found by the round 4 review pass.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Minimal, well-scoped bug fix with a regression test that drives the real component; no security or quality concerns.

> **Overview**
> Adds a missing `requestUpdate()` to the Events select handler so the issue-comment section renders when trigger event types change, and strengthens the test to exercise the actual `sl-select` element (reveal and hide paths).

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit b6b4099. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->