### PR TITLE
Import settings in the API app module so the lifespan can start

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -27,6 +27,7 @@ from starlette.websockets import WebSocketState
 
 from preloop import __version__
 from fastapi.encoders import jsonable_encoder
+from preloop.config import settings
 from preloop.api.auth import auth_router, get_current_active_user
 from preloop.api.endpoints import (
     account,

--- a/backend/tests/api/test_app_lifespan_settings.py
+++ b/backend/tests/api/test_app_lifespan_settings.py
@@ -1,0 +1,12 @@
+"""The lifespan reads ``settings`` at startup; a missing import only shows in production."""
+
+from preloop.api import app as app_module
+from preloop.config import settings
+
+
+def test_app_module_binds_settings_for_lifespan() -> None:
+    # Tests run with is_testing set, so the webhook delivery branch that reads
+    # settings.webhook_delivery_enabled is skipped and a NameError there would
+    # never surface here. Bind the name explicitly so the regression is caught.
+    assert app_module.settings is settings
+    assert isinstance(settings.webhook_delivery_enabled, bool)


### PR DESCRIPTION
Hotfix. #504 made the lifespan read settings.webhook_delivery_enabled (app.py:370) before starting the webhook delivery worker, but app.py never imported settings. The test suite skips that branch under is_testing, so the NameError only surfaced in production: every API and gateway pod built from main after #504 exits with code 3 at startup (NameError: name settings is not defined, then Application startup failed). Observed on prod and staging tonight (2026-09-09 00:52Z) on image 4d35813e; the previous ReplicaSets kept serving.

Fix: one import, plus a test that binds the name so the regression cannot hide behind the testing flag.

Deploy this before any other change: the new image cannot start without it.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> A one-line import plus a regression test to restore production startup after #504; no security, performance, or behavior changes.
>
> **Overview**
> Adds the missing `from preloop.config import settings` in `preloop.api.app` so the lifespan can read `settings.webhook_delivery_enabled` (app.py:371) without a production `NameError`, and adds a test asserting the module-level binding so the regression cannot hide behind `is_testing`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fbc13165. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->