### PR TITLE
Fix the empty Overview Activity box: ask the audit timeline for the news

### DIFF
--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -513,10 +513,12 @@ describe('activity-feed', () => {
       localStorage.removeItem('accessToken');
     });
 
-    it('pages past a wall of gateway traffic to find the news', async () => {
+    it('asks for the news by name past a wall of gateway traffic', async () => {
       // The staging 03:00 bug: the newest audit page was 50 successful
       // gateway calls, which are not news, so the feed read "Nothing yet"
-      // while the audit page listed events from a minute before.
+      // while the audit page listed events from a minute before. Paging past
+      // the wall only works when the wall is thin, so the second question
+      // names the actions instead of stepping over the traffic.
       localStorage.setItem('accessToken', 'test-token');
       const { restore, urls } = stubFetch([
         gatewayNoise(AUDIT_PAGE_SIZE),
@@ -540,16 +542,18 @@ describe('activity-feed', () => {
       expect(rowText(el)[0]).to.contain('get_pull_request');
       const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
       expect(audit.length).to.be.greaterThan(1);
-      expect(audit[1]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
+      expect(audit[1]).to.not.contain('start_date=');
+      expect(audit[1]).to.contain('event_type=tool_call');
       restore();
       localStorage.removeItem('accessToken');
     });
 
-    it('asks for at most three audit pages per slice, the last two together', async () => {
-      // A busy account whose whole timeline is successful gateway calls: the
-      // fill used to walk four pages one after the other for rows that were
-      // never going to be news. Each slice still stops at three; a window
-      // that produced no rows then asks the unbounded slice the same way.
+    it('never reads the same drowned page twice', async () => {
+      // The prod bug of 2026-09-08. A gateway doing thousands of calls a day
+      // fills every unfiltered page with traffic the feed drops, and dropping
+      // the date bound asks for the very same newest groups again: six
+      // requests, three hundred groups, no rows. The newest page is read once
+      // and the rest of the fill names what it wants.
       localStorage.setItem('accessToken', 'test-token');
       const { restore, urls } = stubFetch([gatewayNoise(AUDIT_PAGE_SIZE)]);
       const el = await fixture<ActivityFeed>(
@@ -560,14 +564,71 @@ describe('activity-feed', () => {
         'the fill finishes'
       );
       const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
-      expect(audit.length).to.equal(6);
+      expect(audit.length).to.equal(4);
       expect(audit[0]).to.contain('start_date=');
-      expect(audit[1]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
-      expect(audit[2]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
-      expect(audit[3]).to.not.contain('start_date=');
-      expect(audit[4]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
-      expect(audit[5]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
+      expect(audit[0]).to.not.contain('event_type=');
+      // The news slice: named actions, no date bound, and its own three
+      // pages, the last two asked for together.
+      for (const url of audit.slice(1)) {
+        expect(url).to.not.contain('start_date=');
+        expect(url).to.contain('event_type=tool_call');
+        expect(url).to.not.contain('event_type=model_gateway_request');
+      }
+      expect(audit[2]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
+      expect(audit[3]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
       restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('fills the rail when every unfiltered page is gateway traffic', async () => {
+      // The founder's account: 91,822 audit groups, 8,251 of them in the last
+      // day, and effectively all of the newest ones successful gateway calls.
+      // No unfiltered page, windowed or not, ever holds a row, so this is the
+      // case the paging fallback could not reach and the rail read
+      // "Nothing yet" under a full history.
+      localStorage.setItem('accessToken', 'test-token');
+      const original = window.fetch;
+      const urls: string[] = [];
+      const history = Array.from({ length: FEED_INITIAL_ROWS }, (_, index) =>
+        auditGroup(
+          'runtime_session_created',
+          {
+            id: `hist-${index}`,
+            resource_id: `sess-${index}`,
+            details: { runtime_principal_name: 'Hermes' },
+            timestamp: new Date(
+              Date.now() - (index + 1) * 3600000
+            ).toISOString(),
+          },
+          'created'
+        )
+      );
+      window.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        urls.push(url);
+        if (url.includes('/audit-logs/grouped')) {
+          // The server answers what it is asked: an unfiltered read is the
+          // newest groups, which are all traffic, however deep it pages.
+          const news = url.includes('event_type=');
+          const groups = news ? history : gatewayNoise(AUDIT_PAGE_SIZE);
+          return new Response(
+            JSON.stringify({ groups, total: 91822, skip: 0, limit: 50 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return new Response(JSON.stringify({ users: [] }), { status: 200 });
+      }) as typeof window.fetch;
+
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => rowText(el).length === FEED_INITIAL_ROWS,
+        'the history fills the rail under the traffic'
+      );
+      expect(rowText(el)[0]).to.contain('Hermes started a session');
+      expect(listItems(el)[0]).to.equal('earlier');
+      window.fetch = original;
       localStorage.removeItem('accessToken');
     });
 
@@ -707,9 +768,10 @@ describe('activity-feed', () => {
     });
 
     it('reads history when the last day is full of dropped traffic', async () => {
-      // The window is three full pages of successful gateway calls, which
-      // the feed drops, so `exhausted` is false. Without a zero-row fallback
-      // the card said "Nothing yet" while /console/audit listed real history.
+      // The newest page is successful gateway calls, which the feed drops, so
+      // the day produced no rows. Without a second question the card said
+      // "Nothing yet" while /console/audit listed real history. The news
+      // slice pages here because its own first pages fold to nothing too.
       localStorage.setItem('accessToken', 'test-token');
       const old = new Date(Date.now() - 40 * 3600 * 1000).toISOString();
       const { restore, urls } = stubFetch([
@@ -741,9 +803,11 @@ describe('activity-feed', () => {
       const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
       expect(audit.length).to.equal(4);
       expect(audit[0]).to.contain('start_date=');
-      expect(audit[1]).to.contain('start_date=');
-      expect(audit[2]).to.contain('start_date=');
-      expect(audit[3]).to.not.contain('start_date=');
+      // The day is read once. Everything after it is the news slice, which
+      // asks by action and pages until it has rows.
+      expect(audit[1]).to.contain('event_type=');
+      expect(audit[2]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
+      expect(audit[3]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
       restore();
       localStorage.removeItem('accessToken');
     });

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -581,8 +581,8 @@ describe('activity-feed', () => {
     });
 
     it('fills the rail when every unfiltered page is gateway traffic', async () => {
-      // The founder's account: 91,822 audit groups, 8,251 of them in the last
-      // day, and effectively all of the newest ones successful gateway calls.
+      // An account doing thousands of gateway calls a day: the newest audit
+      // groups are successful `model_gateway_request`, which is not news.
       // No unfiltered page, windowed or not, ever holds a row, so this is the
       // case the paging fallback could not reach and the rail read
       // "Nothing yet" under a full history.
@@ -612,7 +612,7 @@ describe('activity-feed', () => {
           const news = url.includes('event_type=');
           const groups = news ? history : gatewayNoise(AUDIT_PAGE_SIZE);
           return new Response(
-            JSON.stringify({ groups, total: 91822, skip: 0, limit: 50 }),
+            JSON.stringify({ groups, total: 14000, skip: 0, limit: 50 }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           );
         }
@@ -813,9 +813,9 @@ describe('activity-feed', () => {
     });
 
     it('fills the rail from history on a quiet account, under an Earlier line', async () => {
-      // The founder's account on 2026-09-07: nothing in the last day, a full
-      // history behind it, and a card that said "Nothing yet" until the next
-      // socket message arrived.
+      // A quiet account: nothing in the last day, a full history behind it,
+      // and a card that said "Nothing yet" until the next socket message
+      // arrived.
       localStorage.setItem('accessToken', 'test-token');
       const history = Array.from({ length: FEED_INITIAL_ROWS }, (_, index) =>
         auditGroup(

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -189,8 +189,8 @@ const AUDIT_WINDOW_HOURS = 24;
  *
  * Paging cannot get past a busy gateway. `GET /audit-logs/grouped` has no
  * "everything except" filter, so an unfiltered read answers with the newest
- * primary events whatever they are, and on the founder's account that is
- * 8,251 groups in a day, effectively all of them successful
+ * primary events whatever they are, and on an account doing thousands of
+ * gateway calls a day that is effectively all successful
  * `model_gateway_request`, which is not news and never becomes a row. Three
  * pages is 150 groups, about nine minutes of that traffic; dropping the date
  * bound reads the same newest 150 groups again, so the unbounded slice cannot
@@ -199,12 +199,18 @@ const AUDIT_WINDOW_HOURS = 24;
  *
  * The list mirrors the primary actions of
  * `AuditLogCRUD.get_grouped_by_correlation` (backend/preloop/models/crud/
- * audit_log.py) minus the two the feed has nothing to say about: a successful
- * gateway call, and `runtime_session_updated` (a session still going is not
- * an event). It is a filter, not the feed's vocabulary: the unfiltered page
- * is still read first, so an action the server starts writing before this
- * list hears about it is still on the rail whenever it is among the newest
- * fifty groups, and always on the socket.
+ * audit_log.py) minus `model_gateway_request` and `runtime_session_updated`.
+ * The grouped API filters `event_type` by action only — no status clause —
+ * so naming `model_gateway_request` would drown the slice in successful
+ * calls. Failed and `budget_denied` gateway requests are news the feed
+ * knows how to draw, but they stay out of reach of this named slice by
+ * design: there is no status-aware action filter that can ask for those
+ * without also returning success traffic. `runtime_session_updated` (a
+ * session still going) is not an event. It is a filter, not the feed's
+ * vocabulary: the unfiltered page is still read first, so an action the
+ * server starts writing before this list hears about it is still on the
+ * rail whenever it is among the newest fifty groups, and always on the
+ * socket.
  */
 export const AUDIT_NEWS_ACTIONS = [
   'tool_call',
@@ -1727,7 +1733,7 @@ export class ActivityFeed extends LitElement {
   }
 
   /**
-   * Names for `... by dimo`. Unavailable to non-admins, and that is fine.
+   * Names for `... by alice`. Unavailable to non-admins, and that is fine.
    *
    * Never throws and never stores anything but an array: the actor's name is
    * a nicety, and a lookup that fails, 403s or answers in a shape nobody

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -162,24 +162,60 @@ export const FEED_CAP = 30;
  */
 export const FEED_INITIAL_ROWS = 20;
 /**
- * The audit timeline is mostly traffic, so the fill pages through it.
+ * How many groups one read of the audit timeline asks for.
  *
- * On an account doing 14k gateway calls a day, every one of the newest 40
- * audit groups can be a successful `model_gateway_request`, which is not
- * news and never becomes a row. That is what emptied the feed on staging at
- * 03:00 while `/console/audit` was listing events from a minute before. So
- * the fill asks for a page, keeps what is news, and asks for the next page
- * until it has enough rows or it runs out of patience.
+ * The timeline is mostly traffic. On an account doing 14k gateway calls a
+ * day, every one of the newest 40 audit groups can be a successful
+ * `model_gateway_request`, which is not news and never becomes a row. That is
+ * what emptied the feed on staging at 03:00 while `/console/audit` was listing
+ * events from a minute before. Fifty is enough for the newest page to hold the
+ * news on an account that is not drowning in traffic; the one that is gets
+ * {@link AUDIT_NEWS_ACTIONS} instead of a deeper page.
  */
 export const AUDIT_PAGE_SIZE = 50;
 /**
- * Three pages, and only the first one is on its own: page 0 decides whether
- * more are needed, and pages 1 and 2 are then asked for together rather than
- * one after the other. A fourth page was two more round trips for rows that
- * were already off the bottom of a 20-row rail.
+ * How many pages of the news slice the fill will walk.
+ *
+ * Three, and only the first one is on its own: page 0 decides whether more are
+ * needed, and pages 1 and 2 are then asked for together rather than one after
+ * the other. A fourth page was two more round trips for rows that were already
+ * off the bottom of a 20-row rail. It walks at all only because fifty groups
+ * of news can still fold to a handful of rows.
  */
 export const AUDIT_MAX_PAGES = 3;
 const AUDIT_WINDOW_HOURS = 24;
+/**
+ * The audit actions the fill names when the newest page is all traffic.
+ *
+ * Paging cannot get past a busy gateway. `GET /audit-logs/grouped` has no
+ * "everything except" filter, so an unfiltered read answers with the newest
+ * primary events whatever they are, and on the founder's account that is
+ * 8,251 groups in a day, effectively all of them successful
+ * `model_gateway_request`, which is not news and never becomes a row. Three
+ * pages is 150 groups, about nine minutes of that traffic; dropping the date
+ * bound reads the same newest 150 groups again, so the unbounded slice cannot
+ * help either. Naming the actions is the only question the server can answer
+ * in one round trip.
+ *
+ * The list mirrors the primary actions of
+ * `AuditLogCRUD.get_grouped_by_correlation` (backend/preloop/models/crud/
+ * audit_log.py) minus the two the feed has nothing to say about: a successful
+ * gateway call, and `runtime_session_updated` (a session still going is not
+ * an event). It is a filter, not the feed's vocabulary: the unfiltered page
+ * is still read first, so an action the server starts writing before this
+ * list hears about it is still on the rail whenever it is among the newest
+ * fifty groups, and always on the socket.
+ */
+export const AUDIT_NEWS_ACTIONS = [
+  'tool_call',
+  'authentication',
+  'configuration_change',
+  'permission_check',
+  'role_assigned',
+  'role_removed',
+  'runtime_session_created',
+  'runtime_session_ended',
+] as const;
 /** How long the feed waits for a host that says it is fetching the users. */
 const HOST_USERS_WAIT_MS = 1500;
 
@@ -1734,12 +1770,14 @@ export class ActivityFeed extends LitElement {
   /** One page of the audit timeline, or null when it cannot be read. */
   private async fetchAuditPage(
     skip: number,
-    since: string | null
+    since: string | null,
+    actions?: readonly string[]
   ): Promise<AuditGroupLike[] | null> {
     const params = new URLSearchParams();
     params.set('limit', String(AUDIT_PAGE_SIZE));
     if (skip) params.set('skip', String(skip));
     if (since) params.set('start_date', since);
+    for (const action of actions ?? []) params.append('event_type', action);
     const response = await fetchWithAuth(
       `/api/v1/audit-logs/grouped?${params}`
     );
@@ -1774,50 +1812,39 @@ export class ActivityFeed extends LitElement {
   }
 
   /**
-   * Fill `into` from one slice of the audit timeline, paging while it is short.
+   * Fill `into` from the news slice: the newest events of the actions that
+   * always have something to say, whenever they happened.
    *
-   * `since` bounds the slice (null asks for the newest events whenever they
-   * happened). Page 0 decides whether the rest are needed. When they are,
-   * they are asked for together instead of one after the other, and there
-   * are two of them: a fourth page was two more round trips for rows that
-   * were already off the bottom of the rail.
-   *
-   * Returns whether the timeline was readable at all (a 403 is `false`, and
-   * that is the no-audit-access path) and whether this slice ran out of
-   * groups before it filled the rail, which is what decides if there is any
-   * point asking for an older slice.
+   * This is the read that cannot be drowned. It is asked for only when the
+   * newest day did not fill the rail, because on most accounts that day is
+   * the answer and this is the more expensive query of the two (no date
+   * bound). Page 0 decides whether the rest are needed; a page of fifty
+   * groups can still fold down to two rows when one agent calls one tool
+   * fifty times, so pages 1 and 2 are then asked for together rather than one
+   * after the other. A fourth page was two more round trips for rows that
+   * were already off the bottom of a 20-row rail.
    */
-  private async fillFrom(
-    since: string | null,
-    into: FeedEvent[],
-    page0?: AuditGroupLike[] | null
-  ): Promise<{ read: boolean; exhausted: boolean }> {
-    const firstPage =
-      page0 === undefined ? await this.fetchAuditPage(0, since) : page0;
-    if (firstPage === null) return { read: false, exhausted: false };
+  private async fillNews(into: FeedEvent[]): Promise<void> {
+    const firstPage = await this.fetchAuditPage(0, null, AUDIT_NEWS_ACTIONS);
+    if (firstPage === null) return;
     this.rowsFrom(firstPage, into);
-    if (firstPage.length < AUDIT_PAGE_SIZE) {
-      return { read: true, exhausted: true };
-    }
-    if (foldRows(into).length >= FEED_INITIAL_ROWS) {
-      return { read: true, exhausted: false };
-    }
+    if (firstPage.length < AUDIT_PAGE_SIZE) return;
+    if (foldRows(into).length >= FEED_INITIAL_ROWS) return;
     const more = await Promise.all(
       Array.from({ length: AUDIT_MAX_PAGES - 1 }, (_, index) =>
-        this.fetchAuditPage((index + 1) * AUDIT_PAGE_SIZE, since)
+        this.fetchAuditPage(
+          (index + 1) * AUDIT_PAGE_SIZE,
+          null,
+          AUDIT_NEWS_ACTIONS
+        )
       )
     );
-    let exhausted = false;
     for (const groups of more) {
       if (groups === null) break;
       if (foldRows(into).length >= FEED_INITIAL_ROWS) break;
       this.rowsFrom(groups, into);
-      if (groups.length < AUDIT_PAGE_SIZE) {
-        exhausted = true;
-        break;
-      }
+      if (groups.length < AUDIT_PAGE_SIZE) break;
     }
-    return { read: true, exhausted };
   }
 
   private async loadInitial(): Promise<void> {
@@ -1838,19 +1865,20 @@ export class ActivityFeed extends LitElement {
         this.usersReady,
         new Promise((resolve) => setTimeout(resolve, 2000)),
       ]);
-      const { read, exhausted } = await this.fillFrom(since, events, firstPage);
-      // A quiet account has little or nothing in the last day and still has a
-      // history. Rather than say "Nothing yet" to an account that worked
-      // yesterday, ask again for the newest events whenever they happened.
-      // A day that is full of dropped traffic (successful gateway calls) is
-      // the same empty rail with the same history behind it: `exhausted` is
-      // false because the window still has groups, but the feed has no rows,
-      // so the unwindowed read has to run. Skip it only when the window
-      // already produced news: that account's day is the news, and history
-      // with no lower bound is the expensive read of the two.
-      const rows = foldRows(events).length;
-      if (read && rows < FEED_INITIAL_ROWS && (exhausted || rows === 0)) {
-        await this.fillFrom(null, events);
+      // A 403 is the no-audit-access path: nothing was read, and there is no
+      // second question worth asking.
+      if (firstPage !== null) {
+        this.rowsFrom(firstPage, events);
+        // A quiet account has little or nothing in the last day and still has
+        // a history; a busy one has a day of gateway traffic the feed drops
+        // and the same history behind it. Both read "Nothing yet" off the
+        // newest page, and for both the answer is the same question: the
+        // newest events that are news, whenever they happened. It is asked by
+        // name rather than by paging, because paging past a gateway doing
+        // thousands of calls a day is not a walk that terminates.
+        if (foldRows(events).length < FEED_INITIAL_ROWS) {
+          await this.fillNews(events);
+        }
       }
       // Rows read here are history by definition: the socket had nothing to
       // do with them, and the divider says so.

--- a/frontend/src/components/console-route-transitions.test.ts
+++ b/frontend/src/components/console-route-transitions.test.ts
@@ -222,7 +222,7 @@ const TRACKER = {
 /**
  * A busy gateway account's audit timeline, as the server answers it.
  *
- * The founder's account on 2026-09-08: 91,822 groups, and the newest of them
+ * On an account doing thousands of gateway calls a day, the newest groups
  * are all successful `model_gateway_request`, which the activity feed drops.
  * Every unfiltered read is that traffic however deep it pages, so the history
  * is reachable only by a read that names the actions it wants.
@@ -263,14 +263,14 @@ function stubbedBody(url: string): unknown {
       groups: parsed.searchParams.has('event_type')
         ? AUDIT_HISTORY
         : GATEWAY_TRAFFIC,
-      total: 91822,
+      total: 14000,
     };
   }
   if (path.endsWith('/api/v1/features')) return { features: {}, plugins: [] };
   if (path.endsWith('/api/v1/auth/users/me')) {
     return {
-      username: 'founder',
-      email: 'founder@example.com',
+      username: 'operator',
+      email: 'operator@example.com',
       email_verified: true,
       permissions: null,
       is_superuser: true,
@@ -564,9 +564,8 @@ describe('console route transitions', () => {
         await assertLanded(entry, `return to ${entry.path}`);
       }
     }
-    // The founder's report was that these do nothing. If a view stops
-    // rendering one, this test quietly stops covering it, so the count is
-    // part of the assertion.
+    // These used to do nothing. If a view stops rendering one, this test
+    // quietly stops covering it, so the count is part of the assertion.
     expect(
       clicked.length,
       `section exit links exercised: ${clicked.join(', ')}`

--- a/frontend/src/components/console-route-transitions.test.ts
+++ b/frontend/src/components/console-route-transitions.test.ts
@@ -219,9 +219,53 @@ const TRACKER = {
   created_at: '2026-09-01T10:00:00Z',
 };
 
+/**
+ * A busy gateway account's audit timeline, as the server answers it.
+ *
+ * The founder's account on 2026-09-08: 91,822 groups, and the newest of them
+ * are all successful `model_gateway_request`, which the activity feed drops.
+ * Every unfiltered read is that traffic however deep it pages, so the history
+ * is reachable only by a read that names the actions it wants.
+ */
+const GATEWAY_TRAFFIC = Array.from({ length: 50 }, (_, index) => ({
+  correlation_id: null,
+  outcome: 'success',
+  primary_event: {
+    id: `gw-${index}`,
+    user_id: null,
+    action: 'model_gateway_request',
+    resource_id: 'claude-sonnet',
+    status: 'success',
+    details: { model_alias: 'claude-sonnet', status_code: 200 },
+    timestamp: new Date(Date.now() - index * 1000).toISOString(),
+  },
+}));
+const AUDIT_HISTORY = Array.from({ length: 20 }, (_, index) => ({
+  correlation_id: null,
+  outcome: 'created',
+  primary_event: {
+    id: `hist-${index}`,
+    user_id: null,
+    action: 'runtime_session_created',
+    resource_id: `sess-${index}`,
+    status: 'created',
+    details: { runtime_principal_name: 'Hermes' },
+    timestamp: new Date(Date.now() - (index + 1) * 3600000).toISOString(),
+  },
+}));
+
 /** One stub for every view the matrix visits. Shapes, not fidelity. */
 function stubbedBody(url: string): unknown {
-  const path = new URL(url, window.location.origin).pathname;
+  const parsed = new URL(url, window.location.origin);
+  const path = parsed.pathname;
+  if (path.endsWith('/api/v1/audit-logs/grouped')) {
+    return {
+      groups: parsed.searchParams.has('event_type')
+        ? AUDIT_HISTORY
+        : GATEWAY_TRAFFIC,
+      total: 91822,
+    };
+  }
   if (path.endsWith('/api/v1/features')) return { features: {}, plugins: [] };
   if (path.endsWith('/api/v1/auth/users/me')) {
     return {
@@ -471,6 +515,34 @@ describe('console route transitions', () => {
     // and turned every approval link into a 404.
     const view = deepest() as HTMLElement & { requestId?: string };
     expect(view.requestId).to.equal('appr-1');
+  });
+
+  it('fills the Overview activity feed on the way into it', async () => {
+    // The prod report of 2026-09-08: the Overview's Activity box was empty on
+    // every load. The view is lazy now, so the feed is created by the router
+    // hook after its chunk resolves; this walks that whole path, from a link
+    // click to the rows on the card, against a timeline whose newest groups
+    // are all gateway traffic the feed drops.
+    clickLink('/console/agents');
+    await assertLanded(BY_PATH.get('/console/agents')!, 'leave the overview');
+    clickLink('/console');
+    await assertLanded(BY_PATH.get('/console')!, 'return to the overview');
+
+    const view = deepest() as HTMLElement;
+    const feed = () =>
+      view.shadowRoot?.querySelector('activity-feed') as HTMLElement | null;
+    await waitUntil(() => Boolean(feed()), 'the Overview renders a feed', {
+      timeout: 10000,
+    });
+    await waitUntil(
+      () => (feed()?.shadowRoot?.querySelectorAll('.row').length ?? 0) > 0,
+      'the feed has history rows on first paint, not "Nothing yet"',
+      { timeout: 10000 }
+    );
+    expect(
+      feed()!.shadowRoot!.querySelector('.row')!.textContent,
+      'the row is the history under the traffic'
+    ).to.contain('Hermes');
   });
 
   it('follows every "Back to ..." link and breadcrumb a section renders', async () => {


### PR DESCRIPTION
Fix the empty Overview Activity box: ask the audit timeline for the news

## The report

Prod, after the 2026-09-08 deploy: the Overview's Activity box is empty on
page load. The suspects were #499 (lazy views), #515 (router fixes) and #491
(history on first paint).

## What actually happens

It is not the router and it is not the lazy view. Reproduced in Chromium
against a mock API on the vite dev server, with `ActivityFeed`'s own methods
wrapped from an init script so the fill logs itself:

```
175 feed connected autoload=true usersFromHost=false users=0
175 loadInitial start
228   fetchAuditPage skip=0 since=window -> 50 groups
229 loadInitial end events=20 loading=false
```

`connectedCallback` runs before `firstUpdated`, the host sets `users` after
both, and `GET /api/v1/audit-logs/grouped` is issued on every fresh load.
`24b6db8f` (pre-#499) and `main` produce byte-identical fills, with and
without 120ms of API latency and a 500ms delay on the
`dashboard-control-plane-view` chunk, and navigating into `/console` through
the router hook renders rows on both.

What does reproduce, on `main` and on `24b6db8f` alike, is the prod account's
data. `?limit=5` reports 91,822 groups, `start_date` reports 8,251 in the last
day, and the newest of those are successful `model_gateway_request`, which the
feed drops on purpose (activity-feed.ts:461-469; it is traffic, not news).

```
fetchAuditPage skip=0   since=window -> 50 groups
fetchAuditPage skip=50  since=window -> 50 groups
fetchAuditPage skip=100 since=window -> 50 groups
fillFrom since=window -> read=true exhausted=false into=0
fetchAuditPage skip=0   since=none   -> 50 groups     <- the same newest groups
fetchAuditPage skip=50  since=none   -> 50 groups
fetchAuditPage skip=100 since=none   -> 50 groups
fillFrom since=none   -> read=true exhausted=false into=0
feed: rows=0  "Nothing yet. Events appear here as agents work."
```

Three pages of fifty is 150 groups, about nine minutes of that traffic. The
unbounded fallback added by #491 for exactly this case (`d6a8f69e`) drops the
date bound and therefore asks for the same newest 150 groups again, so it can
never produce a row the windowed slice did not. Six requests, three hundred
groups, no rows, under 91,822 events of history.

## The fix

`GET /audit-logs/grouped` has no "everything except" filter, so paging is the
only way to step over traffic and paging does not terminate against a gateway
that writes faster than the feed reads. The second read now names what it
wants: `event_type=` the server's primary actions minus successful gateway
calls and `runtime_session_updated`, no date bound.

- The newest day is still read first, unfiltered, and on most accounts it is
  still the whole answer and still one request.
- The unfiltered page being first is what keeps the filter from becoming the
  feed's vocabulary: an action nobody has listed yet is still on the rail when
  it is among the newest fifty groups, and always on the socket.
- `fillFrom` (a slice that pages) becomes `fillNews` (the one slice that
  pages, because fifty groups of news can still fold to three rows).

## Numbers

| | before | after |
|---|---|---|
| grouped requests, day is the news | 1 | 1 |
| grouped requests, day is traffic | 6 | 2 |
| feed rows on the prod-shaped account | 0 | 20 |
| `npm test` | 2338 passed | 2340 passed |
| `npx tsc --noEmit` errors | 87 | 87 |
| `dist/assets` bytes | 3,426,717 | 3,426,738 |

## Tests

Two, both failing on `main`:

- `activity-feed.test.ts` "fills the rail when every unfiltered page is
  gateway traffic": the server answers what it is asked, so every unfiltered
  read is traffic however deep it pages. On `main` the rail times out empty.
- `console-route-transitions.test.ts` "fills the Overview activity feed on the
  way into it": the real route table, the real router, a link click into
  `/console`, and rows required on the feed the lazy view creates. On `main`:
  `Timeout: the feed has history rows on first paint, not "Nothing yet"`.

Also updated three existing tests that pinned the old request shape, and the
matrix's audit stub now answers a busy gateway timeline instead of `[]`.

## Deploy

`b21acae0` (this branch's head). Frontend only; no backend or API change, and
the query parameters used are ones `/audit-logs/grouped` already accepts.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Frontend-only bug fix to the Overview Activity feed that swaps an unbounded paging fallback for a named `event_type`-filtered read; sound and well-tested, with both prior review findings addressed in `3ddc8b12`.

> **Overview**
> The empty Activity box was caused by successful `model_gateway_request` traffic drowning the newest audit pages. The fix keeps the unfiltered newest-day read, then asks the timeline for named "news" actions (no date bound) instead of paging past a wall that never terminates. `fillFrom` is folded into `fillNews`. Two new regression tests and updated request-shape tests cover it.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 3ddc8b12. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->