### PR TITLE
CI: cache Playwright browsers and survive a broken Google apt index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,7 @@ jobs:
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
@@ -439,10 +439,12 @@ jobs:
           # Drop that source, then retry the install, which is a no-op for cached browsers.
           sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google.list
           for attempt in 1 2 3; do
-            npx playwright install --with-deps chromium && break
+            npx playwright install --with-deps chromium && exit 0
             echo "playwright install failed (attempt $attempt), retrying in 15s"
             sleep 15
           done
+          echo "playwright install failed after 3 attempts" >&2
+          exit 1
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,8 +421,28 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Read the Playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          # The runner image preconfigures Google's chrome-stable apt source, which this job
+          # never uses. Its index intermittently fails with "Hash Sum mismatch" and takes
+          # "playwright install --with-deps" down with it (main and five PRs on 2026-09-09).
+          # Drop that source, then retry the install, which is a no-op for cached browsers.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google.list
+          for attempt in 1 2 3; do
+            npx playwright install --with-deps chromium && break
+            echo "playwright install failed (attempt $attempt), retrying in 15s"
+            sleep 15
+          done
 
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
Frontend Tests failed on main (2adaec5f, 86457e59) and on PRs #541 to #545 at 17:5x on 2026-09-09 in the Install Playwright browsers step: apt reported Hash Sum mismatch on dl.google.com chrome-stable Packages.gz, which the runner image preconfigures and this job never uses; playwright install --with-deps exited 100 before any test ran.

This caches ~/.cache/ms-playwright keyed on the installed @playwright/test version, removes the Google apt source before installing, and retries the install up to three times. No test or product change.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> CI-only change that caches Playwright browsers and hardens the install step; both previously raised issues (retry-loop failure handling and the unpinned `actions/cache` reference) are now fixed.
>
> **Overview**
> Caches `~/.cache/ms-playwright` keyed on the `@playwright/test` version, removes the preconfigured Google apt source before installing, and retries `playwright install --with-deps` up to three times to survive a broken dl.google.com index. No test or product code changes.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 7db44165. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->