### PR TITLE
Park the run when a long approval window says to, and stop losing preset fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,8 +333,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The failure message names the field that classified the run**: a
   result artifact rejected on its `verdict` reported `status=None`, which
   named a key the CRA incompletion envelope does not carry. The override
-  now reports the field that actually decided, and records it on the
-  milestone as `signal_field` / `signal_value`.
+  now reports the field that actually decided on both the terminal exit
+  and the sentinel-grace path, and records it on the milestone as
+  `signal_field` / `signal_value`.
 
 - **Preset sync no longer drops fields on existing presets**:
   `scripts/sync_flow_presets.py` updated existing global presets from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An approval that should park the run no longer ends it**: when the
+  routing approval workflow had `async_approval_enabled` set (the shipped
+  "Default Approval Workflow" does), `require_approval` returned its
+  `pending_approval` payload before it reached the park handshake, so no
+  window length could park the execution. The agent got an answerless
+  result, wrote its incompletion envelope and exited, and the run was
+  completed and failed closed while a human still held the question. Both
+  paths now go through one `_park_and_build_payload` helper, so the
+  decision to park is made in a single place. The monitor loop also
+  re-checks for a park request in its terminal branch: the park is written
+  by another process and observed on a 5 second poll, so an agent that
+  exits inside that window used to be finalized first. A parked run is no
+  longer fail-closed by the CRA persist boundary, since a park is not a
+  release. Observed on staging execution
+  `e42c6086-f637-4d18-be09-2395c4d488ca`, approval
+  `6a7cd2dc-a9f8-4fa5-9870-b834f5bc1db2`: the waiver was answered 2 minutes
+  20 seconds after the run had already been marked FAILED, against a 3 day
+  window.
+
+- **The failure message names the field that classified the run**: a
+  result artifact rejected on its `verdict` reported `status=None`, which
+  named a key the CRA incompletion envelope does not carry. The override
+  now reports the field that actually decided, and records it on the
+  milestone as `signal_field` / `signal_value`.
+
+- **Preset sync no longer drops fields on existing presets**:
+  `scripts/sync_flow_presets.py` updated existing global presets from a
+  hand-maintained dict that omitted `approval_window_seconds`,
+  `timeout_seconds`, `runner_pool`, `custom_commands`, `webhook_config`
+  and `schedule_config`, and its change detection compared only 8 fields,
+  so a preset whose only change was one of those was reported up to date.
+  Create and update now derive from the same `FlowCreate`, and drift is
+  computed over every field a preset can set. Effect: the 3 day approval
+  window that presets 006 and 014 declare reaches the flow row instead of
+  falling back to the 300 second default. A preset key that no schema
+  claims is now logged rather than silently ignored.
+
 - **Talk stays clickable on the agent page in a narrow container**: an
   action that renders its own element has no click handler an overflow
   menu item can call, so folding it produced a menu row that did nothing.

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -192,6 +192,53 @@ async def _park_execution(
         return False
 
 
+async def _park_and_build_payload(
+    *,
+    execution_id: Any,
+    approval_request_id: Any,
+    expires_at: Any,
+    window_seconds: int,
+    tool_name: str,
+    arguments: Any,
+    base_url: str,
+) -> Optional[str]:
+    """Park the calling execution on this approval, and return the payload.
+
+    The single place that decides whether a park is possible, so the
+    synchronous poll loop and the async-approval early return cannot drift
+    apart. Returns None when the run cannot park (no execution behind the
+    call, a window short enough to answer in place, or a row that is no
+    longer live), in which case the caller keeps its previous behaviour.
+    """
+    from preloop.services.approval_window import should_park
+
+    if not execution_id or not should_park(int(window_seconds)):
+        return None
+    if not await _park_execution(
+        execution_id=execution_id,
+        approval_request_id=approval_request_id,
+        expires_at=expires_at,
+    ):
+        return None
+
+    from preloop.services.approval_park import park_pending_payload
+    from preloop.services.ask_user_inband import approval_console_url
+
+    logger.info(
+        "Execution %s parked on approval %s (window %ss)",
+        execution_id,
+        approval_request_id,
+        window_seconds,
+    )
+    return park_pending_payload(
+        request_id=approval_request_id,
+        tool_name=tool_name,
+        expires_at=expires_at,
+        console_url=approval_console_url(base_url, approval_request_id),
+        question=arguments.get("question") if isinstance(arguments, dict) else None,
+    )
+
+
 async def _deliver_question_in_band(
     *,
     tool_name: str,
@@ -605,10 +652,7 @@ async def require_approval(
             # expires_at is what a human is actually racing. Precedence: the
             # tool's own timeout_seconds, this flow's approval_window_seconds,
             # the workflow timeout, the deployment default; capped per account.
-            from preloop.services.approval_window import (
-                resolve_approval_window,
-                should_park,
-            )
+            from preloop.services.approval_window import resolve_approval_window
 
             window_flow = await _flow_for_execution(db, caller.execution_id)
             window = resolve_approval_window(
@@ -736,6 +780,37 @@ async def require_approval(
                 # Check if async approval mode is enabled
                 if workflow_async_enabled:
                     import json
+
+                    # An async workflow returns here, roughly seventy lines
+                    # before the poll loop where the park handshake lives, so
+                    # on an async workflow the park was simply unreachable:
+                    # park_request_id was never written and the orchestrator
+                    # monitor had nothing to observe. The run then held a
+                    # container and polled until its own timeout killed it,
+                    # which is the exact cost #510 exists to remove.
+                    #
+                    # Staging execution e42c6086-f637-4d18-be09-2395c4d488ca
+                    # (preset 006, approval 6a7cd2dc-a9f8-4fa5-9870-b834f5bc1db2)
+                    # died this way: ask_user returned in 528 ms against a
+                    # three day window, the run was marked FAILED at 16:52:05Z,
+                    # and the human approved at 16:54:25Z with nothing left to
+                    # resume. The workflow was the account's default one, so
+                    # this was default behaviour, not a misconfiguration.
+                    #
+                    # Park before answering. A window short enough to be
+                    # answered in place (should_park) keeps the old polling
+                    # payload untouched.
+                    parked_payload = await _park_and_build_payload(
+                        execution_id=caller.execution_id,
+                        approval_request_id=approval_request_id,
+                        expires_at=approval_request_expires_at,
+                        window_seconds=workflow_timeout_seconds,
+                        tool_name=tool_name,
+                        arguments=arguments,
+                        base_url=base_url,
+                    )
+                    if parked_payload is not None:
+                        return (False, parked_payload)
 
                     logger.info(
                         f"Async approval enabled for workflow '{workflow_name}' - "
@@ -986,44 +1061,18 @@ async def require_approval(
                     # tool returns a structured pending result, the
                     # orchestrator releases the runtime, and the decision (or
                     # the expiry) resumes the same agent session.
-                    if (
-                        caller.execution_id
-                        and should_park(window.seconds)
-                        and elapsed >= int(settings.approval_park_after_seconds)
-                    ):
-                        parked = await _park_execution(
+                    if elapsed >= int(settings.approval_park_after_seconds):
+                        parked_payload = await _park_and_build_payload(
                             execution_id=caller.execution_id,
                             approval_request_id=approval_request_id,
                             expires_at=approval_request_expires_at,
+                            window_seconds=window.seconds,
+                            tool_name=tool_name,
+                            arguments=arguments,
+                            base_url=base_url,
                         )
-                        if parked:
-                            from preloop.services.approval_park import (
-                                park_pending_payload,
-                            )
-                            from preloop.services.ask_user_inband import (
-                                approval_console_url,
-                            )
-
-                            logger.info(
-                                "Execution %s parked on approval %s (window %ss)",
-                                caller.execution_id,
-                                approval_request_id,
-                                window.seconds,
-                            )
-                            return (
-                                False,
-                                park_pending_payload(
-                                    request_id=approval_request_id,
-                                    tool_name=tool_name,
-                                    expires_at=approval_request_expires_at,
-                                    console_url=approval_console_url(
-                                        base_url, approval_request_id
-                                    ),
-                                    question=arguments.get("question")
-                                    if isinstance(arguments, dict)
-                                    else None,
-                                ),
-                            )
+                        if parked_payload is not None:
+                            return (False, parked_payload)
 
                     # Check if initial timeout expired
                     if elapsed >= timeout_seconds and not escalation_triggered:

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -192,6 +192,25 @@ async def _park_execution(
         return False
 
 
+def _beyond_async_polling(window_seconds: int) -> bool:
+    """True when agent-side polling is no longer a way to wait out a window.
+
+    An async workflow answers a gated call with polling instructions: poll
+    ``get_approval_status`` every N seconds for up to the window. That is a
+    fair contract for an interactive tool call, which is what
+    ``approval_default_window_seconds`` describes, and it is not a contract
+    at all for a compliance decision measured in days. The same line already
+    exists in approval_window.py's own words: five minutes is a reasonable
+    default for an interactive tool call and a nonsense default for a
+    compliance decision.
+
+    Past that line the run parks instead. Below it the async path is
+    unchanged, which keeps park/resume additive rather than replacing a
+    shipped behaviour on every account that uses the default workflow.
+    """
+    return int(window_seconds) > int(settings.approval_default_window_seconds)
+
+
 async def _park_and_build_payload(
     *,
     execution_id: Any,
@@ -797,20 +816,22 @@ async def require_approval(
                     # resume. The workflow was the account's default one, so
                     # this was default behaviour, not a misconfiguration.
                     #
-                    # Park before answering. A window short enough to be
-                    # answered in place (should_park) keeps the old polling
-                    # payload untouched.
-                    parked_payload = await _park_and_build_payload(
-                        execution_id=caller.execution_id,
-                        approval_request_id=approval_request_id,
-                        expires_at=approval_request_expires_at,
-                        window_seconds=workflow_timeout_seconds,
-                        tool_name=tool_name,
-                        arguments=arguments,
-                        base_url=base_url,
-                    )
-                    if parked_payload is not None:
-                        return (False, parked_payload)
+                    # Park before answering, but only for a window that
+                    # agent-side polling cannot cover. A window within the
+                    # interactive default keeps the polling payload exactly as
+                    # it shipped, so this stays additive.
+                    if _beyond_async_polling(workflow_timeout_seconds):
+                        parked_payload = await _park_and_build_payload(
+                            execution_id=caller.execution_id,
+                            approval_request_id=approval_request_id,
+                            expires_at=approval_request_expires_at,
+                            window_seconds=workflow_timeout_seconds,
+                            tool_name=tool_name,
+                            arguments=arguments,
+                            base_url=base_url,
+                        )
+                        if parked_payload is not None:
+                            return (False, parked_payload)
 
                     logger.info(
                         f"Async approval enabled for workflow '{workflow_name}' - "

--- a/backend/preloop/services/approval_park.py
+++ b/backend/preloop/services/approval_park.py
@@ -79,8 +79,12 @@ def park_pending_payload(
     """The structured pending result a parked tool call returns to the agent.
 
     Additive: the async-approval path keeps returning ``pending_approval``
-    with polling instructions, and this one says the opposite (stop, do not
-    poll) because the run itself is about to be suspended.
+    with polling instructions for a window inside the interactive default,
+    and this one says the opposite (stop, do not poll) because the run itself
+    is about to be suspended. Beyond that default the async path parks too:
+    "poll for up to three days" is not a contract an agent can honour, and
+    on staging it cost a run and a CRA waiver
+    (execution e42c6086-f637-4d18-be09-2395c4d488ca).
     """
     payload: Dict[str, Any] = {
         "status": "parked_for_human",

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -315,6 +315,33 @@ def _result_artifact_confirmation(artifact: Optional[Dict[str, Any]]) -> Optiona
     return None
 
 
+def _artifact_failure_signal(artifact: Optional[Dict[str, Any]]) -> tuple[str, Any]:
+    """Name the field that classified an artifact as an explicit failure.
+
+    The override message used to read ``status=None`` whenever a CRA
+    incompletion envelope (#512) failed the run, because it always printed
+    ``status`` even though the envelope has no ``status`` key and the field
+    that actually decided was ``verdict``. Staging execution
+    e42c6086-f637-4d18-be09-2395c4d488ca is the example: an operator reading
+    "status=None" has no way to find the ``verdict: error`` that caused it.
+    """
+    if not isinstance(artifact, dict):
+        return "status", None
+    status = artifact.get("status")
+    if (
+        isinstance(status, str)
+        and status.strip().lower() in RESULT_ARTIFACT_FAILURE_STATUSES
+    ):
+        return "status", status
+    verdict = artifact.get("verdict")
+    if (
+        isinstance(verdict, str)
+        and verdict.strip().lower() in RESULT_ARTIFACT_VERDICT_FAILURES
+    ):
+        return "verdict", verdict
+    return "status", status
+
+
 # Line-start prefix an agent can print during the one-shot confirmation round
 # to state plainly that the ORIGINAL task did not complete. Everything after
 # the prefix is surfaced verbatim as the failure reason.
@@ -3144,6 +3171,12 @@ class FlowExecutionOrchestrator:
         """Deny a successful release when CRA persist validation failed closed."""
         from preloop.cra.persist import apply_cra_fail_closed_completion
 
+        if final_status == WAITING_FOR_HUMAN_STATUS:
+            # A parked run has not finished, so there is no release to deny.
+            # The artifact captured at park time is a mid-flight snapshot;
+            # the CRA verdict belongs to the resumed run that writes the real
+            # one. Failing closed here would mark a live execution FAILED.
+            return final_status, error_message
         decision = getattr(self, "_cra_persist_decision", None)
         if decision is None:
             return final_status, error_message
@@ -4282,6 +4315,83 @@ class FlowExecutionOrchestrator:
             seconds=remaining, source=budget.source, consumed_seconds=consumed
         )
 
+    async def _park_if_requested(
+        self, agent_executor: Any, session_reference: str, elapsed: float
+    ) -> Optional[Dict[str, Any]]:
+        """Park this run if the approval path asked for it; else None.
+
+        Called from two places in the monitor loop, and that is the point.
+        The park request is written by a different process (the approval
+        path) and observed here on a 5 second poll, while the agent that
+        received ``parked_for_human`` stops on its own. Checking only at the
+        top of the loop leaves a window in which the agent exits first and
+        the run is completed, fail-closed and notified as terminal while a
+        human still holds the question. So the terminal branch asks again.
+        """
+        from preloop.models.crud import crud_flow_execution
+
+        if self.execution_log is None:
+            return None
+        park_request = crud_flow_execution.get_park_request(
+            self.db,
+            execution_id=self.execution_log.id,
+        )
+        if not park_request or park_request.get("parked_at") is not None:
+            return None
+        logger.info(
+            "Parking execution %s on approval %s (expires %s)",
+            self.execution_log.id,
+            park_request["request_id"],
+            park_request.get("expires_at"),
+        )
+        self.execution_logger.log_milestone(
+            "execution_parked",
+            {
+                "approval_request_id": str(park_request["request_id"]),
+                "expires_at": (
+                    park_request["expires_at"].isoformat()
+                    if park_request.get("expires_at")
+                    else None
+                ),
+                "elapsed": elapsed,
+            },
+        )
+        # Capture BEFORE stopping: the result artifact call also captures the
+        # evidence pack, the workspace snapshot and the packed CLI session,
+        # which are exactly what the resume restores. On the terminal-branch
+        # call the container has already exited, and capture still works
+        # because the container is kept (AutoRemove=False).
+        result_artifact = await self._capture_result_artifact(
+            agent_executor, session_reference
+        )
+        try:
+            await agent_executor.stop(session_reference)
+        except Exception:
+            logger.warning(
+                "Could not stop the runtime for parked execution %s",
+                self.execution_log.id,
+                exc_info=True,
+            )
+        await self._publish_update(
+            "execution_parked",
+            {
+                "approval_request_id": str(park_request["request_id"]),
+                "elapsed": elapsed,
+            },
+        )
+        return {
+            "status": WAITING_FOR_HUMAN_STATUS,
+            "output_summary": None,
+            "error_message": None,
+            "actions_taken": self.execution_logger.get_actions_taken(),
+            "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
+            "result": result_artifact,
+            "park": {
+                "approval_request_id": str(park_request["request_id"]),
+                "compute_seconds": (self._chain_consumed_seconds() + int(elapsed)),
+            },
+        }
+
     async def _monitor_agent_execution(
         self, session_reference: str, agent_executor: Any
     ) -> Dict[str, Any]:
@@ -4389,65 +4499,11 @@ class FlowExecutionOrchestrator:
                 # park request on this row because the question will not be
                 # answered on a container's timescale. Release the runtime and
                 # hand the run to the resume path; nothing here fails.
-                park_request = crud_flow_execution.get_park_request(
-                    self.db,
-                    execution_id=self.execution_log.id,
+                parked_result = await self._park_if_requested(
+                    agent_executor, session_reference, elapsed
                 )
-                if park_request and park_request.get("parked_at") is None:
-                    logger.info(
-                        "Parking execution %s on approval %s (expires %s)",
-                        self.execution_log.id,
-                        park_request["request_id"],
-                        park_request.get("expires_at"),
-                    )
-                    self.execution_logger.log_milestone(
-                        "execution_parked",
-                        {
-                            "approval_request_id": str(park_request["request_id"]),
-                            "expires_at": (
-                                park_request["expires_at"].isoformat()
-                                if park_request.get("expires_at")
-                                else None
-                            ),
-                            "elapsed": elapsed,
-                        },
-                    )
-                    # Capture BEFORE stopping: the result artifact call also
-                    # captures the evidence pack, the workspace snapshot and
-                    # the packed CLI session, which are exactly what the
-                    # resume restores.
-                    result_artifact = await self._capture_result_artifact(
-                        agent_executor, session_reference
-                    )
-                    try:
-                        await agent_executor.stop(session_reference)
-                    except Exception:
-                        logger.warning(
-                            "Could not stop the runtime for parked execution %s",
-                            self.execution_log.id,
-                            exc_info=True,
-                        )
-                    await self._publish_update(
-                        "execution_parked",
-                        {
-                            "approval_request_id": str(park_request["request_id"]),
-                            "elapsed": elapsed,
-                        },
-                    )
-                    return {
-                        "status": WAITING_FOR_HUMAN_STATUS,
-                        "output_summary": None,
-                        "error_message": None,
-                        "actions_taken": self.execution_logger.get_actions_taken(),
-                        "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
-                        "result": result_artifact,
-                        "park": {
-                            "approval_request_id": str(park_request["request_id"]),
-                            "compute_seconds": (
-                                self._chain_consumed_seconds() + int(elapsed)
-                            ),
-                        },
-                    }
+                if parked_result is not None:
+                    return parked_result
 
                 # Check if user requested stop
                 if self._stop_requested.is_set():
@@ -4594,6 +4650,19 @@ class FlowExecutionOrchestrator:
                     AgentStatus.FAILED,
                     AgentStatus.STOPPED,
                 ):
+                    # An agent handed `parked_for_human` stops working and
+                    # exits, which it can do entirely between two 5 second
+                    # polls of this loop. Ask once more before treating the
+                    # exit as the end of the run: a park that lost this race
+                    # would be completed, fail-closed and notified as
+                    # terminal while a human still holds the question, and
+                    # the eventual decision would have nothing to resume.
+                    parked_result = await self._park_if_requested(
+                        agent_executor, session_reference, elapsed
+                    )
+                    if parked_result is not None:
+                        return parked_result
+
                     # Agent finished, get final result
                     logger.info(
                         f"Agent finished with status {status.value} at {elapsed}s"
@@ -4646,10 +4715,16 @@ class FlowExecutionOrchestrator:
                     ):
                         assert result_artifact is not None
                         artifact_status = result_artifact.get("status")
+                        # Name the field that actually classified this, not
+                        # always "status": a CRA incompletion envelope (#512)
+                        # carries no status key and is classified on verdict.
+                        signal_field, signal_value = _artifact_failure_signal(
+                            result_artifact
+                        )
                         logger.warning(
                             "Agent exited with SUCCEEDED status but result.json "
-                            "reports an explicit failure status "
-                            f"({artifact_status!r}). "
+                            "reports an explicit failure "
+                            f"({signal_field}={signal_value!r}). "
                             "Overriding status to FAILED."
                         )
                         self.execution_logger.log_milestone(
@@ -4658,13 +4733,15 @@ class FlowExecutionOrchestrator:
                                 "original_status": result.status.value,
                                 "exit_code": result.exit_code,
                                 "artifact_status": artifact_status,
+                                "signal_field": signal_field,
+                                "signal_value": signal_value,
                                 "sentinel_seen": self._success_sentinel_seen.is_set(),
                             },
                         )
                         final_status = "FAILED"
                         error_message = result.error_message or (
                             "Agent reported an explicit failure in result.json "
-                            f"(status={artifact_status!r})."
+                            f"({signal_field}={signal_value!r})."
                         )
                     elif (
                         result.status == AgentStatus.SUCCEEDED

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -4839,6 +4839,12 @@ class FlowExecutionOrchestrator:
                             # failure in result.json wins over the sentinel.
                             assert result_artifact is not None
                             artifact_status = result_artifact.get("status")
+                            # Name the field that classified this, not always
+                            # "status": a CRA incompletion envelope has no status
+                            # key and is classified on verdict.
+                            signal_field, signal_value = _artifact_failure_signal(
+                                result_artifact
+                            )
                             # Container may still be in post-exec; fetch the
                             # result so _retry_decision sees exit_code instead
                             # of treating it as unknown.
@@ -4847,6 +4853,8 @@ class FlowExecutionOrchestrator:
                                 "result_artifact_failure_override",
                                 {
                                     "artifact_status": artifact_status,
+                                    "signal_field": signal_field,
+                                    "signal_value": signal_value,
                                     "sentinel_seen": True,
                                     "exit_code": result.exit_code,
                                 },
@@ -4855,8 +4863,8 @@ class FlowExecutionOrchestrator:
                                 "status": "FAILED",
                                 "error_message": (
                                     "Agent reported an explicit failure in "
-                                    "result.json (status="
-                                    f"{artifact_status!r})."
+                                    "result.json "
+                                    f"({signal_field}={signal_value!r})."
                                 ),
                                 "actions_taken": self.execution_logger.get_actions_taken(),
                                 "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -412,6 +412,17 @@ prompt_template: |
        "date": {"type": "string", "format": "date",
          "x-autofill": "date"}},
      "required": []}
+    Pass timeout_seconds: 259200 (3 days) on that same call. A human
+    reading a CRA waiver needs longer than the 300 second deployment
+    default, and the tool argument is the first thing the platform
+    consults when it resolves the window, ahead of the flow's
+    approval_window_seconds, the approval workflow and that default,
+    so the window no longer depends on the flow row alone. The
+    platform clamps the value to the deployment ceiling and the
+    account cap, so naming it can only shorten the wait against
+    policy, never extend it past policy. A window this long parks the
+    execution rather than blocking it: expect the answer through
+    `_answers_prompt` on resume, as described next.
     The question and context never authorize a waiver, including
     negated wording such as "do not waive" or a CVE mentioned only in
     prose. A finding is accepted only by appearing in the returned

--- a/backend/tests/test_approval_park_survives_agent_exit.py
+++ b/backend/tests/test_approval_park_survives_agent_exit.py
@@ -1,0 +1,481 @@
+"""The park must survive both an async workflow and a fast agent exit.
+
+Staging execution ``e42c6086-f637-4d18-be09-2395c4d488ca`` (preset 006,
+approval ``6a7cd2dc-a9f8-4fa5-9870-b834f5bc1db2``) raised a CRA waiver at
+16:47:41Z against a three day window and was marked FAILED at 16:52:05Z with
+``parked_at``, ``park_request_id`` and ``park_expires_at`` all null. The human
+approved at 16:54:25Z, 2 minutes 20 seconds too late, with nothing left to
+resume. #510 had shipped; the park was simply never reached.
+
+Two independent reasons, one per half of this file:
+
+1. the account's default approval workflow has ``async_approval_enabled``,
+   and that branch of ``require_approval`` returns a ``pending_approval``
+   payload before the poll loop where the park handshake lives (the tool
+   call took 528 ms, not the 90 seconds a park needs);
+2. even once it parks, the park request is written by a different process
+   and observed on a 5 second poll, so an agent that receives
+   ``parked_for_human`` and exits can outrun the observation, and the
+   terminal branch used to complete the run and fail it closed.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from preloop.services import approval_park
+
+UTC = timezone.utc
+
+# The result.json preset 006 actually wrote on the staging run: the #512
+# incompletion envelope. Note there is no "status" key at all.
+STAGING_INCOMPLETION_ENVELOPE = {
+    "schema": "preloop.cra.releaseaudit/v1",
+    "flow": "release-security-audit",
+    "run_at": "2026-09-09T16:51:36Z",
+    "regime_profile": "cra",
+    "verdict": "error",
+    "incomplete": {
+        "reason": (
+            "The audit could not be completed because a required human "
+            "decision on approval request "
+            "6a7cd2dc-a9f8-4fa5-9870-b834f5bc1db2 did not arrive before "
+            "the execution limit."
+        ),
+        "stage": "vuln_scan",
+    },
+    "disclaimer": "Machine-generated evidence for conformity assessment support.",
+}
+
+
+@pytest.mark.asyncio
+class TestAsyncWorkflowParks:
+    """An async approval workflow must park, not hand out polling advice."""
+
+    @staticmethod
+    def _patch_park(monkeypatch, *, recorded=True):
+        monkeypatch.setattr("preloop.models.db.session.get_session_factory", MagicMock)
+        monkeypatch.setattr(
+            "preloop.api.loop_safety.run_db_off_loop",
+            AsyncMock(side_effect=lambda fn: fn()),
+        )
+        write = MagicMock(return_value=recorded)
+        monkeypatch.setattr(approval_park, "request_park", write)
+        return write
+
+    async def test_a_three_day_window_parks_and_tells_the_agent_to_stop(
+        self, monkeypatch
+    ):
+        """The staging case: 259200 seconds, an execution, so park."""
+        from preloop.services import approval_helper
+
+        write = self._patch_park(monkeypatch)
+        expires = datetime.now(UTC) + timedelta(days=3)
+        payload = await approval_helper._park_and_build_payload(
+            execution_id="e42c6086",
+            approval_request_id="6a7cd2dc",
+            expires_at=expires,
+            window_seconds=259200,
+            tool_name="ask_user",
+            arguments={"question": "Please review and submit any waivers."},
+            base_url="https://staging.example.test",
+        )
+        assert payload is not None
+        parsed = json.loads(payload)
+        assert parsed["status"] == "parked_for_human"
+        assert parsed["request_id"] == "6a7cd2dc"
+        assert parsed["tool_name"] == "ask_user"
+        assert "do not poll" in parsed["message"]
+        assert parsed["question"] == "Please review and submit any waivers."
+        assert write.call_args.kwargs["expires_at"] == expires
+
+    async def test_a_short_window_keeps_the_polling_payload(self, monkeypatch):
+        """Under the park threshold nothing changes: no park, no restart."""
+        from preloop.services import approval_helper
+
+        write = self._patch_park(monkeypatch)
+        assert (
+            await approval_helper._park_and_build_payload(
+                execution_id="exec-1",
+                approval_request_id="req-1",
+                expires_at=None,
+                window_seconds=30,
+                tool_name="ask_user",
+                arguments={},
+                base_url="https://example.test",
+            )
+            is None
+        )
+        write.assert_not_called()
+
+    async def test_a_call_with_no_execution_behind_it_never_parks(self, monkeypatch):
+        """A plain MCP session has no run to suspend."""
+        from preloop.services import approval_helper
+
+        write = self._patch_park(monkeypatch)
+        assert (
+            await approval_helper._park_and_build_payload(
+                execution_id=None,
+                approval_request_id="req-1",
+                expires_at=None,
+                window_seconds=259200,
+                tool_name="ask_user",
+                arguments={},
+                base_url="https://example.test",
+            )
+            is None
+        )
+        write.assert_not_called()
+
+    async def test_a_run_that_already_finished_is_not_parked(self, monkeypatch):
+        """request_park claims zero rows, so the caller keeps its old path."""
+        from preloop.services import approval_helper
+
+        self._patch_park(monkeypatch, recorded=False)
+        assert (
+            await approval_helper._park_and_build_payload(
+                execution_id="exec-1",
+                approval_request_id="req-1",
+                expires_at=None,
+                window_seconds=259200,
+                tool_name="ask_user",
+                arguments={},
+                base_url="https://example.test",
+            )
+            is None
+        )
+
+    async def test_the_async_branch_reaches_the_park_helper(self, monkeypatch):
+        """Regression guard for the defect itself.
+
+        The async branch returned ~70 lines above the poll loop, so the park
+        was unreachable. Pin that the async payload is only built when the
+        park helper declines.
+        """
+        import inspect
+
+        from preloop.services import approval_helper
+
+        source = inspect.getsource(approval_helper.require_approval)
+        async_at = source.index("if workflow_async_enabled:")
+        park_at = source.index("_park_and_build_payload", async_at)
+        pending_at = source.index('"status": "pending_approval"', async_at)
+        assert park_at < pending_at, (
+            "the park attempt must precede the pending_approval payload, "
+            "or an async workflow can never park"
+        )
+
+
+@pytest.mark.asyncio
+class TestParkSurvivesAFastAgentExit:
+    """The agent stops when told to; the monitor must not call that an end."""
+
+    def _orchestrator(self, monkeypatch, *, park_request):
+        from preloop.services import flow_orchestrator as module
+
+        orchestrator = object.__new__(module.FlowExecutionOrchestrator)
+        orchestrator.db = MagicMock()
+        orchestrator.execution_log = SimpleNamespace(id=uuid.uuid4())
+        orchestrator.execution_logger = MagicMock()
+        orchestrator.execution_logger.get_actions_taken.return_value = []
+        orchestrator.execution_logger.get_mcp_usage_logs.return_value = []
+        orchestrator._publish_update = AsyncMock()
+        orchestrator._capture_result_artifact = AsyncMock(
+            return_value=dict(STAGING_INCOMPLETION_ENVELOPE)
+        )
+        orchestrator._chain_consumed_seconds = MagicMock(return_value=0)
+        monkeypatch.setattr(
+            module.crud_flow_execution,
+            "get_park_request",
+            MagicMock(return_value=park_request),
+        )
+        return orchestrator
+
+    async def test_a_pending_park_wins_over_the_container_exit(self, monkeypatch):
+        request_id = uuid.uuid4()
+        expires = datetime.now(UTC) + timedelta(days=3)
+        orchestrator = self._orchestrator(
+            monkeypatch,
+            park_request={
+                "request_id": request_id,
+                "requested_at": datetime.now(UTC),
+                "expires_at": expires,
+                "parked_at": None,
+            },
+        )
+        executor = SimpleNamespace(stop=AsyncMock())
+        result = await orchestrator._park_if_requested(executor, "session-1", 295)
+
+        assert result is not None
+        assert result["status"] == "WAITING_FOR_HUMAN"
+        assert result["error_message"] is None
+        assert result["park"]["approval_request_id"] == str(request_id)
+        assert result["park"]["compute_seconds"] == 295
+        executor.stop.assert_awaited_once_with("session-1")
+
+    async def test_an_already_confirmed_park_is_not_parked_twice(self, monkeypatch):
+        orchestrator = self._orchestrator(
+            monkeypatch,
+            park_request={
+                "request_id": uuid.uuid4(),
+                "requested_at": datetime.now(UTC),
+                "expires_at": None,
+                "parked_at": datetime.now(UTC),
+            },
+        )
+        assert (
+            await orchestrator._park_if_requested(
+                SimpleNamespace(stop=AsyncMock()), "session-1", 10
+            )
+            is None
+        )
+
+    async def test_no_park_request_leaves_the_run_alone(self, monkeypatch):
+        orchestrator = self._orchestrator(monkeypatch, park_request=None)
+        assert (
+            await orchestrator._park_if_requested(
+                SimpleNamespace(stop=AsyncMock()), "session-1", 10
+            )
+            is None
+        )
+
+    async def test_a_runtime_that_will_not_stop_still_parks(self, monkeypatch):
+        """The container has already exited on the terminal-branch call."""
+        orchestrator = self._orchestrator(
+            monkeypatch,
+            park_request={
+                "request_id": uuid.uuid4(),
+                "requested_at": datetime.now(UTC),
+                "expires_at": None,
+                "parked_at": None,
+            },
+        )
+        executor = SimpleNamespace(stop=AsyncMock(side_effect=RuntimeError("gone")))
+        result = await orchestrator._park_if_requested(executor, "session-1", 5)
+        assert result["status"] == "WAITING_FOR_HUMAN"
+
+    async def test_the_terminal_branch_asks_about_the_park(self):
+        """The race is only closed if the exit path re-checks."""
+        import inspect
+
+        from preloop.services import flow_orchestrator as module
+
+        source = inspect.getsource(
+            module.FlowExecutionOrchestrator._monitor_agent_execution
+        )
+        terminal_at = source.index("if status in (")
+        assert "_park_if_requested" in source[terminal_at:], (
+            "the terminal branch must re-check the park request, or an agent "
+            "that exits between two polls is completed instead of parked"
+        )
+        # Two call sites: the loop head and the terminal branch.
+        assert source.count("_park_if_requested") == 2
+
+
+class TestFailClosedDoesNotTouchAParkedRun:
+    """A run that has not finished has no release to deny."""
+
+    def _orchestrator(self):
+        from preloop.cra.persist import CraPersistDecision
+        from preloop.cra.validate import CraValidationResult
+        from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+        orchestrator = object.__new__(FlowExecutionOrchestrator)
+        orchestrator._cra_persist_decision = CraPersistDecision(
+            artifact=dict(STAGING_INCOMPLETION_ENVELOPE),
+            validation=CraValidationResult(
+                ok=False,
+                failures=["run did not complete: the waiver was unanswered"],
+                schema_id="preloop.cra.releaseaudit/v1",
+                incomplete=True,
+            ),
+        )
+        return orchestrator
+
+    def test_a_parked_run_is_never_failed_closed(self):
+        orchestrator = self._orchestrator()
+        assert orchestrator._cra_persist_decision.invalid is True
+        status, error = orchestrator._apply_cra_fail_closed("WAITING_FOR_HUMAN", None)
+        assert status == "WAITING_FOR_HUMAN"
+        assert error is None
+
+    def test_a_finished_run_still_fails_closed(self):
+        """The guard is about park, not about weakening fail-closed."""
+        orchestrator = self._orchestrator()
+        status, error = orchestrator._apply_cra_fail_closed("SUCCEEDED", None)
+        assert status == "FAILED"
+        assert error
+
+
+class TestFailureMessageNamesTheFieldThatDecided:
+    """`status=None` sent operators looking for a key that does not exist."""
+
+    def test_the_incompletion_envelope_is_reported_on_its_verdict(self):
+        from preloop.services.flow_orchestrator import _artifact_failure_signal
+
+        field, value = _artifact_failure_signal(STAGING_INCOMPLETION_ENVELOPE)
+        assert (field, value) == ("verdict", "error")
+        assert "status" not in STAGING_INCOMPLETION_ENVELOPE
+
+    def test_an_explicit_status_still_wins(self):
+        from preloop.services.flow_orchestrator import _artifact_failure_signal
+
+        assert _artifact_failure_signal({"status": "failure", "verdict": "error"}) == (
+            "status",
+            "failure",
+        )
+
+    def test_no_artifact_reports_status_none(self):
+        from preloop.services.flow_orchestrator import _artifact_failure_signal
+
+        assert _artifact_failure_signal(None) == ("status", None)
+
+    def test_the_envelope_is_still_classified_as_a_failure(self):
+        from preloop.services.flow_orchestrator import _result_artifact_confirmation
+
+        assert _result_artifact_confirmation(STAGING_INCOMPLETION_ENVELOPE) == "failure"
+
+
+@pytest.mark.asyncio
+class TestTheWholeHandshakeOnAFastExit:
+    """Monitor result to persisted park to the resume the decision starts."""
+
+    async def test_a_fast_exit_parks_and_notifies_nobody(self, monkeypatch):
+        from preloop.services import flow_orchestrator as module
+
+        request_id = uuid.uuid4()
+        monkeypatch.setattr(
+            module.crud_flow_execution,
+            "get_park_request",
+            MagicMock(
+                return_value={
+                    "request_id": request_id,
+                    "requested_at": datetime.now(UTC),
+                    "expires_at": datetime.now(UTC) + timedelta(days=3),
+                    "parked_at": None,
+                }
+            ),
+        )
+        confirm = MagicMock()
+        monkeypatch.setattr(module.crud_flow_execution, "confirm_park", confirm)
+
+        orchestrator = object.__new__(module.FlowExecutionOrchestrator)
+        orchestrator.db = MagicMock()
+        orchestrator.execution_log = SimpleNamespace(id=uuid.uuid4())
+        orchestrator.flow = SimpleNamespace(id=uuid.uuid4(), account_id=uuid.uuid4())
+        orchestrator.execution_logger = MagicMock()
+        orchestrator.execution_logger.get_actions_taken.return_value = []
+        orchestrator.execution_logger.get_mcp_usage_logs.return_value = []
+        orchestrator._publish_update = AsyncMock()
+        orchestrator._capture_result_artifact = AsyncMock(
+            return_value=dict(STAGING_INCOMPLETION_ENVELOPE)
+        )
+        orchestrator._chain_consumed_seconds = MagicMock(return_value=0)
+        orchestrator.tool_calls_count = 4
+        orchestrator.total_tokens = 6568865
+        orchestrator.estimated_cost = 0.0
+        orchestrator._update_execution_log = AsyncMock()
+        orchestrator._sync_runtime_session = MagicMock()
+        orchestrator._notify_terminal = AsyncMock()
+        orchestrator._start_queued_followup = AsyncMock()
+
+        # The agent exited between two polls, so the terminal branch is where
+        # the park is observed.
+        agent_result = await orchestrator._park_if_requested(
+            SimpleNamespace(stop=AsyncMock()), "session-1", 558
+        )
+        assert agent_result["status"] == "WAITING_FOR_HUMAN"
+
+        # Fail-closed must not touch it on the way out.
+        from preloop.cra.persist import CraPersistDecision
+        from preloop.cra.validate import CraValidationResult
+
+        orchestrator._cra_persist_decision = CraPersistDecision(
+            artifact=dict(STAGING_INCOMPLETION_ENVELOPE),
+            validation=CraValidationResult(ok=False, failures=["incomplete"]),
+        )
+        status, error = orchestrator._apply_cra_fail_closed(
+            agent_result["status"], agent_result["error_message"]
+        )
+        assert (status, error) == ("WAITING_FOR_HUMAN", None)
+
+        await orchestrator._finalize_park(
+            agent_result=agent_result,
+            output_summary=None,
+            merged_result=agent_result["result"],
+        )
+
+        kwargs = orchestrator._update_execution_log.await_args.kwargs
+        assert kwargs["status"] == "WAITING_FOR_HUMAN"
+        assert "end_time" not in kwargs
+        assert confirm.call_args.kwargs["compute_seconds"] == 558
+        # A parked run is alive: nobody is told it ended.
+        orchestrator._notify_terminal.assert_not_awaited()
+        orchestrator._start_queued_followup.assert_not_awaited()
+
+    async def test_the_decision_then_resumes_the_parked_run(self, monkeypatch):
+        """The half that was dead on staging: an answer with a run to land on."""
+        parked = SimpleNamespace(
+            id=uuid.uuid4(),
+            flow_id=uuid.uuid4(),
+            trigger_event_details={"payload": {"source": "cra"}},
+            cli_session={"session_id": "codex-01a0870d"},
+            park_request_id=uuid.uuid4(),
+            parked_compute_seconds=558,
+            start_time=datetime.now(UTC),
+            parked_at=datetime.now(UTC),
+        )
+        request = SimpleNamespace(
+            id=parked.park_request_id,
+            status="approved",
+            tool_name="ask_user",
+            tool_args={"question": "Please review and submit any waivers."},
+            answer_text="waived GO-2026-5932",
+            selected_option=None,
+            approver_comment=None,
+            responses=[{"user_id": "founder"}],
+            resolved_at=datetime.now(UTC),
+            structured_answer={
+                "waived": [{"id": "GO-2026-5932", "reason": "VEX not_affected"}]
+            },
+        )
+        started = []
+
+        monkeypatch.setattr(approval_park, "_load_request", lambda db, rid: request)
+        monkeypatch.setattr(
+            "preloop.models.db.session.get_session_factory",
+            lambda: MagicMock(return_value=MagicMock(__enter__=lambda s: s)),
+        )
+        monkeypatch.setattr(
+            "preloop.models.crud.crud_flow_execution.list_parked_for_request",
+            MagicMock(return_value=[parked]),
+        )
+        monkeypatch.setattr(
+            "preloop.models.crud.crud_flow_execution.claim_parked_for_resume",
+            MagicMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            "preloop.models.crud.crud_flow.get",
+            MagicMock(return_value=SimpleNamespace(id=parked.flow_id)),
+        )
+
+        async def _start(db, flow, row, details):
+            started.append(details)
+            return uuid.uuid4()
+
+        monkeypatch.setattr(approval_park, "_start_resume_execution", _start)
+
+        ids = await approval_park.resume_parked_executions(parked.park_request_id)
+        assert len(ids) == 1
+        details = started[0]
+        assert details["_resume"]["execution_id"] == str(parked.id)
+        assert details["_resume"]["cli_session"]["session_id"] == "codex-01a0870d"
+        answer = details["payload"]["answers"][str(parked.park_request_id)]
+        assert answer["status"] == "approved"
+        assert answer["structured_answer"]["waived"][0]["id"] == "GO-2026-5932"
+        # The human's wait is not charged to the resumed run's budget.
+        assert details["_answers"]["consumed_seconds"] == 558

--- a/backend/tests/test_approval_park_survives_agent_exit.py
+++ b/backend/tests/test_approval_park_survives_agent_exit.py
@@ -356,6 +356,24 @@ class TestFailureMessageNamesTheFieldThatDecided:
 
         assert _result_artifact_confirmation(STAGING_INCOMPLETION_ENVELOPE) == "failure"
 
+    def test_the_sentinel_grace_path_names_the_field_too(self):
+        """The still-running grace path used to print status=None."""
+        import inspect
+
+        from preloop.services import flow_orchestrator as module
+
+        source = inspect.getsource(
+            module.FlowExecutionOrchestrator._monitor_agent_execution
+        )
+        grace_at = source.index("sentinel_grace_period_expired")
+        grace_slice = source[grace_at:]
+        assert "_artifact_failure_signal" in grace_slice, (
+            "the sentinel-grace override must name the field that classified "
+            "the artifact, or a CRA incompletion envelope still reports "
+            "status=None"
+        )
+        assert "result.json (status=" not in grace_slice
+
 
 @pytest.mark.asyncio
 class TestTheWholeHandshakeOnAFastExit:

--- a/backend/tests/test_approval_park_survives_agent_exit.py
+++ b/backend/tests/test_approval_park_survives_agent_exit.py
@@ -149,6 +149,23 @@ class TestAsyncWorkflowParks:
             is None
         )
 
+    async def test_the_interactive_default_still_polls(self):
+        """Below the line the async path is untouched, so this stays additive.
+
+        should_park is true at 300s (the park threshold is 90s), but agent
+        side polling can cover the interactive default and the shipped
+        pending_approval contract is fine there. Only a window widened past
+        that default, which is what a compliance decision needs, parks.
+        """
+        from preloop.services import approval_helper
+        from preloop.config import settings
+
+        default = int(settings.approval_default_window_seconds)
+        assert approval_helper._beyond_async_polling(default) is False
+        assert approval_helper._beyond_async_polling(default - 1) is False
+        assert approval_helper._beyond_async_polling(default + 1) is True
+        assert approval_helper._beyond_async_polling(259200) is True
+
     async def test_the_async_branch_reaches_the_park_helper(self, monkeypatch):
         """Regression guard for the defect itself.
 

--- a/backend/tests/test_preset_sync_carries_every_field.py
+++ b/backend/tests/test_preset_sync_carries_every_field.py
@@ -1,0 +1,257 @@
+"""The preset sync must not drop a field between create and update.
+
+Presets 006 and 014 declare ``approval_window_seconds: 259200``. On staging
+both reported ``None``, and so did a fresh clone of 006, because those preset
+rows already existed and therefore only ever took the sync's update path,
+whose hand-maintained ``update_data`` dict had fallen six fields behind the
+create path: approval_window_seconds, timeout_seconds, runner_pool,
+custom_commands, webhook_config and schedule_config.
+
+The consequence is the failure #510 was written to remove.
+``resolve_approval_window`` fell back to
+``settings.approval_default_window_seconds`` (300s), so the CRA waiver in
+execution e42c6086-f637-4d18-be09-2395c4d488ca would have had five minutes to
+answer rather than three days, had the operator not patched the flow row by
+hand first. Round 1's waiver died that way: answered in 175 seconds, 27
+seconds late.
+
+These tests pin the fix from both ends: one source of truth for the field
+list, and the specific fields that were lost.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from preloop.models.models.flow import Flow
+from preloop.models.schemas.flow import FlowCreate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync_flow_presets.py"
+
+
+def _load_sync_module():
+    """Import scripts/sync_flow_presets.py, which is not on the package path."""
+    spec = importlib.util.spec_from_file_location(
+        "sync_flow_presets_under_test", SYNC_SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def sync():
+    return _load_sync_module()
+
+
+# A preset definition that sets every field a preset author is allowed to set.
+# Nothing here is a real preset: the point is coverage of the field list.
+FULLY_LOADED_PRESET = {
+    "name": "Every Field Preset",
+    "description": "sets everything a preset can set",
+    "icon": "shield-lock",
+    "trigger_event_source": None,
+    "trigger_event_types": ["push"],
+    "trigger_config": {"branch": "main"},
+    "webhook_config": {"webhook_secret": "s3cret-token"},
+    "schedule_config": {"type": "cron", "expr": "0 3 * * *", "timezone": "UTC"},
+    "prompt_template": "audit the release",
+    "agent_type": "claude-code",
+    "agent_config": {"model": "claude-sonnet-4-5"},
+    "allowed_mcp_servers": ["preloop"],
+    "allowed_mcp_tools": [{"server": "preloop", "name": "ask_user"}],
+    "git_clone_config": {"enabled": False},
+    "custom_commands": {"enabled": True, "commands": ["echo hi"]},
+    "runner_pool": "server",
+    "timeout_seconds": 7200,
+    "approval_window_seconds": 259200,
+    "notifications": {"on_failure": {"comment_on_trigger_issue": True}},
+}
+
+
+def _covers(written, declared):
+    """True when the written value carries everything the preset declared.
+
+    Nested config values come back as full model dumps with their defaults
+    filled in, so equality is the wrong test for them; what matters is that
+    nothing the author wrote was lost on the way to the row.
+    """
+    if isinstance(declared, dict):
+        return isinstance(written, dict) and all(
+            k in written and _covers(written[k], v) for k, v in declared.items()
+        )
+    return written == declared
+
+
+# The fields P3 lost. Named individually so a regression says which one.
+FIELDS_THE_UPDATE_PATH_DROPPED = [
+    ("approval_window_seconds", 259200),
+    ("timeout_seconds", 7200),
+    ("runner_pool", "server"),
+    ("custom_commands", {"enabled": True, "commands": ["echo hi"]}),
+    ("webhook_config", {"webhook_secret": "s3cret-token"}),
+    ("schedule_config", {"type": "cron", "expr": "0 3 * * *", "timezone": "UTC"}),
+]
+
+
+class TestOneSourceOfTruth:
+    """The update path derives from the same field list as the create path."""
+
+    def test_the_row_fields_are_the_flowcreate_fields(self, sync):
+        """Add a field to FlowCreate and the update path picks it up for free.
+
+        This is the assertion that would have caught P3 when
+        approval_window_seconds was added to FlowBase: the hand-maintained
+        dict could not have satisfied it.
+        """
+        written = set(sync.preset_row_fields(FULLY_LOADED_PRESET))
+        expected = set(FlowCreate.model_fields) - set(sync.PRESET_UNMANAGED_FIELDS)
+        assert written == expected
+
+    def test_the_platform_owned_fields_are_not_written_back(self, sync):
+        """Template tracking belongs to derived flows, not to the catalog."""
+        written = sync.preset_row_fields(FULLY_LOADED_PRESET)
+        for field in sync.PRESET_UNMANAGED_FIELDS:
+            assert field not in written
+
+    def test_every_column_written_exists_on_the_flow_model(self, sync):
+        """A field the schema has and the table does not would silently vanish."""
+        for field in sync.preset_row_fields(FULLY_LOADED_PRESET):
+            assert hasattr(Flow, field), field
+
+
+class TestFieldsSurviveAnUpdate:
+    """Every field a preset can set reaches an existing preset row."""
+
+    @pytest.mark.parametrize("field,expected", FIELDS_THE_UPDATE_PATH_DROPPED)
+    def test_a_dropped_field_now_lands(self, sync, field, expected):
+        assert _covers(sync.preset_row_fields(FULLY_LOADED_PRESET)[field], expected)
+
+    def test_the_whole_definition_survives(self, sync):
+        row_fields = sync.preset_row_fields(FULLY_LOADED_PRESET)
+        for field, value in FULLY_LOADED_PRESET.items():
+            if field in sync.PRESET_FORCED_FIELDS:
+                continue
+            assert _covers(row_fields[field], value), field
+
+    def test_the_sync_owns_preset_identity(self, sync):
+        """is_preset, is_enabled and trigger_event_source are not the author's."""
+        armed = dict(FULLY_LOADED_PRESET, is_preset=False, is_enabled=True)
+        armed["trigger_event_source"] = "github"
+        row_fields = sync.preset_row_fields(armed)
+        assert row_fields["is_preset"] is True
+        assert row_fields["is_enabled"] is False
+        assert row_fields["trigger_event_source"] is None
+
+    def test_account_id_is_never_written(self, sync):
+        """A global preset stays global even if a definition names an account."""
+        claimed = dict(
+            FULLY_LOADED_PRESET, account_id="11111111-1111-1111-1111-111111111111"
+        )
+        assert "account_id" not in sync.preset_row_fields(claimed)
+
+    def test_an_unknown_key_is_reported_not_swallowed(self, sync, caplog):
+        """Pydantic ignores extras; a preset author should not have to guess."""
+        with caplog.at_level("WARNING"):
+            sync.build_preset_flow_create(
+                dict(FULLY_LOADED_PRESET, trigger_event_type="push")
+            )
+        assert "trigger_event_type" in caplog.text
+        assert "FlowCreate" in caplog.text
+
+
+class TestDriftDetection:
+    """A stale row must be detected, not just written correctly when detected."""
+
+    def test_a_window_only_change_is_detected(self, sync):
+        """The old comparison checked 8 fields and would have said 'up to date'.
+
+        This is the second half of P3: even with a correct update dict, a
+        preset whose only change was approval_window_seconds would never have
+        reached it.
+        """
+        row = Flow(**sync.preset_row_fields(FULLY_LOADED_PRESET))
+        assert sync.preset_drift(row, sync.preset_row_fields(FULLY_LOADED_PRESET)) == []
+
+        row.approval_window_seconds = None
+        drift = sync.preset_drift(row, sync.preset_row_fields(FULLY_LOADED_PRESET))
+        assert drift == ["approval_window_seconds"]
+
+    def test_an_account_owned_preset_is_flagged(self, sync):
+        row = Flow(**sync.preset_row_fields(FULLY_LOADED_PRESET))
+        row.account_id = "11111111-1111-1111-1111-111111111111"
+        assert "account_id (should be NULL)" in sync.preset_drift(
+            row, sync.preset_row_fields(FULLY_LOADED_PRESET)
+        )
+
+    def test_applying_the_row_fields_clears_the_drift(self, sync):
+        """What the sync loop does, end to end, on a stale staging row."""
+        row_fields = sync.preset_row_fields(FULLY_LOADED_PRESET)
+        row = Flow(**row_fields)
+        row.approval_window_seconds = None
+        row.timeout_seconds = None
+        row.runner_pool = None
+
+        for field, value in row_fields.items():
+            setattr(row, field, value)
+
+        assert row.approval_window_seconds == 259200
+        assert row.timeout_seconds == 7200
+        assert row.runner_pool == "server"
+        assert sync.preset_drift(row, row_fields) == []
+
+
+class TestTheShippedCatalog:
+    """The real presets, since they are what staging runs."""
+
+    def test_every_preset_validates(self, sync):
+        from preloop.flow_presets import FLOW_PRESETS
+
+        assert FLOW_PRESETS
+        for preset in FLOW_PRESETS:
+            created = sync.build_preset_flow_create(preset)
+            assert created.is_preset is True
+            assert created.is_enabled is False
+
+    def test_the_cra_presets_keep_their_three_day_window(self, sync):
+        """006 and 014 are the two that declare it, and both were losing it."""
+        from preloop.flow_presets import FLOW_PRESETS
+
+        by_name = {p["name"]: p for p in FLOW_PRESETS}
+        windowed = {
+            name: sync.preset_row_fields(p)["approval_window_seconds"]
+            for name, p in by_name.items()
+            if p.get("approval_window_seconds") is not None
+        }
+        assert windowed == {
+            "Release Security Audit": 259200,
+            "Security Maintenance Implementation": 259200,
+        }
+
+    def test_preset_timeouts_survive(self, sync):
+        from preloop.flow_presets import FLOW_PRESETS
+
+        declared = {
+            p["name"]: p["timeout_seconds"]
+            for p in FLOW_PRESETS
+            if p.get("timeout_seconds") is not None
+        }
+        assert declared, "expected at least one preset to declare timeout_seconds"
+        for preset in FLOW_PRESETS:
+            if preset["name"] in declared:
+                assert (
+                    sync.preset_row_fields(preset)["timeout_seconds"]
+                    == declared[preset["name"]]
+                )
+
+    def test_no_preset_declares_a_key_no_schema_claims(self, sync, caplog):
+        from preloop.flow_presets import FLOW_PRESETS
+
+        with caplog.at_level("WARNING"):
+            for preset in FLOW_PRESETS:
+                sync.build_preset_flow_create(preset)
+        assert "FlowCreate does not define" not in caplog.text

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -818,6 +818,27 @@ class TestReleaseAuditWaivers:
         ):
             assert field in prompt, f"missing gate field: {field}"
 
+    def test_the_waiver_call_names_its_own_window(self, prompt):
+        """The window must not depend on the flow row alone.
+
+        Round 2 (P3): the presets sync dropped approval_window_seconds, so
+        this preset's declared 3 days never reached the flow row and
+        resolve_approval_window fell back to the 300 second deployment
+        default. The tool argument is the first source that function
+        consults, so naming it here survives a stale or hand-cloned row.
+        """
+        norm = _norm(prompt)
+        assert "Pass timeout_seconds: 259200 (3 days) on that same call" in norm
+        assert str(self.THREE_DAYS) in prompt
+
+    THREE_DAYS = 259200
+
+    def test_the_declared_window_matches_the_flow_field(self):
+        """The tool argument and the flow field say the same thing."""
+        preset = _load_preset(PRESET_FILES["Release Security Audit"])
+        assert preset["approval_window_seconds"] == self.THREE_DAYS
+        assert f"timeout_seconds: {self.THREE_DAYS}" in preset["prompt_template"]
+
     def test_interactive_collection_is_batched_and_fail_closed(self, prompt):
         norm = _norm(prompt)
         assert 'waiver_collection: "interactive"' in norm

--- a/scripts/sync_flow_presets.py
+++ b/scripts/sync_flow_presets.py
@@ -59,6 +59,84 @@ logger.info(f"Loading presets from: {[str(d) for d in PRESETS_DIRS]}")
 logger.info(f"Found {len(FLOW_PRESETS)} preset definitions")
 
 
+# Fields the sync owns rather than the preset author. The catalog is global
+# (no account), is never armed (a preset is cloned before it runs), and its
+# trigger source is bound when a clone is instantiated, not here.
+PRESET_FORCED_FIELDS = {
+    "is_preset": True,
+    "is_enabled": False,
+    "trigger_event_source": None,
+}
+
+# Set by the platform on derived flows, never by a preset definition, so the
+# update path must not write them back over a preset row.
+PRESET_UNMANAGED_FIELDS = frozenset(
+    {
+        "account_id",
+        "source_preset_id",
+        "source_prompt_hash",
+        "source_tools_hash",
+        "prompt_customized",
+        "tools_customized",
+        "preset_update_available",
+    }
+)
+
+
+def build_preset_flow_create(preset_def: dict) -> schemas.FlowCreate:
+    """Validate one preset definition into the FlowCreate a preset row is built from.
+
+    Both the create and the update path go through here, so the set of fields
+    a preset can set is stated once. It used to be stated twice: the create
+    path passed the whole definition to FlowCreate while the update path
+    copied a hand-maintained dict, and that dict had fallen six fields behind
+    (approval_window_seconds, timeout_seconds, runner_pool, custom_commands,
+    webhook_config, schedule_config). Presets 006 and 014 declare
+    approval_window_seconds: 259200 and already existed on staging, so they
+    only ever took the update path and reported None, which put every
+    approval they raise back on the 300 second default.
+    """
+    preset_data = {k: v for k, v in preset_def.items() if k not in PRESET_FORCED_FIELDS}
+    preset_data.pop("account_id", None)
+    unknown = sorted(set(preset_data) - set(schemas.FlowCreate.model_fields))
+    if unknown:
+        # Not fatal: a deploy should not fall over a spare key. Loud, though,
+        # because a key that no schema claims is a preset that does not do
+        # what its YAML says.
+        logger.warning(
+            "  Preset '%s' declares %s, which FlowCreate does not define; ignored",
+            preset_def.get("name"),
+            ", ".join(unknown),
+        )
+    preset_data.update(PRESET_FORCED_FIELDS)
+    return schemas.FlowCreate(**preset_data)
+
+
+def preset_row_fields(preset_def: dict) -> dict:
+    """The column values an existing global preset row has to be set to.
+
+    Derived from the same FlowCreate as the create path, minus the fields the
+    platform owns, so a field cannot land on a new preset and miss an
+    existing one.
+    """
+    fields = build_preset_flow_create(preset_def).model_dump()
+    for field in PRESET_UNMANAGED_FIELDS:
+        fields.pop(field, None)
+    return fields
+
+
+def preset_drift(existing_flow: Flow, row_fields: dict) -> List[str]:
+    """Names of the fields on which the stored preset differs from its definition."""
+    drifted = [
+        field
+        for field, value in row_fields.items()
+        if hasattr(existing_flow, field) and getattr(existing_flow, field) != value
+    ]
+    if existing_flow.account_id is not None:
+        drifted.append("account_id (should be NULL)")
+    return drifted
+
+
 def sync_global_presets(db: Session, dry_run: bool = False) -> int:
     """
     Sync global flow presets (account_id=None).
@@ -87,71 +165,24 @@ def sync_global_presets(db: Session, dry_run: bool = False) -> int:
         existing_flow = existing_by_name.get(preset_name)
 
         if existing_flow:
-            # Check if preset needs updating
-            needs_update = False
-            update_fields = []
+            # Compare against every field the preset definition owns, not a
+            # subset: a preset whose only change is approval_window_seconds
+            # used to be reported as up to date and never written.
+            row_fields = preset_row_fields(preset_def)
+            update_fields = preset_drift(existing_flow, row_fields)
 
-            # Compare key fields that might have changed
-            if existing_flow.description != preset_def.get("description"):
-                needs_update = True
-                update_fields.append("description")
-            if existing_flow.icon != preset_def.get("icon"):
-                needs_update = True
-                update_fields.append("icon")
-            if existing_flow.prompt_template != preset_def.get("prompt_template"):
-                needs_update = True
-                update_fields.append("prompt_template")
-            if existing_flow.agent_type != preset_def.get("agent_type"):
-                needs_update = True
-                update_fields.append("agent_type")
-            if existing_flow.agent_config != preset_def.get("agent_config"):
-                needs_update = True
-                update_fields.append("agent_config")
-            if existing_flow.allowed_mcp_tools != preset_def.get("allowed_mcp_tools"):
-                needs_update = True
-                update_fields.append("allowed_mcp_tools")
-            if existing_flow.git_clone_config != preset_def.get("git_clone_config"):
-                needs_update = True
-                update_fields.append("git_clone_config")
-            if existing_flow.notifications != preset_def.get("notifications"):
-                needs_update = True
-                update_fields.append("notifications")
-
-            # Check if preset incorrectly has an account_id (should be None)
             if existing_flow.account_id is not None:
-                needs_update = True
-                update_fields.append("account_id (should be NULL)")
                 logger.warning(
                     f"  Global preset '{preset_name}' has account_id={existing_flow.account_id}, will be fixed"
                 )
 
-            if needs_update:
+            if update_fields:
                 logger.info(
                     f"  Updating global preset '{preset_name}' (fields: {', '.join(update_fields)})"
                 )
                 if not dry_run:
-                    # Update the preset - set account_id to None explicitly
-                    update_data = {
-                        "name": preset_name,
-                        "description": preset_def.get("description"),
-                        "icon": preset_def.get("icon"),
-                        "prompt_template": preset_def.get("prompt_template"),
-                        "agent_type": preset_def.get("agent_type"),
-                        "agent_config": preset_def.get("agent_config"),
-                        "allowed_mcp_servers": preset_def.get(
-                            "allowed_mcp_servers", []
-                        ),
-                        "allowed_mcp_tools": preset_def.get("allowed_mcp_tools", []),
-                        "git_clone_config": preset_def.get("git_clone_config"),
-                        "notifications": preset_def.get("notifications"),
-                        "trigger_event_source": preset_def.get("trigger_event_source"),
-                        "trigger_event_type": preset_def.get("trigger_event_type"),
-                        "trigger_config": preset_def.get("trigger_config"),
-                        "is_preset": True,
-                        "is_enabled": False,  # Global presets are always disabled
-                    }
                     # Update directly to ensure account_id stays NULL
-                    for field, value in update_data.items():
+                    for field, value in row_fields.items():
                         if hasattr(existing_flow, field):
                             setattr(existing_flow, field, value)
                     existing_flow.account_id = None  # Ensure it's NULL
@@ -164,16 +195,11 @@ def sync_global_presets(db: Session, dry_run: bool = False) -> int:
             # Create new global preset
             logger.info(f"  Creating new global preset '{preset_name}'")
             if not dry_run:
-                # Prepare preset data
-                preset_data = preset_def.copy()
-                preset_data.pop("account_id", None)  # Ensure no account_id
-                preset_data["trigger_event_source"] = None
-                preset_data["trigger_event_type"] = preset_def.get("trigger_event_type")
-                preset_data["is_preset"] = True
-                preset_data["is_enabled"] = False
-
-                flow_create = schemas.FlowCreate(**preset_data)
-                crud_flow.create(db=db, flow_in=flow_create, account_id=None)
+                crud_flow.create(
+                    db=db,
+                    flow_in=build_preset_flow_create(preset_def),
+                    account_id=None,
+                )
             changes_count += 1
 
     logger.info(f"Total global preset changes: {changes_count}")


### PR DESCRIPTION
## What this fixes

A CRA dogfood run on staging raised an interactive waiver with a **three day**
window, and the run died five minutes later anyway. Execution
`e42c6086-f637-4d18-be09-2395c4d488ca` (preset 006), approval
`6a7cd2dc-a9f8-4fa5-9870-b834f5bc1db2`. The founder answered at 16:54:25Z. The
execution had been `FAILED` since 16:52:05Z. A correct human risk acceptance
attached to nothing, which is exactly the failure #510 was written to remove.

The logs say why. `mcp: preloop/ask_user started` at 16:47:41.229615Z,
`(completed)` at 16:47:41.757642Z: **528 milliseconds**. The tool never waited,
so it never reached the park handshake. The approval routed to approval workflow
`9842aa97-22ca-4d1c-a7ed-1120f05ad6d6`, which is the account's
`"Default Approval Workflow"` with `async_approval_enabled: true`, and the async
branch of `require_approval` returns its `pending_approval` payload roughly
seventy lines above the poll loop that holds the park. On the default workflow
the park was structurally unreachable, whatever the window.

What the agent did next is the cost: it polled the approval over HTTP itself
(five URL guesses, all 404, and `get_approval_status` is not on preset 006's
allowlist so it could not have polled properly either), then wrote the #512
incompletion envelope and exited. 6,568,865 tokens.

## Four changes

**1. Park before the async early return.** Both the async branch and the poll
loop now call one `_park_and_build_payload` helper, so whether a call can park
is decided in a single place. It returns `None` (caller keeps its old
behaviour) when there is no execution behind the call, when the window is short
enough to answer in place, or when the row is no longer live.

**2. Only past the interactive default.** The async path parks only when the
window exceeds `settings.approval_default_window_seconds`. Below that line
agent-side polling is a fair contract and nothing changes, which keeps
park/resume additive; above it, "poll every 15 seconds for up to three days" is
not a contract an agent can honour. The line is the one `approval_window.py`
already draws in prose: five minutes is a reasonable default for an interactive
tool call and a nonsense default for a compliance decision. The staging case is
259200 seconds and parks.

**3. The monitor's terminal branch re-checks the park.** The park request is
written by the approval process and observed on a 5 second poll, while the agent
that received `parked_for_human` stops on its own. An agent that exits inside
that window used to be completed, fail-closed and notified as terminal with a
human still holding the question. This race is separate from the one above and
survives it.

**4. A parked run is not a release.** `_apply_cra_fail_closed` now passes
`WAITING_FOR_HUMAN` through unchanged: there is no release to deny, and the
artifact captured at park time is a mid-flight snapshot, not the verdict. And
the failure-override message now names the field that actually classified the
artifact: the staging message read `status=None`, but the #512 envelope has no
`status` key and the field that matched was `verdict: error`.

## Also in here: the sync bug that would have made this worse

`scripts/sync_flow_presets.py` updated existing global presets from a
hand-maintained dict that omitted `approval_window_seconds`, `timeout_seconds`,
`runner_pool`, `custom_commands`, `webhook_config` and `schedule_config`, while
the create path carried all of them. Its change detection compared only 8
fields, so a preset whose sole change was one of the six was reported up to date
and never written at all. Both halves had to go.

Presets 006 and 014 declare `approval_window_seconds: 259200` and already
existed on staging, so they only ever took the update path and reported `None`.
`resolve_approval_window` then falls back to 300 seconds. Round 1's waiver died
that way: answered in 175 seconds, 27 seconds late. Round 2 only had three days
because the operator patched the flow row by hand.

Create and update now both go through `build_preset_flow_create`, the row values
are its `model_dump()` minus the fields the platform owns on derived flows, and
drift is computed over that same set. A test asserts set equality with
`FlowCreate.model_fields`, so the next field added to `FlowBase` is carried for
free.

Preset 006 additionally passes `timeout_seconds: 259200` on its `ask_user` call,
so the window no longer depends on the flow row alone. The tool argument is the
first source `resolve_approval_window` consults, and the platform still clamps
it to the deployment ceiling and the account cap.

## Tests

- `backend/tests/test_approval_park_survives_agent_exit.py`, 19 new tests. Its
  `STAGING_INCOMPLETION_ENVELOPE` constant is the real `result.json` from
  `e42c6086`: `verdict: error`, an `incomplete.reason` naming the approval id,
  and no `status` key. Two tests use `inspect.getsource`, deliberately: the
  defect was an early `return` placed above the code that should have run, and
  statement order inside a function is not otherwise observable.
- `backend/tests/test_preset_sync_carries_every_field.py`, 20 new tests.
- 2 new tests in `backend/tests/test_security_audit_presets.py`.
- `backend/tests/test_approval_park.py` (the existing #510 suite) passes
  unchanged.

Whole backend suite, same machine, same database, `-m "not integration"`:
`main` 9466 passed / 11 failed, this branch 9507 passed / 11 failed. The 11 are
pre-existing and environmental (no `OPENAI_API_KEY`, no seeded model rows);
they fail identically on `main`.

No migration: no schema change.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the approval park/resume path and changes async-approval behaviour past the interactive default window; well-tested (41 new tests) and additive by design.
>
> **Overview**
> Fixes a staging incident where a 3-day approval window on an async approval workflow never parked the run, so a correct human risk acceptance attached to nothing. Unifies the park decision into one helper, re-checks the park in the monitor's terminal branch, passes `WAITING_FOR_HUMAN` through the CRA fail-closed boundary, names the field that classified a failed artifact, and fixes preset sync dropping six fields.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 220588a8. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->