### PR TITLE
Fix the console navigation regressions from the in-house router (#499)

### DIFF
--- a/frontend/src/components/console-route-transitions.test.ts
+++ b/frontend/src/components/console-route-transitions.test.ts
@@ -1,0 +1,503 @@
+/**
+ * The console's route-transition matrix.
+ *
+ * Every console section is entered by clicking a link, checked for the element
+ * and params the route table promises, left through each of its own "Back to"
+ * links, and walked with the browser's Back and Forward buttons. It runs the
+ * real table from `lit-app` against the real router, in a real browser, with
+ * the API stubbed, because #499 broke navigation in a way no view test could
+ * see: the URL was right, the params were right, and the wrong element was on
+ * screen.
+ */
+import { expect, fixtureCleanup, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import { invalidateApiCaches } from '../api';
+import './lit-app';
+
+/** A route as the table declares it and as the console must render it. */
+interface Landing {
+  /** Path a link points at. */
+  path: string;
+  /** Where the router settles, when a redirect moves it. */
+  url?: string;
+  /** Custom element that must end up under the shell. */
+  tag: string;
+  /** `location.params` of that element, when the route takes any. */
+  params?: Record<string, string>;
+  /** Views that render outside <console-shell> (the catch-all). */
+  atOutlet?: boolean;
+  /** Routes whose component no module defines yet. */
+  undefinedElement?: boolean;
+}
+
+/** Every console section, in the order the matrix walks them. */
+const MATRIX: Landing[] = [
+  { path: '/console', tag: 'dashboard-view', params: {} },
+  { path: '/console/agents', tag: 'agents-view', params: {} },
+  {
+    path: '/console/agents/agent-1',
+    tag: 'agent-detail-view',
+    params: { agentId: 'agent-1' },
+  },
+  {
+    path: '/console/agents/agent-1/talk',
+    tag: 'agent-talk-view',
+    params: { agentId: 'agent-1' },
+  },
+  { path: '/console/flows', tag: 'flows-view', params: {} },
+  { path: '/console/flows/new', tag: 'flow-view', params: {} },
+  {
+    path: '/console/flows/flow-1',
+    tag: 'flow-view',
+    params: { flowId: 'flow-1' },
+  },
+  {
+    path: '/console/flows/executions',
+    tag: 'flow-executions-view',
+    params: {},
+  },
+  {
+    path: '/console/flows/executions/exec-1',
+    tag: 'flow-execution-view',
+    params: { executionId: 'exec-1' },
+  },
+  { path: '/console/approvals', tag: 'approvals-view', params: {} },
+  {
+    path: '/console/approval/appr-1',
+    tag: 'approval-view',
+    params: { requestId: 'appr-1' },
+  },
+  // The bare /console/runners route only exists to redirect.
+  {
+    path: '/console/runners',
+    url: '/console/settings/runners',
+    tag: 'runners-view',
+  },
+  { path: '/console/tools', tag: 'tools-view', params: {} },
+  { path: '/console/ai-models', tag: 'ai-models-view', params: {} },
+  {
+    path: '/console/ai-models/model-1',
+    tag: 'ai-model-detail-view',
+    params: { modelId: 'model-1' },
+  },
+  { path: '/console/settings/api-keys', tag: 'api-keys-view', params: {} },
+  {
+    path: '/console/settings/api-keys/key-1',
+    tag: 'api-key-view',
+    params: { keyId: 'key-1' },
+  },
+  { path: '/console/policies', tag: 'policies-view', params: {} },
+  { path: '/console/trackers', tag: 'trackers-view', params: {} },
+  {
+    path: '/console/trackers/tracker-1',
+    tag: 'tracker-detail-view',
+    params: { trackerId: 'tracker-1' },
+  },
+  {
+    path: '/console/trackers/tracker-1/issues/issue-1',
+    tag: 'tracker-issue-view',
+    params: { trackerId: 'tracker-1', issueId: 'issue-1' },
+  },
+  {
+    path: '/console/runtime-sessions',
+    tag: 'runtime-sessions-view',
+    params: {},
+  },
+  { path: '/console/audit', tag: 'audit-view', params: {} },
+  { path: '/console/attention', tag: 'attention-view', params: {} },
+  { path: '/console/cost', tag: 'cost-view', params: {} },
+  { path: '/console/api-usage', tag: 'api-usage-view', params: {} },
+  { path: '/console/issues', tag: 'issues-view', params: {} },
+  // Settings pages, including the group's own redirect to profile.
+  {
+    path: '/console/settings',
+    url: '/console/settings/profile',
+    tag: 'profile-view',
+  },
+  { path: '/console/settings/security', tag: 'security-view', params: {} },
+  { path: '/console/settings/appearance', tag: 'appearance-view', params: {} },
+  { path: '/console/settings/account', tag: 'account-view', params: {} },
+  { path: '/console/settings/users', tag: 'user-management-view', params: {} },
+  { path: '/console/settings/teams', tag: 'team-management-view', params: {} },
+  {
+    path: '/console/settings/invitations',
+    tag: 'invitation-management-view',
+    params: {},
+  },
+  {
+    path: '/console/settings/notification-preferences',
+    tag: 'notification-preferences-view',
+    params: {},
+  },
+  // Declared in the table with a component no module defines. The router still
+  // has to attach the element the table names; the missing module is tracked
+  // separately, and this row is here so the day it lands the route works.
+  { path: '/console/pricing', tag: 'pricing-view', undefinedElement: true },
+  { path: '/console/authorize', tag: 'oauth-consent-view', params: {} },
+  {
+    path: '/console/governance',
+    url: '/console/policies',
+    tag: 'policies-view',
+  },
+  {
+    path: '/console/does-not-exist',
+    tag: 'not-found-view',
+    atOutlet: true,
+  },
+];
+
+const BY_PATH = new Map(MATRIX.map((entry) => [entry.path, entry]));
+
+/** The console's route groups, where a parent route owns no component. */
+const FLOWS_GROUP = [
+  '/console/flows',
+  '/console/flows/new',
+  '/console/flows/flow-1',
+  '/console/flows/executions',
+  '/console/flows/executions/exec-1',
+];
+const TRACKERS_GROUP = [
+  '/console/trackers',
+  '/console/trackers/tracker-1',
+  '/console/trackers/tracker-1/issues/issue-1',
+];
+
+type RoutedElement = HTMLElement & {
+  location?: { params: Record<string, string> };
+};
+
+const FLOW = {
+  id: 'flow-1',
+  name: 'Nightly triage',
+  description: 'A flow',
+  enabled: true,
+  agent_id: 'agent-1',
+  trigger_type: 'schedule',
+  trigger_config: {},
+  steps: [],
+  created_at: '2026-09-01T10:00:00Z',
+  updated_at: '2026-09-01T10:00:00Z',
+};
+const EXECUTION = {
+  id: 'exec-1',
+  flow_id: 'flow-1',
+  flow_name: 'Nightly triage',
+  status: 'completed',
+  trigger_type: 'schedule',
+  created_at: '2026-09-02T10:00:00Z',
+  started_at: '2026-09-02T10:00:00Z',
+  completed_at: '2026-09-02T10:05:00Z',
+  steps: [],
+  logs: [],
+};
+const APPROVAL = {
+  id: 'appr-1',
+  status: 'pending',
+  action_type: 'tool_call',
+  tool_name: 'shell',
+  agent_id: 'agent-1',
+  agent_name: 'Agent One',
+  risk_level: 'high',
+  requested_at: '2026-09-03T10:00:00Z',
+  expires_at: '2026-12-03T10:00:00Z',
+  request_data: {},
+  arguments: {},
+};
+const AGENT = {
+  id: 'agent-1',
+  name: 'Agent One',
+  agent_type: 'claude_code',
+  status: 'active',
+  created_at: '2026-09-01T10:00:00Z',
+};
+const TRACKER = {
+  id: 'tracker-1',
+  name: 'Repo',
+  tracker_type: 'github',
+  status: 'connected',
+  created_at: '2026-09-01T10:00:00Z',
+};
+
+/** One stub for every view the matrix visits. Shapes, not fidelity. */
+function stubbedBody(url: string): unknown {
+  const path = new URL(url, window.location.origin).pathname;
+  if (path.endsWith('/api/v1/features')) return { features: {}, plugins: [] };
+  if (path.endsWith('/api/v1/auth/users/me')) {
+    return {
+      username: 'founder',
+      email: 'founder@example.com',
+      email_verified: true,
+      permissions: null,
+      is_superuser: true,
+    };
+  }
+  if (/\/api\/v1\/flows\/executions\/[^/]+\/logs/u.test(path)) return [];
+  if (/\/api\/v1\/flows\/executions\/[^/]+$/u.test(path)) return EXECUTION;
+  if (path.includes('/api/v1/flows/executions')) return [EXECUTION];
+  if (/\/api\/v1\/flows\/[^/]+\/executions/u.test(path)) return [EXECUTION];
+  if (/\/api\/v1\/flows\/[^/]+$/u.test(path)) return FLOW;
+  if (path.endsWith('/api/v1/flows')) return [FLOW];
+  if (/\/api\/v1\/approval-requests\/[^/]+\/history$/u.test(path)) return [];
+  if (/\/api\/v1\/approval-requests\/[^/]+$/u.test(path)) return APPROVAL;
+  if (path.includes('/api/v1/approval-requests')) return [APPROVAL];
+  if (/\/api\/v1\/agents\/[^/]+$/u.test(path)) return AGENT;
+  if (path.includes('/api/v1/agents')) return [AGENT];
+  if (/\/api\/v1\/trackers\/[^/]+$/u.test(path)) return TRACKER;
+  if (path.includes('/api/v1/trackers')) return [TRACKER];
+  // Everything else: a list where a list is plausible, an object otherwise.
+  if (
+    /(models|keys|policies|tools|issues|projects|sessions|logs|events|users|teams|invitations|rules|servers|bypasses|workflows|providers|plans|budgets)/u.test(
+      path
+    )
+  ) {
+    return [];
+  }
+  // Spend and usage pages read nested totals off their summary payloads.
+  const zeroTokens = {
+    total_tokens: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_tokens: 0,
+    reasoning_tokens: 0,
+  };
+  if (/(summary|usage|overview|cost)/u.test(path)) {
+    return {
+      token_usage: zeroTokens,
+      ...zeroTokens,
+      total_cost: 0,
+      total_requests: 0,
+      items: [],
+      series: [],
+    };
+  }
+  return {};
+}
+
+describe('console route transitions', () => {
+  let app: HTMLElement;
+  let fetchStub: sinon.SinonStub;
+  const startUrl = window.location.pathname + window.location.search;
+
+  const outlet = () => app.shadowRoot!.querySelector('main')!;
+  const shell = () => outlet().querySelector('console-shell');
+
+  /** The deepest element the router attached, whatever it nested it under. */
+  const deepest = (): RoutedElement | null => {
+    let node: Element | null = outlet().firstElementChild;
+    let last: Element | null = null;
+    while (node) {
+      last = node;
+      node = node.firstElementChild;
+    }
+    return last as RoutedElement | null;
+  };
+
+  /** Click a link, exactly as a view's own anchor would be clicked. */
+  const clickLink = (href: string): void => {
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    anchor.textContent = href;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+  };
+
+  /** Assert the console is showing what the table promises for `entry`. */
+  async function assertLanded(entry: Landing, how: string): Promise<void> {
+    const url = entry.url ?? entry.path;
+    await waitUntil(
+      () => window.location.pathname === url,
+      `${how}: expected the URL to be ${url}, got ${window.location.pathname}`,
+      { timeout: 10000 }
+    );
+    const selector = entry.atOutlet
+      ? `main > ${entry.tag}`
+      : `console-shell > ${entry.tag}`;
+    await waitUntil(
+      () =>
+        Boolean(
+          entry.atOutlet
+            ? outlet().firstElementChild?.localName === entry.tag
+            : shell()?.querySelector(`:scope > ${entry.tag}`)
+        ),
+      `${how}: expected ${selector} at ${url}, got ` +
+        `${outlet().firstElementChild?.localName ?? 'nothing'} > ` +
+        `${outlet().firstElementChild?.firstElementChild?.localName ?? '-'}`,
+      { timeout: 10000 }
+    );
+
+    const view = deepest()!;
+    expect(view.localName, `${how}: rendered element at ${url}`).to.equal(
+      entry.tag
+    );
+    // The routed view is the shell's only child, and nothing hangs off it.
+    // A view nested inside the view it was reached from is exactly the #499
+    // regression: right URL, right params, wrong page on screen.
+    if (!entry.atOutlet) {
+      expect(
+        shell()!.children.length,
+        `${how}: views under the shell`
+      ).to.equal(1);
+    }
+    expect(
+      view.firstElementChild,
+      `${how}: ${entry.tag} must not host another routed view`
+    ).to.equal(null);
+    if (entry.params) {
+      expect(view.location?.params, `${how}: params at ${url}`).to.deep.equal(
+        entry.params
+      );
+    }
+    if (entry.undefinedElement) {
+      expect(customElements.get(entry.tag)).to.equal(undefined);
+    }
+  }
+
+  /**
+   * Every way out of a view that leads to another section in the matrix: the
+   * "Back to ..." buttons, the breadcrumbs, the "All executions" link. Only
+   * the view's own shadow root is searched, so the set is bounded by the page
+   * under test.
+   */
+  function exitLinks(view: Element): { href: string; click: () => void }[] {
+    const root = (view as HTMLElement & { shadowRoot: ShadowRoot | null })
+      .shadowRoot;
+    if (!root) return [];
+    const found = new Map<string, { href: string; click: () => void }>();
+    const keep = (href: string | null, click: () => void) => {
+      if (!href || !BY_PATH.has(href) || found.has(href)) return;
+      found.set(href, { href, click });
+    };
+    for (const anchor of root.querySelectorAll('a[href^="/console"]')) {
+      keep(anchor.getAttribute('href'), () =>
+        (anchor as HTMLAnchorElement).click()
+      );
+    }
+    // Shoelace buttons carry the href on the host and render the anchor in
+    // their own shadow root, which is the node a user's click starts on.
+    for (const button of root.querySelectorAll('sl-button[href^="/console"]')) {
+      const inner = (button as HTMLElement).shadowRoot?.querySelector('a');
+      if (!inner) continue;
+      keep(button.getAttribute('href'), () => inner.click());
+    }
+    return [...found.values()];
+  }
+
+  before(async () => {
+    invalidateApiCaches();
+    (window as Window & { BRAND_CONFIG?: unknown }).BRAND_CONFIG = {
+      name: 'Preloop',
+      domain: 'preloop.ai',
+      company: { legal_name: 'Preloop', address: '', city: '' },
+      branding: {
+        logo_light: '/logo.svg',
+        logo_dark: '/logo-dark.svg',
+        favicon: '/favicon.ico',
+        primary_color: '#000',
+        gradient_product: '',
+        gradient_ai: '',
+      },
+      social: { twitter: '', linkedin: '', instagram: '' },
+    };
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      return new Response(JSON.stringify(stubbedBody(url)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    window.history.replaceState({}, '', '/console');
+    app = document.createElement('lit-app');
+    document.body.append(app);
+    await assertLanded(BY_PATH.get('/console')!, 'first load of /console');
+  });
+
+  after(() => {
+    app.remove();
+    fixtureCleanup();
+    fetchStub.restore();
+    localStorage.clear();
+    delete (window as Window & { BRAND_CONFIG?: unknown }).BRAND_CONFIG;
+    window.history.replaceState({}, '', startUrl);
+  });
+
+  it('renders every section entered by a link click, and back and forward again', async () => {
+    let previous = BY_PATH.get('/console')!;
+    for (const entry of MATRIX) {
+      if (entry.path === '/console') continue;
+      clickLink(entry.path);
+      await assertLanded(entry, `click ${previous.path} -> ${entry.path}`);
+
+      window.history.back();
+      await assertLanded(previous, `back from ${entry.path}`);
+
+      window.history.forward();
+      await assertLanded(entry, `forward to ${entry.path}`);
+      previous = entry;
+    }
+  });
+
+  it('renders every ordered pair inside the flows and trackers groups', async () => {
+    // The route groups are where #499 went wrong: `flows` and `trackers` have
+    // children but no component, so their level in the chain owns no element.
+    for (const group of [FLOWS_GROUP, TRACKERS_GROUP]) {
+      for (const from of group) {
+        for (const to of group) {
+          if (from === to) continue;
+          clickLink(from);
+          await assertLanded(BY_PATH.get(from)!, `setup ${from}`);
+          clickLink(to);
+          await assertLanded(BY_PATH.get(to)!, `${from} -> ${to}`);
+        }
+      }
+    }
+  });
+
+  it('connects a view against the URL it navigated to', async () => {
+    clickLink('/console/approvals');
+    await assertLanded(BY_PATH.get('/console/approvals')!, 'visit approvals');
+
+    const approval = BY_PATH.get('/console/approval/appr-1')!;
+    clickLink(approval.path);
+    await assertLanded(approval, 'open an approval');
+
+    // <approval-view> takes its request id out of window.location in
+    // connectedCallback. Connecting it before the URL moved left the id empty
+    // and turned every approval link into a 404.
+    const view = deepest() as HTMLElement & { requestId?: string };
+    expect(view.requestId).to.equal('appr-1');
+  });
+
+  it('follows every "Back to ..." link and breadcrumb a section renders', async () => {
+    const clicked: string[] = [];
+    for (const entry of MATRIX) {
+      if (entry.atOutlet) continue;
+      clickLink(entry.path);
+      await assertLanded(entry, `visit ${entry.path}`);
+      const links = exitLinks(deepest()!);
+      for (let index = 0; index < links.length; index++) {
+        // The view is rebuilt on the way back in, so re-read its links.
+        const fresh = exitLinks(deepest()!)[index];
+        if (!fresh) break;
+        const target = BY_PATH.get(fresh.href)!;
+        fresh.click();
+        await assertLanded(target, `${entry.path}: exit link ${fresh.href}`);
+        clicked.push(`${entry.path} -> ${fresh.href}`);
+        clickLink(entry.path);
+        await assertLanded(entry, `return to ${entry.path}`);
+      }
+    }
+    // The founder's report was that these do nothing. If a view stops
+    // rendering one, this test quietly stops covering it, so the count is
+    // part of the assertion.
+    expect(
+      clicked.length,
+      `section exit links exercised: ${clicked.join(', ')}`
+    ).to.be.greaterThan(14);
+  });
+});

--- a/frontend/src/router/router.test.ts
+++ b/frontend/src/router/router.test.ts
@@ -593,6 +593,106 @@ describe('router', () => {
     });
   });
 
+  describe('history', () => {
+    it('names the destination before the view is connected', async () => {
+      const tag = `rt-url-at-connect-${++tagSeq}`;
+      let pathAtConnect: string | undefined;
+      customElements.define(
+        tag,
+        class extends HTMLElement {
+          connectedCallback() {
+            pathAtConnect = window.location.pathname + window.location.search;
+          }
+        }
+      );
+      const from = defineTag('rt-url-at-connect-from');
+      await router.setRoutes(
+        [
+          { path: '/connect/from', component: from },
+          { path: '/connect/to/:id', component: tag },
+        ],
+        true
+      );
+      await router.render('/connect/from', { history: 'push' });
+      await router.render('/connect/to/9?tab=logs', { history: 'push' });
+      // Views read the URL when they connect: <approval-view> takes its
+      // request id from the path there. Connecting them against the page they
+      // came from is what turned an approval link into a 404.
+      expect(pathAtConnect).to.equal('/connect/to/9?tab=logs');
+    });
+
+    it('connects the view a redirect landed on against the final URL', async () => {
+      const tag = `rt-url-after-redirect-${++tagSeq}`;
+      let pathAtConnect: string | undefined;
+      customElements.define(
+        tag,
+        class extends HTMLElement {
+          connectedCallback() {
+            pathAtConnect = window.location.pathname;
+          }
+        }
+      );
+      await router.setRoutes(
+        [
+          { path: '/hopto', redirect: '/hopto/profile' },
+          { path: '/hopto/profile', component: tag },
+        ],
+        true
+      );
+      await router.render('/hopto', { history: 'push' });
+      expect(pathAtConnect).to.equal('/hopto/profile');
+      expect(window.location.pathname).to.equal('/hopto/profile');
+    });
+
+    it('leaves the URL alone when a guard cancels the navigation', async () => {
+      const leaving = `rt-url-prevented-${++tagSeq}`;
+      const next = defineTag('rt-url-prevented-next');
+      customElements.define(
+        leaving,
+        class extends HTMLElement {
+          onBeforeLeave(
+            _location: RouterLocation,
+            commands: { prevent(): unknown }
+          ) {
+            return commands.prevent();
+          }
+        }
+      );
+      await router.setRoutes(
+        [
+          { path: '/prevented/stay', component: leaving },
+          { path: '/prevented/next', component: next },
+        ],
+        true
+      );
+      await router.render('/prevented/stay', { history: 'push' });
+      await router.render('/prevented/next', { history: 'push' });
+      expect(window.location.pathname).to.equal('/prevented/stay');
+    });
+
+    it('leaves the URL alone when a newer navigation overtakes an older one', async () => {
+      const slow = defineTag('rt-url-slow');
+      const fast = defineTag('rt-url-fast');
+      let release!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await router.setRoutes(
+        [
+          { path: '/race/slow', component: slow, load: () => pending },
+          { path: '/race/fast', component: fast },
+        ],
+        true
+      );
+      const overtaken = router.render('/race/slow', { history: 'push' });
+      await router.render('/race/fast', { history: 'push' });
+      release();
+      await overtaken;
+      expect(window.location.pathname).to.equal('/race/fast');
+      expect(outlet.querySelector(fast)).to.exist;
+    });
+  });
+
   describe('component loading', () => {
     it('awaits a route load() before creating the element', async () => {
       const tag = `rt-lazy-${++tagSeq}`;

--- a/frontend/src/router/router.test.ts
+++ b/frontend/src/router/router.test.ts
@@ -469,6 +469,130 @@ describe('router', () => {
     });
   });
 
+  // The console groups its flows (and trackers, and issues) under a parent
+  // route that has children but no component of its own. That group occupies a
+  // level in the chain while owning no element, which is what #499 got wrong.
+  describe('component-less group routes', () => {
+    /** `/console/flows` and its children, as the console declares them. */
+    const groupRoutes = (tags: {
+      shell: string;
+      list: string;
+      create: string;
+      detail: string;
+      execution: string;
+    }) => [
+      {
+        path: '/console',
+        component: tags.shell,
+        children: [
+          {
+            path: 'flows',
+            children: [
+              { path: '', component: tags.list },
+              { path: 'new', component: tags.create },
+              {
+                path: 'executions/:executionId',
+                component: tags.execution,
+              },
+              { path: ':flowId', component: tags.detail },
+            ],
+          },
+        ],
+      },
+    ];
+
+    it('does not reuse a leaf element as the group it sits under', async () => {
+      const tags = {
+        shell: defineTag('rt-group-shell'),
+        list: defineTag('rt-group-list'),
+        create: defineTag('rt-group-create'),
+        detail: defineTag('rt-group-detail'),
+        execution: defineTag('rt-group-execution'),
+      };
+      await router.setRoutes(groupRoutes(tags), true);
+
+      await router.render('/console/flows/executions/e1');
+      expect(outlet.querySelector(`${tags.shell} > ${tags.execution}`)).to
+        .exist;
+
+      // Back to the list: the execution view must go, not become the group.
+      await router.render('/console/flows');
+      expect(outlet.querySelector(`${tags.shell} > ${tags.list}`)).to.exist;
+      expect(outlet.querySelector(tags.execution)).to.equal(null);
+
+      // And down again: the list must go, not host the execution view.
+      await router.render('/console/flows/executions/e1');
+      expect(outlet.querySelector(`${tags.shell} > ${tags.execution}`)).to
+        .exist;
+      expect(outlet.querySelector(tags.list)).to.equal(null);
+    });
+
+    it('does not hand a sibling route location to the view it left', async () => {
+      const detail = `rt-group-params-detail-${++tagSeq}`;
+      const seen: (string | undefined)[] = [];
+      customElements.define(
+        detail,
+        class extends HTMLElement {
+          onBeforeEnter(location: RouterLocation) {
+            seen.push(location.params.flowId);
+          }
+        }
+      );
+      const tags = {
+        shell: defineTag('rt-group-params-shell'),
+        list: defineTag('rt-group-params-list'),
+        create: defineTag('rt-group-params-create'),
+        detail,
+        execution: defineTag('rt-group-params-execution'),
+      };
+      await router.setRoutes(groupRoutes(tags), true);
+
+      await router.render('/console/flows/f1');
+      await router.render('/console/flows/executions/e1');
+
+      // The flow page must not be re-entered with the execution's params:
+      // that is how <flow-view> lost its flowId and drew the create form.
+      expect(seen).to.deep.equal(['f1']);
+      expect(outlet.querySelector(detail)).to.equal(null);
+      expect(outlet.querySelector(`${tags.shell} > ${tags.execution}`)).to
+        .exist;
+    });
+
+    it('keeps two routes that share a component apart inside a group', async () => {
+      const tags = {
+        shell: defineTag('rt-group-share-shell'),
+        list: defineTag('rt-group-share-list'),
+        create: defineTag('rt-group-share-view'),
+        detail: defineTag('rt-group-share-view-detail'),
+        execution: defineTag('rt-group-share-execution'),
+      };
+      // `new` and `:flowId` are one component in the console. Reuse across
+      // them is fine; hosting one inside the other is not.
+      const routes = groupRoutes({ ...tags, detail: tags.create });
+      await router.setRoutes(routes, true);
+
+      await router.render('/console/flows/f1');
+      await router.render('/console/flows/new');
+      expect(outlet.querySelector(`${tags.shell} > ${tags.create}`)).to.exist;
+      expect(outlet.querySelectorAll(tags.create).length).to.equal(1);
+    });
+
+    it('keeps the shell alive while the group changes underneath it', async () => {
+      const tags = {
+        shell: defineTag('rt-group-keep-shell'),
+        list: defineTag('rt-group-keep-list'),
+        create: defineTag('rt-group-keep-create'),
+        detail: defineTag('rt-group-keep-detail'),
+        execution: defineTag('rt-group-keep-execution'),
+      };
+      await router.setRoutes(groupRoutes(tags), true);
+      await router.render('/console/flows');
+      const shellElement = outlet.querySelector(tags.shell);
+      await router.render('/console/flows/executions/e1');
+      expect(outlet.querySelector(tags.shell)).to.equal(shellElement);
+    });
+  });
+
   describe('component loading', () => {
     it('awaits a route load() before creating the element', async () => {
       const tag = `rt-lazy-${++tagSeq}`;

--- a/frontend/src/router/router.ts
+++ b/frontend/src/router/router.ts
@@ -663,7 +663,10 @@ export class Router {
   }
 
   /**
-   * Write the history entry once the destination is known.
+   * Write the history entry once the destination is known, which is before
+   * the destination's views are connected: a view that reads
+   * `window.location` in `connectedCallback` must read where it is, not where
+   * it came from.
    *
    * Only the destination is ever written, never the URL a redirect passed
    * through, so a redirect costs no back-button stop. The kind of entry is the

--- a/frontend/src/router/router.ts
+++ b/frontend/src/router/router.ts
@@ -249,6 +249,20 @@ function routableAnchor(event: MouseEvent): HTMLAnchorElement | undefined {
   return anchor;
 }
 
+/**
+ * The innermost element of a rendered chain. Levels whose route owns no
+ * element are holes, so the leaf is the last entry that is not one.
+ */
+function deepestElement(
+  elements: readonly (RoutedElement | null)[]
+): RoutedElement | undefined {
+  for (let level = elements.length - 1; level >= 0; level--) {
+    const element = elements[level];
+    if (element) return element;
+  }
+  return undefined;
+}
+
 /** Router instances that are listening, so the static `go` can reach them. */
 const activeRouters = new Set<Router>();
 
@@ -256,7 +270,13 @@ export class Router {
   #outlet: Element | null = null;
   #flat: CompiledRoute[] = [];
   #chain: Route[] = [];
-  #elements: RoutedElement[] = [];
+  /**
+   * The rendered element per chain level, `null` where the route at that level
+   * owns no element of its own. The holes are the point: `#elements[level]`
+   * and `#chain[level]` must describe the same route, or reuse compares a
+   * component-less group route against the element of a deeper route.
+   */
+  #elements: (RoutedElement | null)[] = [];
   #renderId = 0;
   #listening = false;
   #loading: LoadingRenderer | null = null;
@@ -446,7 +466,7 @@ export class Router {
     };
     const commands = this.#commands();
 
-    const leaving = this.#elements[this.#elements.length - 1];
+    const leaving = deepestElement(this.#elements);
     if (leaving?.onBeforeLeave) {
       const verdict = await leaving.onBeforeLeave(context, commands, this);
       if (isPrevent(verdict)) return { cancelled: true };
@@ -468,12 +488,15 @@ export class Router {
     // shell on every click.
     let parent: Element = outlet;
     let diverged = false;
-    const next: RoutedElement[] = [];
+    const next: (RoutedElement | null)[] = [];
     const attach: { parent: Element; element: RoutedElement }[] = [];
 
     for (let level = 0; level < hit.chain.length; level++) {
       const route = hit.chain[level];
-      if (!route) continue;
+      if (!route) {
+        next.push(null);
+        continue;
+      }
 
       let element: RoutedElement | null = null;
       if (route.action) {
@@ -513,7 +536,18 @@ export class Router {
         element = document.createElement(route.component) as RoutedElement;
       }
 
-      if (!element) continue;
+      // A route that owns no element (a group like `flows`, whose children
+      // carry the components) still occupies its level. Recording the hole
+      // keeps `#elements` indexed by chain level; dropping it would shift
+      // every deeper element up, and the next navigation would then find the
+      // leaf's element sitting where the group's is looked up and reuse it as
+      // the group: the flows section rendering inside the page it came from.
+      if (!element) {
+        // The group itself changed, so nothing below it may be reused either.
+        if (this.#chain[level] !== route) diverged = true;
+        next.push(null);
+        continue;
+      }
       if (!reusable) {
         diverged = true;
         attach.push({ parent, element });
@@ -530,7 +564,8 @@ export class Router {
       parent = element;
     }
 
-    if (!next.length) return { stale: true };
+    const rendered = deepestElement(next);
+    if (!rendered) return { stale: true };
 
     // Attach only once every action and guard has had a chance to redirect.
     // An action on a nested route that returns `commands.redirect` must not
@@ -538,11 +573,16 @@ export class Router {
     for (const step of attach) {
       step.parent.replaceChildren(step.element);
     }
+    // A chain that ends higher than the last one leaves the old leaf attached
+    // under an element that was reused, where no `replaceChildren` reached it.
+    for (let level = next.length; level < this.#elements.length; level++) {
+      this.#elements[level]?.remove();
+    }
 
     this.#chain = hit.chain.slice(0, next.length);
     this.#elements = next;
     this.location = context;
-    next[next.length - 1]?.onAfterEnter?.(context, commands, this);
+    rendered.onAfterEnter?.(context, commands, this);
     return { location: context };
   }
 

--- a/frontend/src/router/router.ts
+++ b/frontend/src/router/router.ts
@@ -416,7 +416,10 @@ export class Router {
     let current = start;
 
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-      const outcome = await this.#renderOnce(current, renderId);
+      const outcome = await this.#renderOnce(current, renderId, {
+        mode: options.history ?? 'none',
+        start,
+      });
       // A chunk that never arrived still moved the operator: the panel in the
       // outlet is about the route they asked for, and the reload it offers can
       // only reach that route if the address bar names it. A newer navigation
@@ -432,7 +435,8 @@ export class Router {
         current = splitUrl(outcome.redirect);
         continue;
       }
-      this.#writeHistory(current, options.history ?? 'none', start);
+      // The history entry for a successful render is written inside
+      // #renderOnce, before the view is connected.
       if (outcome.location) this.#announce(outcome.location);
       return;
     }
@@ -442,7 +446,11 @@ export class Router {
   /** One resolution pass. Returns a redirect instead of following it. */
   async #renderOnce(
     target: { pathname: string; search: string; hash: string },
-    renderId: number
+    renderId: number,
+    history: {
+      mode: 'push' | 'replace' | 'none';
+      start: { pathname: string; search: string; hash: string };
+    }
   ): Promise<{
     redirect?: string;
     cancelled?: boolean;
@@ -566,6 +574,15 @@ export class Router {
 
     const rendered = deepestElement(next);
     if (!rendered) return { stale: true };
+
+    // From here the pass is terminal: every action and guard has run and
+    // nothing can redirect any more, so the address bar can name the
+    // destination. It has to happen before the views are connected. Vaadin
+    // Router updated history before it added the new content, and console
+    // views rely on that: <approval-view> takes its request id out of
+    // `window.location.pathname` in connectedCallback, and reading the page it
+    // came from left the id empty and the fetch a 404.
+    this.#writeHistory(target, history.mode, history.start);
 
     // Attach only once every action and guard has had a chance to redirect.
     // An action on a nested route that returns `commands.redirect` must not


### PR DESCRIPTION
Fix the console navigation regressions from the in-house router (#499)

## What the founder saw

- clicking a flow execution lands on the create-flow page
- "Back to Flows" changes the URL and not the page
- opening an approval gives a 404

All three reproduce in a real browser (chromium, vite dev server, mocked API)
on `main` at a6ef25cd, and none of them reproduce on a direct load or a
refresh, which is why they got through review.

| From (fresh load) | Click | URL after | What was attached | What the shell showed |
|---|---|---|---|---|
| `/console/flows/flow-1` | an execution link | `/console/flows/executions/exec-1` | `console-shell > flow-view > flow-execution-view` | `flow-view` with `flowId` gone: the create-flow form |
| `/console/flows/executions/exec-1` | "Back to Flows" | `/console/flows` | `console-shell > flow-executions-view > flows-view` | the executions list, unchanged |
| `/console/approvals` | an approval row | `/console/approval/appr-1` | `console-shell > approval-view` | `approval-view` with `requestId=""`, which fetches `/api/v1/approval-requests/` and renders not-found |

A sweep of 38 link transitions across every console section on `main` fails 6
of them, all inside the two route groups (`flows`, `trackers`). On this branch
it fails none.

## Root cause 1: component-less group routes lost their slot

`frontend/src/router/router.ts`, `#renderOnce`.

`flows`, `trackers` and `issues` are declared as routes with children and no
component of their own (`components/lit-app.ts:311-349`). Such a route occupies
a level in the matched chain and owns no element. `#renderOnce` skipped it when
building the element array, so from then on `#elements[level]` and
`#chain[level]` described different routes. The reuse test

    this.#chain[level] === route && this.#elements[level]?.parentElement === parent

then compared the group's route against the leaf's element, and since a group
has no `component` the tag check passed unconditionally. The leaf was reused as
the group: the next view was attached inside it (into light DOM nothing slots,
so the old page stayed on screen) and the old view was re-entered with the new
route's `location`. `flow-view.onBeforeEnter` reads `location.params.flowId`,
an execution route has none, so it drew the create form.

Elements are now indexed by chain level with a hole where a route owns none, a
group whose route changed marks the chain diverged, and a chain that ends
higher than the last one removes the leaf that nothing replaced.

## Root cause 2: history was written after the view was connected

`frontend/src/router/router.ts`, `render` / `#renderOnce`.

Vaadin Router updated the address bar before it added the new content
(`__updateBrowserHistory` at dist:1785, `__addAppearingContent` at dist:1797),
and console views were written against that guarantee.
`approval-view.connectedCallback` takes its request id out of
`window.location.pathname` when the property is not set, which is what an
in-app link does. The in-house router wrote history after attaching, so the
view read the page it came from, kept `requestId` empty and 404ed.

The write now happens at the terminal point of a resolution pass: after every
action and guard has had its chance to redirect or cancel, before the attach
loop. A pass that redirects, is cancelled, or is overtaken by a newer
navigation still writes nothing.

Checked and cleared while hunting: `routableAnchor` does walk `composedPath`,
so Shoelace `sl-button href` anchors inside shadow roots are intercepted; the
route table's order is right and `/console/approval/:requestId` compiles to
`^/console/approval/([^/]+)$`, which matches well before the catch-all.

## The regression net

`frontend/src/components/console-route-transitions.test.ts` (new, web-test-runner,
real chromium, stubbed API) drives the real table from `lit-app` through the
real router:

- every console section entered by a link click (39 routes: overview, agents +
  detail + talk, flows + new + detail + executions + execution, approvals +
  approval, runners, tools, models + detail, api keys + key, policies, trackers
  + detail + issue, sessions, audit, attention, cost, api usage, issues, the
  settings pages, pricing, authorize, the governance and settings redirects,
  not-found), asserting the rendered element, its `location.params`, that it is
  the shell's only child and that nothing is nested under it, then Back and
  Forward after each;
- every ordered pair inside the two component-less groups (20 flows pairs, 6
  trackers pairs);
- every in-view exit link and breadcrumb (18 of them: "Back to Flows", "All
  executions", "Back to tracker", the approval and model and api-key back
  links), followed to its target;
- `approval-view.requestId` after a link click, which is the founder's 404.

All four cases fail against the router as #499 shipped it.
`router.test.ts` gains 8 unit tests: 4 for group routes (3 fail without the
fix) and 4 for history ordering (2 fail without the fix).

## Numbers

- `npm test`: 2338 passed, 0 failed, 187 files (baseline a6ef25cd: 2326 passed,
  186 files)
- `npx tsc --noEmit`: 87 errors, the same 87 as the baseline, none in `src/router`
- `npm run build`: passes; total dist JS 3,211,610 bytes against 3,211,406 on
  the baseline (+204 bytes)
- real-browser sweep: 38 link transitions plus Back and Forward at each, 6
  failures before, 0 after

No view was patched: both fixes are in the router.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Router-only bug fix with comprehensive regression coverage; no security surface and no API changes.
>
> **Overview**
> Fixes two navigation regressions in the in-house router: component-less group routes (flows/trackers/issues) now keep their chain-level slot, and history is written before views connect so `connectedCallback` reads the destination URL. Adds a real-browser route-transition matrix plus 8 unit tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c7ef36d5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->