### PR TITLE
Helm: replace leftover hook Jobs before creating them again

### DIFF
--- a/helm/preloop/templates/init-db-job.yaml
+++ b/helm/preloop/templates/init-db-job.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/helm/preloop/templates/migration-job.yaml
+++ b/helm/preloop/templates/migration-job.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/helm/preloop/templates/seed-job.yaml
+++ b/helm/preloop/templates/seed-job.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
The init-db, migration and seed hook Jobs carried hook-delete-policy: hook-succeeded only. Any interrupted or failed deploy left the Job behind, and the next helm upgrade failed with jobs.batch already exists until someone deleted it by hand (test environment, 2026-09-09, and after most interrupted deploys).

before-hook-creation,hook-succeeded removes the previous Job right before the new one is created; a failed Job stays available for inspection until the next run replaces it. helm lint passes. No behaviour change on a clean deploy.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> A minimal, correct Helm annotation fix that is validated by the existing `helm lint`/`helm template` CI checks.
>
> **Overview**
> Adds `before-hook-creation` to the `hook-delete-policy` of the init-db, migration and seed hook Jobs so a leftover Job from a failed/interrupted deploy is replaced on the next upgrade rather than failing with `jobs.batch already exists`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ba35719. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->