### PR TITLE
Retention policy, legal hold and period export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Record retention, legal hold and period export**: an account now states
+  how long it keeps each class of record (audit rows, approvals, evidence
+  pack records, runtime sessions, usage) in days, with a floor of 183 days
+  (six months, the AI Act Art. 26(6) horizon) that a deployment can raise and
+  nothing can lower, and a 365 day default.
+  `GET/PUT /api/v1/retention/settings` and `GET /api/v1/retention/purge-preview`.
+  A bounded background sweeper deletes what is past retention: batches of
+  1000, a batch ceiling, a wall clock budget per pass and an off-peak UTC
+  window, one audit row per class per pass with the cutoff and the count. It
+  is **off by default** (`RETENTION_PURGE_ENABLED`), so an upgrade never
+  silently starts deleting audit history, and `RETENTION_PURGE_DRY_RUN` gives
+  the counts without the deletes. A legal hold
+  (`POST /api/v1/retention/holds`, mandatory reason, actor recorded, audited
+  on both place and release) freezes one execution, approval or evidence
+  pack: the purge skips it and the evidence janitor leaves the ciphertext
+  alone past `expires_at`, so a held pack is still downloadable. Evidence
+  receipts now report the real `legal_hold` state instead of a hardcoded
+  false; `object_lock` stays false because Preloop cannot verify a property
+  of the storage layer beneath it.
+  `POST /api/v1/retention/exports?start=&end=` returns a tar.gz of one period
+  (audit rows, approvals, evidence receipts, holds) with a `manifest.json`
+  carrying a sha256 per member and a digest over the member list, in the same
+  shape an evidence pack manifest uses. The bundle is not signed; the digests
+  show the archive was not altered after Preloop built it, not that the
+  records were true when they were written.
+
 - **Approval windows on a human timescale, with parked executions**: an
   approval or question can now stay open for hours or days instead of the
   fixed 5 minutes. `approval_window_seconds` is a per-flow setting (flow form

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -53,6 +53,7 @@ from preloop.api.endpoints import (
     projects,
     public_approval,
     pull_requests,
+    retention,
     roles,
     search as search_router,
     security_maintenance,
@@ -365,6 +366,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     else:
         logger.info("Skipping optimization job sweeper for %s role.", service_role)
 
+    # Start the retention purge sweeper (skip in testing mode). Off the
+    # request path by construction, and it sleeps before its first pass rather
+    # than deleting on boot: a crash loop must not turn into a delete loop.
+    # Disabled unless RETENTION_PURGE_ENABLED is set, so an upgrade never
+    # silently starts removing audit history.
+    retention_purge_sweeper = None
+    if not is_testing and is_api_role and settings.retention_purge_enabled:
+        from preloop.services.retention_purge import get_retention_purge_sweeper
+
+        retention_purge_sweeper = get_retention_purge_sweeper()
+        await retention_purge_sweeper.start()
+        logger.info("Retention purge sweeper started.")
+    else:
+        logger.info(
+            "Retention purge sweeper not started (enabled=%s, role=%s).",
+            settings.retention_purge_enabled,
+            service_role,
+        )
+
     # Start the webhook delivery worker (skip in testing mode). Outbound
     # deliveries never run on the request path; this drains the outbox.
     webhook_delivery_worker = None
@@ -576,6 +596,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("Webhook delivery worker stopped.")
         except Exception as e:
             logger.error(f"Error stopping webhook delivery worker: {e}", exc_info=True)
+
+    # Stop the retention purge sweeper. A pass in flight finishes its current
+    # batch and stops at the next check; batches are small on purpose so this
+    # is a short wait, and a half-done purge is simply resumed next pass.
+    if not is_testing and retention_purge_sweeper:
+        try:
+            await retention_purge_sweeper.stop()
+            logger.info("Retention purge sweeper stopped.")
+        except Exception as e:
+            logger.error(f"Error stopping retention purge sweeper: {e}", exc_info=True)
 
     # Stop the optimization-job sweeper and abandon in-flight optimization
     # jobs (skip in testing mode). shutdown(wait=False) on purpose: a model
@@ -1017,6 +1047,11 @@ def create_app() -> FastAPI:
         )
         app.include_router(
             event_webhooks.router,
+            prefix="/api/v1",
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            retention.router,
             prefix="/api/v1",
             dependencies=[Depends(get_current_active_user)],
         )

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -904,8 +904,10 @@ def get_flow_execution_evidence_status(
 
     Status is one of ``available``, ``missing``, ``expired``, or ``failed``.
     Served from the persisted execution receipt (no decrypt). Availability
-    is not integrity proof. ``object_lock`` and ``legal_hold`` are always
-    false: this API does not implement WORM retention.
+    is not integrity proof. ``object_lock`` is always false: this API does
+    not implement WORM retention and cannot verify a property of the storage
+    layer beneath it. ``legal_hold`` is true while a hold covers the pack or
+    its execution, which blocks payload expiry and purge inside Preloop.
     """
     execution = crud_flow_execution.get(
         db=db, id=execution_id, account_id=current_user.account_id

--- a/backend/preloop/api/endpoints/retention.py
+++ b/backend/preloop/api/endpoints/retention.py
@@ -179,7 +179,7 @@ def update_retention_settings(
         # substance, and the message names the floor so the console can show
         # it without a second round trip.
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     except ValueError as exc:
         raise HTTPException(
@@ -376,7 +376,7 @@ def create_period_export(
         )
     except PeriodExportError as exc:
         codes = {
-            "period_too_large": status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "period_too_large": status.HTTP_413_CONTENT_TOO_LARGE,
             "invalid_period": status.HTTP_400_BAD_REQUEST,
         }
         raise HTTPException(

--- a/backend/preloop/api/endpoints/retention.py
+++ b/backend/preloop/api/endpoints/retention.py
@@ -1,0 +1,401 @@
+"""Retention settings, legal holds and the period export.
+
+Three surfaces that only make sense together. The settings say how long
+records are kept, the holds say which records are exempt while a matter is
+open, and the export is how a period leaves the platform before retention
+catches up with it.
+
+Every handler here is a plain ``def``. They all hold a synchronous session,
+and FastAPI dispatches sync handlers on the anyio threadpool, so a wait for a
+pool connection blocks a worker thread rather than the event loop
+(``tests/api/test_event_loop_pool_wait.py`` ratchets that count).
+
+Permissions reuse ``view_policies`` / ``manage_policies`` for settings and
+holds, and ``view_audit_logs`` for the export, which is a bulk read of the
+audit trail. A new permission would need seeding in the EE role matrix, which
+is not part of this change; the same choice was made for outbound webhooks.
+
+The export streams a tar built in memory. That is deliberate and bounded:
+``RETENTION_EXPORT_MAX_ROWS`` per record class, and going over is a 413
+telling the caller to narrow the period rather than a truncated archive
+somebody later mistakes for the whole period.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time, timedelta
+from typing import Annotated, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from preloop.api.auth import get_current_active_user
+from preloop.api.common import get_account_for_user
+from preloop.config import settings
+from preloop.models.crud import crud_audit_log
+from preloop.models.crud import legal_hold as crud_legal_hold
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.user import User
+from preloop.schemas.retention import (
+    LegalHoldCreate,
+    LegalHoldRead,
+    LegalHoldRelease,
+    RetentionClassRead,
+    RetentionPurgePreview,
+    RetentionSettingsRead,
+    RetentionSettingsUpdate,
+)
+from preloop.services import retention_policy
+from preloop.services.legal_hold import (
+    HoldOutcome,
+    LegalHoldError,
+    hold_summary,
+    place_hold,
+    release_hold,
+)
+from preloop.services.retention_export import (
+    PeriodExportError,
+    audit_period_export,
+    build_period_export,
+)
+from preloop.services.retention_purge import count_purgeable
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/retention", tags=["Retention"])
+
+VIEW_PERMISSION = "view_policies"
+MANAGE_PERMISSION = "manage_policies"
+EXPORT_PERMISSION = "view_audit_logs"
+
+AUDIT_ACTION_SETTINGS = "retention_settings_updated"
+
+#: One year of days. A period export is a compliance artifact, not a data
+#: dump: a caller who wants five years takes five archives, and each one stays
+#: small enough to hash and store.
+MAX_PERIOD_DAYS = 366
+
+
+def _settings_payload(account: Account) -> RetentionSettingsRead:
+    """Resolved retention plus the deployment facts that constrain it."""
+    resolved = retention_policy.resolve_all(account.meta_data)
+    return RetentionSettingsRead(
+        floor_days=retention_policy.floor_days(),
+        default_days=retention_policy.default_days(),
+        max_days=retention_policy.MAX_RETENTION_DAYS,
+        classes=[
+            RetentionClassRead(
+                record_class=record_class,
+                label=retention_policy.RECORD_CLASS_LABELS[record_class],
+                days=setting.days,
+                source=setting.source,
+                floored=setting.floored,
+            )
+            for record_class, setting in resolved.items()
+        ],
+        purge_enabled=bool(settings.retention_purge_enabled),
+        purge_dry_run=bool(settings.retention_purge_dry_run),
+        purge_window_utc=settings.retention_purge_window_utc or None,
+        evidence_payload_hours=int(settings.flow_evidence_retention_hours),
+    )
+
+
+def _hold_read(outcome_or_hold, flagged: Optional[dict] = None) -> LegalHoldRead:
+    """Render a hold row, optionally with what a mutation just changed."""
+    if isinstance(outcome_or_hold, HoldOutcome):
+        summary = hold_summary(outcome_or_hold.hold)
+        flagged = outcome_or_hold.flagged
+    else:
+        summary = hold_summary(outcome_or_hold)
+    return LegalHoldRead(**summary, flagged=flagged)
+
+
+def _parse_day(value: str, field: str) -> datetime:
+    """Accept a date or a full timestamp, always land in UTC."""
+    raw = (value or "").strip()
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field} is required (YYYY-MM-DD)",
+        )
+    try:
+        if len(raw) == 10:
+            parsed = datetime.combine(
+                datetime.strptime(raw, "%Y-%m-%d").date(), time.min
+            )
+        else:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field} must be YYYY-MM-DD or an ISO 8601 timestamp",
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+@router.get("/settings", response_model=RetentionSettingsRead)
+@require_permission(VIEW_PERMISSION)
+def get_retention_settings(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Return this account's retention per record class, and the floor."""
+    return _settings_payload(account)
+
+
+@router.put("/settings", response_model=RetentionSettingsRead)
+@require_permission(MANAGE_PERMISSION)
+def update_retention_settings(
+    payload: RetentionSettingsUpdate,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Set retention per record class, never below the six month floor.
+
+    The body is the full desired state: a class the caller omits, or sets to
+    null, goes back to the deployment default.
+    """
+    before = {
+        record_class: setting.days
+        for record_class, setting in retention_policy.resolve_all(
+            account.meta_data
+        ).items()
+    }
+    try:
+        updated = retention_policy.set_retention(
+            account.meta_data, values=payload.classes
+        )
+    except retention_policy.RetentionFloorError as exc:
+        # 422 rather than 400: the value is well formed and refused on
+        # substance, and the message names the floor so the console can show
+        # it without a second round trip.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    account.meta_data = updated
+    flag_modified(account, "meta_data")
+    db.add(account)
+    after = {
+        record_class: setting.days
+        for record_class, setting in retention_policy.resolve_all(updated).items()
+    }
+    changed = {
+        record_class: {"from": before[record_class], "to": days}
+        for record_class, days in after.items()
+        if before.get(record_class) != days
+    }
+    crud_audit_log.log_action(
+        db,
+        account_id=account.id,
+        user_id=current_user.id,
+        action=AUDIT_ACTION_SETTINGS,
+        resource_type="retention",
+        resource_id="settings",
+        status="success",
+        details={"changed": changed, "floor_days": retention_policy.floor_days()},
+        commit=False,
+    )
+    db.commit()
+    db.refresh(account)
+    return _settings_payload(account)
+
+
+@router.get("/purge-preview", response_model=RetentionPurgePreview)
+@require_permission(VIEW_PERMISSION)
+def preview_retention_purge(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Count what the purge would remove today, without removing anything.
+
+    Nobody should discover the effect of a retention setting by watching rows
+    disappear. Rows under a legal hold are already excluded by the same
+    filters the purge uses, so the count is the count.
+    """
+    now = datetime.now(UTC)
+    rows = []
+    total = 0
+    for record_class, setting in retention_policy.resolve_all(
+        account.meta_data
+    ).items():
+        cutoff = now - timedelta(days=setting.days)
+        count = count_purgeable(
+            db, account_id=account.id, record_class=record_class, cutoff=cutoff
+        )
+        total += count
+        rows.append(
+            {
+                "record_class": record_class,
+                "label": retention_policy.RECORD_CLASS_LABELS[record_class],
+                "retention_days": setting.days,
+                "cutoff": cutoff.isoformat(),
+                "purgeable": count,
+            }
+        )
+    return RetentionPurgePreview(
+        account_id=account.id,
+        purge_enabled=bool(settings.retention_purge_enabled),
+        classes=rows,
+        total=total,
+    )
+
+
+@router.get("/holds", response_model=List[LegalHoldRead])
+@require_permission(VIEW_PERMISSION)
+def list_legal_holds(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    active_only: bool = Query(True, description="Hide released holds"),
+    resource_type: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """List this account's legal holds, newest first."""
+    rows = crud_legal_hold.list_for_account(
+        db,
+        account_id=account.id,
+        active_only=active_only,
+        resource_type=resource_type,
+        limit=limit,
+    )
+    return [_hold_read(row) for row in rows]
+
+
+@router.post(
+    "/holds", response_model=LegalHoldRead, status_code=status.HTTP_201_CREATED
+)
+@require_permission(MANAGE_PERMISSION)
+def create_legal_hold(
+    payload: LegalHoldCreate,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Freeze one execution, approval or evidence pack until released."""
+    try:
+        outcome = place_hold(
+            db,
+            account_id=account.id,
+            resource_type=payload.resource_type,
+            resource_id=payload.resource_id,
+            reason=payload.reason,
+            user_id=current_user.id,
+        )
+    except LegalHoldError as exc:
+        db.rollback()
+        codes = {
+            "resource_not_found": status.HTTP_404_NOT_FOUND,
+            "already_held": status.HTTP_409_CONFLICT,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    return _hold_read(outcome)
+
+
+@router.post("/holds/{hold_id}/release", response_model=LegalHoldRead)
+@require_permission(MANAGE_PERMISSION)
+def release_legal_hold(
+    hold_id: UUID,
+    payload: LegalHoldRelease,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Lift a hold. The record stays, with who lifted it and why."""
+    try:
+        outcome = release_hold(
+            db,
+            account_id=account.id,
+            hold_id=hold_id,
+            reason=payload.reason,
+            user_id=current_user.id,
+        )
+    except LegalHoldError as exc:
+        db.rollback()
+        codes = {
+            "hold_not_found": status.HTTP_404_NOT_FOUND,
+            "already_released": status.HTTP_409_CONFLICT,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    return _hold_read(outcome)
+
+
+@router.post("/exports", response_class=Response)
+@require_permission(EXPORT_PERMISSION)
+def create_period_export(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    start: str = Query(..., description="Period start, inclusive (YYYY-MM-DD)"),
+    end: str = Query(..., description="Period end, exclusive (YYYY-MM-DD)"),
+):
+    """Build a tar.gz of one period: audit rows, approvals, receipts, holds.
+
+    The archive carries ``manifest.json`` with a sha256 per member and a
+    digest over the member list, in the same shape an evidence pack manifest
+    uses, so one verifier covers both.
+    """
+    period_start = _parse_day(start, "start")
+    period_end = _parse_day(end, "end")
+    if period_end <= period_start:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="end must be after start",
+        )
+    if (period_end - period_start).days > MAX_PERIOD_DAYS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"a period export covers at most {MAX_PERIOD_DAYS} days; "
+                "take consecutive periods for a longer range"
+            ),
+        )
+    try:
+        export = build_period_export(
+            db, account=account, start=period_start, end=period_end
+        )
+    except PeriodExportError as exc:
+        codes = {
+            "period_too_large": status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "invalid_period": status.HTTP_400_BAD_REQUEST,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    audit_period_export(
+        db, account_id=account.id, user_id=current_user.id, export=export
+    )
+    return Response(
+        content=export.archive,
+        media_type="application/gzip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{export.filename}"',
+            # The digest of the bytes served, so a caller can check the
+            # download before they file it.
+            "X-Preloop-Archive-Sha256": export.sha256,
+            "X-Preloop-Members-Digest": str(
+                export.manifest.get("members_digest") or ""
+            ),
+        },
+    )

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -550,6 +550,98 @@ class Settings(BaseSettings):
     )
     flow_environment_profiles_file: str = ""
 
+    # Record retention, legal hold and the purge job
+    # (docs/guide/flows/evidence-storage.md). These govern how long *records*
+    # are kept (audit rows, approvals, evidence pack rows, runtime sessions,
+    # usage), which is a different question from how long the encrypted
+    # evidence payload is kept (FLOW_EVIDENCE_RETENTION_HOURS above).
+    retention_default_days: int = Field(
+        365,
+        ge=1,
+        description=(
+            "Default retention per record class, in days, for accounts that "
+            "set nothing. Twelve months. Resolved values are clamped up to "
+            "the effective floor, so a shorter default cannot take effect "
+            "(RETENTION_DEFAULT_DAYS)."
+        ),
+    )
+    retention_floor_days: int = Field(
+        183,
+        ge=1,
+        description=(
+            "Deployment floor for any retention setting, in days. The "
+            "absolute floor of 183 days (six months, AI Act Art. 26(6)) is a "
+            "module constant in preloop.services.retention_policy: this "
+            "setting can only raise it, never lower it "
+            "(RETENTION_FLOOR_DAYS)."
+        ),
+    )
+    retention_purge_enabled: bool = Field(
+        False,
+        description=(
+            "Run the scheduled retention purge. Off by default on purpose: a "
+            "job that starts deleting an account's audit history on upgrade "
+            "is not something an operator should discover afterwards. Turn it "
+            "on deliberately (RETENTION_PURGE_ENABLED)."
+        ),
+    )
+    retention_purge_dry_run: bool = Field(
+        False,
+        description=(
+            "Count and audit what the purge would delete without deleting "
+            "anything. Audit rows are written with action "
+            "'retention_purge_preview' (RETENTION_PURGE_DRY_RUN)."
+        ),
+    )
+    retention_purge_interval_seconds: int = Field(
+        3600,
+        ge=60,
+        description="Seconds between retention purge passes.",
+    )
+    retention_purge_batch_size: int = Field(
+        1000,
+        ge=1,
+        le=100000,
+        description=(
+            "Rows deleted per statement. Each batch is its own transaction so "
+            "the purge never holds a long lock."
+        ),
+    )
+    retention_purge_max_batches: int = Field(
+        50,
+        ge=1,
+        description=(
+            "Maximum batches per record class per account per pass. The "
+            "backlog is drained across passes rather than in one long "
+            "transaction."
+        ),
+    )
+    retention_purge_max_seconds: int = Field(
+        300,
+        ge=1,
+        description=(
+            "Wall-clock budget for one purge pass. The pass stops cleanly at "
+            "the budget and resumes on the next tick."
+        ),
+    )
+    retention_purge_window_utc: str = Field(
+        "1-5",
+        description=(
+            "Off-peak UTC hour window the purge may run in, as 'start-end' "
+            "(half open, so '1-5' means 01:00 to 04:59 UTC). Empty string "
+            "means any hour (RETENTION_PURGE_WINDOW_UTC)."
+        ),
+    )
+    retention_export_max_rows: int = Field(
+        100000,
+        ge=1,
+        description=(
+            "Maximum rows per record class in one period export. Exceeding it "
+            "is an error telling the caller to narrow the period; a compliance "
+            "export is never silently truncated (RETENTION_EXPORT_MAX_ROWS)."
+        ),
+    )
+
     # Outbound event webhooks (docs/guide/webhooks.md). Every default is
     # usable as-is; a deployment only tunes these when a receiver is slow or
     # an account produces a lot of events.

--- a/backend/preloop/models/alembic/versions/20260910_retention_legal_hold.py
+++ b/backend/preloop/models/alembic/versions/20260910_retention_legal_hold.py
@@ -1,0 +1,126 @@
+"""Legal hold records plus the derived enforcement flags they drive.
+
+Revision ID: 20260910_retention_hold
+Revises: 20260908_webhook_delivery_key
+Create Date: 2026-09-10
+
+``legal_hold`` is the account-visible record: who froze what, why, and the
+release with its own actor and reason. The boolean columns added to
+``flow_execution``, ``approval_request`` and ``flow_artifact`` are the derived
+enforcement state the retention purge and the evidence janitor test, written
+in the same transaction as the record so a batch DELETE stays a single table
+query.
+
+Retention settings themselves need no migration: they live in
+``account.meta_data`` under ``retention``, the same place the approval window
+cap and subject governance live.
+
+Downgrade drops the flags and the table. It does not resurrect anything a
+purge already removed, which is the honest limit of a reversible migration
+over a destructive feature.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260910_retention_hold"
+down_revision: Union[str, None] = "20260908_webhook_delivery_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+_FLAGGED_TABLES = ("flow_execution", "approval_request", "flow_artifact")
+
+
+def upgrade() -> None:
+    """Create the hold record table and the three enforcement flags."""
+    op.create_table(
+        "legal_hold",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("resource_type", sa.String(32), nullable=False),
+        sa.Column("resource_id", sa.String(255), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "placed_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("placed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "released_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("release_reason", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_legal_hold_id", "legal_hold", ["id"])
+    op.create_index("ix_legal_hold_account_id", "legal_hold", ["account_id"])
+    op.create_index(
+        "ix_legal_hold_placed_by_user_id", "legal_hold", ["placed_by_user_id"]
+    )
+    op.create_index("ix_legal_hold_placed_at", "legal_hold", ["placed_at"])
+    op.create_index(
+        "ix_legal_hold_account_released", "legal_hold", ["account_id", "released_at"]
+    )
+    # One active hold per resource. Two teams asking for the same freeze is
+    # one freeze, and concurrent callers race past a service-level check.
+    op.create_index(
+        "uq_legal_hold_active_resource",
+        "legal_hold",
+        ["account_id", "resource_type", "resource_id"],
+        unique=True,
+        postgresql_where=sa.text("released_at IS NULL"),
+    )
+
+    for table in _FLAGGED_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "legal_hold",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        # Partial index: the purge and the janitor only ever ask "is this one
+        # held?", and held rows are the rare case. A full index on a boolean
+        # that is false for every historical row would be dead weight.
+        op.create_index(
+            f"ix_{table}_legal_hold",
+            table,
+            ["legal_hold"],
+            postgresql_where=sa.text("legal_hold"),
+        )
+
+
+def downgrade() -> None:
+    """Drop the flags and the hold records."""
+    for table in _FLAGGED_TABLES:
+        op.drop_index(f"ix_{table}_legal_hold", table_name=table)
+        op.drop_column(table, "legal_hold")
+    op.drop_index("uq_legal_hold_active_resource", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_account_released", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_placed_at", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_placed_by_user_id", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_account_id", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_id", table_name="legal_hold")
+    op.drop_table("legal_hold")

--- a/backend/preloop/models/crud/flow_artifact.py
+++ b/backend/preloop/models/crud/flow_artifact.py
@@ -120,11 +120,18 @@ def lease(
 
 
 def cleanup(db: Session, *, now: datetime) -> int:
-    """Release expired unleased payloads while retaining honest availability."""
+    """Release expired unleased payloads while retaining honest availability.
+
+    A row under a legal hold is skipped whatever its ``expires_at`` says. The
+    hold has to block payload expiry, not only deletion: an evidence pack a
+    regulator may ask for has to still be downloadable, and "the record row
+    survived but the bytes are gone" is not what anyone means by a hold.
+    """
     count = (
         db.query(models.FlowArtifact)
         .filter(
             models.FlowArtifact.expires_at <= now,
+            models.FlowArtifact.legal_hold.is_(False),
             or_(
                 models.FlowArtifact.lease_until.is_(None),
                 models.FlowArtifact.lease_until <= now,

--- a/backend/preloop/models/crud/legal_hold.py
+++ b/backend/preloop/models/crud/legal_hold.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.models.approval_request import ApprovalRequest
 from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow import Flow
 from preloop.models.models.flow_execution import FlowExecution
 from preloop.models.models.legal_hold import (
     HOLD_RESOURCE_APPROVAL,
@@ -24,6 +25,19 @@ from preloop.models.models.legal_hold import (
     HOLD_RESOURCE_EXECUTION,
     LegalHold,
 )
+
+
+def execution_in_account(account_id: Any):
+    """Account filter for an execution.
+
+    ``flow_execution`` carries no ``account_id`` of its own: an execution
+    belongs to an account through its flow. Every execution-scoped query here
+    goes through this so the ownership check cannot be forgotten in one place
+    and remembered in another.
+    """
+    return FlowExecution.flow_id.in_(
+        select(Flow.id).where(Flow.account_id == account_id)
+    )
 
 
 def get(db: Session, *, account_id: Any, hold_id: UUID) -> Optional[LegalHold]:
@@ -142,7 +156,7 @@ def set_execution_flag(
         update(FlowExecution)
         .where(
             FlowExecution.id == execution_id,
-            FlowExecution.account_id == account_id,
+            execution_in_account(account_id),
         )
         .values(legal_hold=held)
         .execution_options(synchronize_session=False)

--- a/backend/preloop/models/crud/legal_hold.py
+++ b/backend/preloop/models/crud/legal_hold.py
@@ -1,0 +1,230 @@
+"""Legal hold persistence: the record rows and the derived enforcement flags.
+
+Every function here is account scoped. A hold that could be placed on, listed
+with, or released from another account's records would be worse than no hold
+at all, so the account id is a required argument on every call rather than
+something a caller may pass.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    LegalHold,
+)
+
+
+def get(db: Session, *, account_id: Any, hold_id: UUID) -> Optional[LegalHold]:
+    """One hold, never outside the account that owns it."""
+    return db.execute(
+        select(LegalHold).where(
+            LegalHold.id == hold_id,
+            LegalHold.account_id == str(account_id),
+        )
+    ).scalar_one_or_none()
+
+
+def get_active(
+    db: Session, *, account_id: Any, resource_type: str, resource_id: str
+) -> Optional[LegalHold]:
+    """The active hold on one resource, if there is one."""
+    return db.execute(
+        select(LegalHold).where(
+            LegalHold.account_id == str(account_id),
+            LegalHold.resource_type == resource_type,
+            LegalHold.resource_id == str(resource_id),
+            LegalHold.released_at.is_(None),
+        )
+    ).scalar_one_or_none()
+
+
+def list_for_account(
+    db: Session,
+    *,
+    account_id: Any,
+    active_only: bool = False,
+    resource_type: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[LegalHold]:
+    """Holds for one account, newest first."""
+    stmt = select(LegalHold).where(LegalHold.account_id == str(account_id))
+    if active_only:
+        stmt = stmt.where(LegalHold.released_at.is_(None))
+    if resource_type:
+        stmt = stmt.where(LegalHold.resource_type == resource_type)
+    stmt = stmt.order_by(LegalHold.placed_at.desc()).offset(skip).limit(limit)
+    return list(db.execute(stmt).scalars().all())
+
+
+def active_resource_ids(
+    db: Session, *, account_id: Any, resource_type: str
+) -> set[str]:
+    """Resource ids under an active hold, for recomputing derived flags."""
+    rows = db.execute(
+        select(LegalHold.resource_id).where(
+            LegalHold.account_id == str(account_id),
+            LegalHold.resource_type == resource_type,
+            LegalHold.released_at.is_(None),
+        )
+    ).scalars()
+    return {str(value) for value in rows}
+
+
+def create(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: str,
+    reason: str,
+    placed_by_user_id: Optional[UUID],
+    placed_at: datetime,
+    commit: bool = False,
+) -> LegalHold:
+    """Insert the hold record. The caller sets the derived flags."""
+    hold = LegalHold(
+        account_id=str(account_id),
+        resource_type=resource_type,
+        resource_id=str(resource_id),
+        reason=reason,
+        placed_by_user_id=placed_by_user_id,
+        placed_at=placed_at,
+    )
+    db.add(hold)
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    else:
+        db.flush()
+    return hold
+
+
+def release(
+    db: Session,
+    *,
+    hold: LegalHold,
+    released_by_user_id: Optional[UUID],
+    released_at: datetime,
+    release_reason: str,
+    commit: bool = False,
+) -> LegalHold:
+    """Mark the hold released. The caller recomputes the derived flags."""
+    hold.released_at = released_at
+    hold.released_by_user_id = released_by_user_id
+    hold.release_reason = release_reason
+    db.add(hold)
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    else:
+        db.flush()
+    return hold
+
+
+def set_execution_flag(
+    db: Session, *, account_id: Any, execution_id: Any, held: bool
+) -> int:
+    """Set the flag on one execution. Returns rows touched (0 or 1)."""
+    result = db.execute(
+        update(FlowExecution)
+        .where(
+            FlowExecution.id == execution_id,
+            FlowExecution.account_id == account_id,
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_approval_flag(
+    db: Session, *, account_id: Any, approval_id: Any, held: bool
+) -> int:
+    """Set the flag on one approval request."""
+    result = db.execute(
+        update(ApprovalRequest)
+        .where(
+            ApprovalRequest.id == approval_id,
+            ApprovalRequest.account_id == account_id,
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_artifact_flag(
+    db: Session, *, account_id: Any, artifact_id: Any, held: bool
+) -> int:
+    """Set the flag on one evidence pack row."""
+    result = db.execute(
+        update(FlowArtifact)
+        .where(
+            FlowArtifact.id == artifact_id,
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.kind == "evidence",
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_execution_evidence_flags(
+    db: Session, *, account_id: Any, execution_id: Any, held: bool
+) -> int:
+    """Cascade a hold to every evidence pack of one execution.
+
+    Freezing a run and letting its evidence expire on the operational window
+    would be a hold in name only, so the execution hold reaches the packs.
+    When clearing, packs that carry their own active pack-level hold are left
+    alone by the caller (see services/legal_hold.py).
+    """
+    result = db.execute(
+        update(FlowArtifact)
+        .where(
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.execution_id == execution_id,
+            FlowArtifact.kind == "evidence",
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def execution_artifact_ids(
+    db: Session, *, account_id: Any, execution_id: Any
+) -> Sequence[UUID]:
+    """Evidence pack ids belonging to one execution."""
+    return list(
+        db.execute(
+            select(FlowArtifact.id).where(
+                FlowArtifact.account_id == account_id,
+                FlowArtifact.execution_id == execution_id,
+                FlowArtifact.kind == "evidence",
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+RESOURCE_FLAG_SETTERS = {
+    HOLD_RESOURCE_EXECUTION: set_execution_flag,
+    HOLD_RESOURCE_APPROVAL: set_approval_flag,
+    HOLD_RESOURCE_EVIDENCE_PACK: set_artifact_flag,
+}

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -30,6 +30,13 @@ from .issue_compliance_result import IssueComplianceResult
 from .plan import Plan, Subscription, MonthlyUsage
 from .issue_relationship import IssueRelationship
 from .issue_set import IssueSet
+from .legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_TYPES,
+    LegalHold,
+)
 from .managed_agent import ManagedAgent
 from .managed_agent_ai_model_binding import ManagedAgentAIModelBinding
 from .managed_agent_credential import ManagedAgentCredential
@@ -139,6 +146,11 @@ __all__ = [
     "MonthlyUsage",
     "IssueRelationship",
     "IssueSet",
+    "LegalHold",
+    "HOLD_RESOURCE_APPROVAL",
+    "HOLD_RESOURCE_EVIDENCE_PACK",
+    "HOLD_RESOURCE_EXECUTION",
+    "HOLD_RESOURCE_TYPES",
     "ManagedAgent",
     "ManagedAgentAIModelBinding",
     "ManagedAgentCredential",

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
 from sqlalchemy import (
+    Boolean,
     String,
     DateTime,
     Text,
@@ -14,6 +15,7 @@ from sqlalchemy import (
     Index,
     inspect,
     text,
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -338,6 +340,19 @@ class ApprovalRequest(Base):
         nullable=True,
         index=True,
         comment="The ApprovalBypass that auto-approved this request",
+    )
+
+    # Derived legal-hold enforcement flag (see models/legal_hold.py). The
+    # account-visible record with actor and reason is a legal_hold row; this
+    # column is what the retention purge tests so a batch DELETE stays a
+    # single table query.
+    legal_hold: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa_false(),
+        index=True,
+        comment="True while a legal hold blocks this approval from purge",
     )
 
     # Relationships

--- a/backend/preloop/models/models/flow_artifact.py
+++ b/backend/preloop/models/models/flow_artifact.py
@@ -1,6 +1,14 @@
 """Encrypted hosted recovery artifacts, isolated by account, flow and thread."""
 
-from sqlalchemy import Column, DateTime, ForeignKey, LargeBinary, String
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    LargeBinary,
+    String,
+    false as sa_false,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from .base import Base
@@ -36,3 +44,10 @@ class FlowArtifact(Base):
     expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
     lease_until = Column(DateTime(timezone=True), nullable=True)
     availability = Column(String(20), nullable=False, default="available")
+    # Derived legal-hold enforcement flag (see models/legal_hold.py). While
+    # true the janitor leaves the ciphertext alone past expires_at and the
+    # retention purge leaves the row alone: a held pack must still be
+    # downloadable, so the hold blocks payload expiry, not just deletion.
+    legal_hold = Column(
+        Boolean, nullable=False, server_default=sa_false(), default=False, index=True
+    )

--- a/backend/preloop/models/models/flow_execution.py
+++ b/backend/preloop/models/models/flow_execution.py
@@ -3,6 +3,7 @@ from datetime import datetime, UTC
 from typing import Optional
 
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     ForeignKey,
@@ -11,6 +12,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, query_expression, relationship
@@ -141,8 +143,16 @@ class FlowExecution(Base):
     evidence_archive = Column(LargeBinary, nullable=True)
     # Availability/retention receipt for captured evidence. Small JSON so a
     # release consumer can distinguish available / missing / expired / failed
-    # without downloading the pack. Not a legal-hold claim.
+    # without downloading the pack. The legal_hold field it carries is the
+    # artifact's own flag, not a storage-layer object-lock claim.
     evidence_receipt = Column(JSONB, nullable=True)
+    # Derived legal-hold enforcement flag. The account-visible record (actor,
+    # reason, release) is a legal_hold row; this column is what the retention
+    # purge tests, in the same transaction, so a batch DELETE stays a single
+    # table query. A hold here also covers this execution's evidence packs.
+    legal_hold = Column(
+        Boolean, nullable=False, server_default=sa_false(), default=False, index=True
+    )
     # Workspace snapshot (tar.gz of /workspace, .git included) captured by the
     # runner on every terminal path so work that was never pushed survives the
     # container. Size-capped at capture time

--- a/backend/preloop/models/models/legal_hold.py
+++ b/backend/preloop/models/models/legal_hold.py
@@ -1,0 +1,129 @@
+"""Legal hold: the record of who froze what, why, and when it was released.
+
+A hold is two things and they are deliberately kept apart.
+
+The **row** in this table is the account-visible fact: an actor, a reason, a
+timestamp, and a release with its own actor and reason. That is what a
+regulator or a customer's counsel actually asks for, and it is why ``reason``
+is NOT NULL: a hold nobody can explain is indistinguishable from a bug.
+
+The **boolean** on ``flow_execution``, ``approval_request`` and
+``flow_artifact`` is derived enforcement state, written in the same
+transaction as the row. The purge and the evidence janitor are batch UPDATEs
+and DELETEs over single tables; making them join a hold table on every pass
+would be the wrong shape for the hot path and would make "did the purge miss a
+held row?" a question about a join rather than about a column. Release
+recomputes the boolean from whatever active holds remain, so two overlapping
+holds cannot be lifted by releasing one.
+
+A hold on an execution covers that execution's evidence packs too. Freezing a
+run and leaving its evidence to expire in thirty days would be a hold in name
+only.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import DateTime
+
+from .base import Base
+
+#: A flow execution. Cascades to that execution's evidence artifacts.
+HOLD_RESOURCE_EXECUTION = "execution"
+#: One approval request.
+HOLD_RESOURCE_APPROVAL = "approval"
+#: One evidence pack (a ``flow_artifact`` row of kind ``evidence``).
+HOLD_RESOURCE_EVIDENCE_PACK = "evidence_pack"
+
+HOLD_RESOURCE_TYPES: tuple[str, ...] = (
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+)
+
+
+class LegalHold(Base):
+    """One hold placed on one resource, with its actor, reason and release."""
+
+    __tablename__ = "legal_hold"
+    __table_args__ = (
+        # One *active* hold per resource. Two teams asking for the same freeze
+        # is one freeze; the durable control is here rather than in a service
+        # check that concurrent callers can race past.
+        Index(
+            "uq_legal_hold_active_resource",
+            "account_id",
+            "resource_type",
+            "resource_id",
+            unique=True,
+            postgresql_where=text("released_at IS NULL"),
+        ),
+        Index("ix_legal_hold_account_released", "account_id", "released_at"),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    resource_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="execution | approval | evidence_pack",
+    )
+    resource_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Identifier of the held resource within this account",
+    )
+    reason: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Why the records are frozen. Mandatory: an unexplained hold "
+        "is indistinguishable from a bug.",
+    )
+    # ON DELETE SET NULL, like approval attribution: removing a user must not
+    # erase the fact that a hold was placed.
+    placed_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    placed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    released_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    released_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    release_reason: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Why the hold was lifted",
+    )
+
+    @property
+    def active(self) -> bool:
+        """True while the hold still blocks purge and payload expiry."""
+        return self.released_at is None
+
+    def __repr__(self) -> str:
+        """Describe the hold without a lazy load."""
+        state = "active" if self.released_at is None else "released"
+        return (
+            f"<LegalHold {self.resource_type}:{self.resource_id} {state} "
+            f"placed_at={self.placed_at}>"
+        )

--- a/backend/preloop/schemas/retention.py
+++ b/backend/preloop/schemas/retention.py
@@ -1,0 +1,147 @@
+"""Schemas for retention settings, legal holds and period exports."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from preloop.models.models.legal_hold import HOLD_RESOURCE_TYPES
+from preloop.services.legal_hold import MAX_REASON_CHARS, MIN_REASON_CHARS
+from preloop.services.retention_policy import RECORD_CLASSES
+
+
+class RetentionClassRead(BaseModel):
+    """Resolved retention for one record class."""
+
+    record_class: str
+    label: str
+    days: int
+    source: str = Field(
+        ..., description="'account' when this account set it, 'default' otherwise"
+    )
+    floored: bool = Field(
+        False, description="True when the stored value was raised to meet the floor"
+    )
+
+
+class RetentionSettingsRead(BaseModel):
+    """Everything the console needs to render the retention panel."""
+
+    floor_days: int = Field(
+        ..., description="No record class can be set below this many days"
+    )
+    default_days: int = Field(
+        ..., description="Applied to any class this account has not set"
+    )
+    max_days: int
+    classes: List[RetentionClassRead]
+    purge_enabled: bool = Field(
+        ...,
+        description=(
+            "False when this deployment never deletes. Retention is then a "
+            "stated policy that nothing enforces."
+        ),
+    )
+    purge_dry_run: bool
+    purge_window_utc: Optional[str] = Field(
+        None, description="Off-peak UTC hour window the purge runs in, e.g. '1-5'"
+    )
+    evidence_payload_hours: int = Field(
+        ...,
+        description=(
+            "How long encrypted evidence payloads are kept. Separate from the "
+            "'evidence' record class, which governs the record row."
+        ),
+    )
+
+
+class RetentionSettingsUpdate(BaseModel):
+    """Full desired state. An omitted class falls back to the default."""
+
+    classes: Dict[str, Optional[int]] = Field(
+        default_factory=dict,
+        description=(
+            "Record class to days. null clears the account's setting for that "
+            f"class. Known classes: {', '.join(RECORD_CLASSES)}"
+        ),
+    )
+
+    @field_validator("classes")
+    @classmethod
+    def _known_classes(
+        cls, value: Dict[str, Optional[int]]
+    ) -> Dict[str, Optional[int]]:
+        """Refuse an unknown class instead of dropping it silently."""
+        unknown = sorted(set(value) - set(RECORD_CLASSES))
+        if unknown:
+            raise ValueError(
+                f"unknown record classes: {', '.join(unknown)}. "
+                f"Known: {', '.join(RECORD_CLASSES)}"
+            )
+        return value
+
+
+class LegalHoldCreate(BaseModel):
+    """Place a hold on one execution, approval or evidence pack."""
+
+    resource_type: str = Field(
+        ..., description=f"One of {', '.join(HOLD_RESOURCE_TYPES)}"
+    )
+    resource_id: str = Field(..., max_length=255)
+    reason: str = Field(
+        ...,
+        min_length=MIN_REASON_CHARS,
+        max_length=MAX_REASON_CHARS,
+        description="Why this record is frozen. Written to the audit log.",
+    )
+
+    @field_validator("resource_type")
+    @classmethod
+    def _known_type(cls, value: str) -> str:
+        if value not in HOLD_RESOURCE_TYPES:
+            raise ValueError(
+                f"resource_type must be one of {', '.join(HOLD_RESOURCE_TYPES)}"
+            )
+        return value
+
+
+class LegalHoldRelease(BaseModel):
+    """Lift a hold. The release reason is recorded too."""
+
+    reason: str = Field(
+        ...,
+        min_length=MIN_REASON_CHARS,
+        max_length=MAX_REASON_CHARS,
+        description="Why the hold is being lifted. Written to the audit log.",
+    )
+
+
+class LegalHoldRead(BaseModel):
+    """One hold, active or released."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    resource_type: str
+    resource_id: str
+    reason: str
+    placed_by_user_id: Optional[UUID] = None
+    placed_at: Optional[datetime] = None
+    released_by_user_id: Optional[UUID] = None
+    released_at: Optional[datetime] = None
+    release_reason: Optional[str] = None
+    active: bool
+    #: Rows whose enforcement flag the place or release call moved, per table.
+    flagged: Optional[Dict[str, int]] = None
+
+
+class RetentionPurgePreview(BaseModel):
+    """What a purge would remove right now, without removing it."""
+
+    account_id: UUID
+    purge_enabled: bool
+    classes: List[Dict[str, Any]]
+    total: int

--- a/backend/preloop/services/flow_artifacts.py
+++ b/backend/preloop/services/flow_artifacts.py
@@ -190,8 +190,15 @@ def evidence_receipt(
         "created_at": created,
         "expires_at": expires,
         "retention_hours": artifact_retention_hours("evidence"),
+        # object_lock stays false because Preloop does not assert it. It is a
+        # storage-layer property the operator configures (S3 Object Lock, a
+        # WORM volume) and the control plane has no way to verify it.
         "object_lock": False,
-        "legal_hold": False,
+        # legal_hold is now a real fact about this row rather than a constant:
+        # true means a legal_hold record freezes the pack, so the janitor
+        # leaves the ciphertext alone past expires_at and the retention purge
+        # leaves the row alone.
+        "legal_hold": bool(getattr(artifact, "legal_hold", False)),
         "integrity_verified": integrity_verified,
         "error": error,
     }
@@ -376,6 +383,11 @@ def _mark_status_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     """Availability metadata for polls; never a verified-download claim."""
     status = str(receipt.get("status") or "missing")
     expires = receipt.get("expires_at")
+    # A held pack does not expire on the poll path either. The hold service
+    # stamps this key on the persisted receipt when it freezes a pack, so the
+    # cheap status poll and the live inspect agree.
+    if receipt.get("legal_hold"):
+        expires = None
     if status == "available" and expires:
         try:
             exp = datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
@@ -428,7 +440,14 @@ def public_evidence_status(execution: Any) -> dict[str, Any]:
 def _receipt_for_artifact(execution: Any, artifact: Any) -> dict[str, Any]:
     """Build a receipt from a scoped evidence row's current availability."""
     now = datetime.now(UTC)
-    expired = artifact.expires_at <= now or artifact.ciphertext is None
+    # A held pack whose bytes are still there is available, whatever the
+    # operational expiry says: the hold is what stopped the janitor from
+    # taking them, so reporting "expired" would contradict the download.
+    held = bool(getattr(artifact, "legal_hold", False))
+    if held and artifact.ciphertext is not None:
+        expired = False
+    else:
+        expired = artifact.expires_at <= now or artifact.ciphertext is None
     status = "expired" if expired else str(artifact.availability or "available")
     if status not in {"available", "expired", "failed"}:
         status = "expired" if expired else "available"

--- a/backend/preloop/services/legal_hold.py
+++ b/backend/preloop/services/legal_hold.py
@@ -1,0 +1,391 @@
+"""Place and release legal holds, and answer "is this held?".
+
+A legal hold is the answer to "counsel says nothing about this incident may be
+deleted while the matter is open". Before this, the honest answer in the
+evidence storage guide was that ``legal_hold`` is always false, and the
+30 day operational evidence window applied to a run under investigation
+exactly as it applied to a run nobody would ever look at again.
+
+Two things happen when a hold is placed, in one transaction:
+
+1. a ``legal_hold`` record with the actor and the mandatory reason, and
+2. the derived boolean on the held rows, which is what the purge and the
+   evidence janitor actually test.
+
+Both the placement and the release are written to the audit log, because a
+hold that can be lifted without a trace is a hold whose absence proves
+nothing.
+
+Release does not blindly clear the boolean. An evidence pack can be covered by
+its own pack-level hold and by a hold on its execution at the same time;
+lifting one must leave the other in force, so the flag is recomputed from the
+holds that remain active.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_audit_log
+from preloop.models.crud import legal_hold as crud
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_TYPES,
+    LegalHold,
+)
+
+logger = logging.getLogger(__name__)
+
+AUDIT_ACTION_PLACED = "legal_hold_placed"
+AUDIT_ACTION_RELEASED = "legal_hold_released"
+
+#: A reason is the whole point of the record. One word is not a reason, and a
+#: novel pasted into an audit row is a different problem.
+MIN_REASON_CHARS = 8
+MAX_REASON_CHARS = 2000
+
+
+class LegalHoldError(ValueError):
+    """A hold could not be placed or released as asked."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class HoldOutcome:
+    """What a place or release call actually changed."""
+
+    hold: LegalHold
+    #: Rows whose derived flag this call moved, per table.
+    flagged: dict[str, int]
+
+
+def _clean_reason(reason: Any) -> str:
+    text = str(reason or "").strip()
+    if len(text) < MIN_REASON_CHARS:
+        raise LegalHoldError(
+            "reason_required",
+            f"a legal hold reason of at least {MIN_REASON_CHARS} characters is "
+            "required; the record exists to explain why the data is frozen",
+        )
+    return text[:MAX_REASON_CHARS]
+
+
+def _coerce_uuid(resource_id: Any) -> UUID:
+    try:
+        return UUID(str(resource_id))
+    except (TypeError, ValueError) as exc:
+        raise LegalHoldError(
+            "resource_not_found", "the resource id is not a valid identifier"
+        ) from exc
+
+
+def _require_resource(
+    db: Session, *, account_id: Any, resource_type: str, resource_id: str
+) -> UUID:
+    """Refuse a hold on something this account does not own.
+
+    A hold on a nonexistent id would look active in a listing and freeze
+    nothing, which is the failure mode a hold exists to prevent.
+    """
+    if resource_type not in HOLD_RESOURCE_TYPES:
+        raise LegalHoldError(
+            "unknown_resource_type",
+            f"resource_type must be one of {', '.join(HOLD_RESOURCE_TYPES)}",
+        )
+    identifier = _coerce_uuid(resource_id)
+    model = {
+        HOLD_RESOURCE_EXECUTION: FlowExecution,
+        HOLD_RESOURCE_APPROVAL: ApprovalRequest,
+        HOLD_RESOURCE_EVIDENCE_PACK: FlowArtifact,
+    }[resource_type]
+    stmt = select(model.id).where(
+        model.id == identifier, model.account_id == account_id
+    )
+    if resource_type == HOLD_RESOURCE_EVIDENCE_PACK:
+        stmt = stmt.where(FlowArtifact.kind == "evidence")
+    if db.execute(stmt).scalar_one_or_none() is None:
+        raise LegalHoldError(
+            "resource_not_found",
+            f"no {resource_type} {resource_id} in this account",
+        )
+    return identifier
+
+
+def _stamp_evidence_receipts(
+    db: Session, *, account_id: Any, execution_ids: Sequence[Any], held: bool
+) -> int:
+    """Mirror the hold onto the persisted evidence receipt of each execution.
+
+    ``GET .../evidence-status`` answers from ``flow_execution.evidence_receipt``
+    without touching ciphertext, and it downgrades an ``available`` receipt to
+    ``expired`` once ``expires_at`` has passed. A held pack whose bytes the
+    janitor was told to leave alone would otherwise poll as expired and
+    download fine, which is exactly the contradiction the receipt exists to
+    avoid.
+    """
+    if not execution_ids:
+        return 0
+    rows = (
+        db.execute(
+            select(FlowExecution).where(
+                FlowExecution.account_id == account_id,
+                FlowExecution.id.in_(list(execution_ids)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stamped = 0
+    for execution in rows:
+        receipt = execution.evidence_receipt
+        if not isinstance(receipt, dict):
+            continue
+        if bool(receipt.get("legal_hold")) == held:
+            continue
+        updated = dict(receipt)
+        updated["legal_hold"] = held
+        execution.evidence_receipt = updated
+        db.add(execution)
+        stamped += 1
+    return stamped
+
+
+def _apply_flags(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: UUID,
+    held: bool,
+) -> dict[str, int]:
+    """Set (or recompute) the derived flags for one hold's resource."""
+    flagged: dict[str, int] = {}
+    if resource_type == HOLD_RESOURCE_EXECUTION:
+        flagged["flow_execution"] = crud.set_execution_flag(
+            db, account_id=account_id, execution_id=resource_id, held=held
+        )
+        flagged["evidence_receipt"] = _stamp_evidence_receipts(
+            db, account_id=account_id, execution_ids=[resource_id], held=held
+        )
+        if held:
+            flagged["flow_artifact"] = crud.set_execution_evidence_flags(
+                db, account_id=account_id, execution_id=resource_id, held=True
+            )
+        else:
+            # Clearing: a pack that carries its own active pack-level hold
+            # keeps its flag. Two overlapping holds, one released, still one
+            # frozen pack.
+            still_held = crud.active_resource_ids(
+                db, account_id=account_id, resource_type=HOLD_RESOURCE_EVIDENCE_PACK
+            )
+            cleared = 0
+            for artifact_id in crud.execution_artifact_ids(
+                db, account_id=account_id, execution_id=resource_id
+            ):
+                if str(artifact_id) in still_held:
+                    continue
+                cleared += crud.set_artifact_flag(
+                    db, account_id=account_id, artifact_id=artifact_id, held=False
+                )
+            flagged["flow_artifact"] = cleared
+    elif resource_type == HOLD_RESOURCE_APPROVAL:
+        flagged["approval_request"] = crud.set_approval_flag(
+            db, account_id=account_id, approval_id=resource_id, held=held
+        )
+    else:
+        execution_id = db.execute(
+            select(FlowArtifact.execution_id).where(
+                FlowArtifact.id == resource_id,
+                FlowArtifact.account_id == account_id,
+            )
+        ).scalar_one_or_none()
+        if not held:
+            # The pack may still sit under an execution-level hold.
+            covering = crud.active_resource_ids(
+                db, account_id=account_id, resource_type=HOLD_RESOURCE_EXECUTION
+            )
+            if execution_id is not None and str(execution_id) in covering:
+                return {"flow_artifact": 0}
+        flagged["flow_artifact"] = crud.set_artifact_flag(
+            db, account_id=account_id, artifact_id=resource_id, held=held
+        )
+        flagged["evidence_receipt"] = _stamp_evidence_receipts(
+            db,
+            account_id=account_id,
+            execution_ids=[execution_id] if execution_id is not None else [],
+            held=held,
+        )
+    return flagged
+
+
+def place_hold(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: str,
+    reason: str,
+    user_id: Optional[UUID] = None,
+    now: Optional[datetime] = None,
+    commit: bool = True,
+) -> HoldOutcome:
+    """Freeze one resource. Record, flags and audit row in one transaction."""
+    cleaned_reason = _clean_reason(reason)
+    identifier = _require_resource(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+    existing = crud.get_active(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+    )
+    if existing is not None:
+        raise LegalHoldError(
+            "already_held",
+            f"{resource_type} {identifier} is already under an active legal hold",
+        )
+    stamp = now or datetime.now(UTC)
+    hold = crud.create(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+        reason=cleaned_reason,
+        placed_by_user_id=user_id,
+        placed_at=stamp,
+    )
+    flagged = _apply_flags(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=identifier,
+        held=True,
+    )
+    crud_audit_log.log_action(
+        db,
+        account_id=account_id,
+        user_id=user_id,
+        action=AUDIT_ACTION_PLACED,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+        status="success",
+        details={
+            "hold_id": str(hold.id),
+            "reason": cleaned_reason,
+            "flagged": flagged,
+        },
+        commit=False,
+    )
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    logger.info(
+        "Legal hold placed on %s %s (%s rows flagged)",
+        resource_type,
+        identifier,
+        sum(flagged.values()),
+    )
+    return HoldOutcome(hold=hold, flagged=flagged)
+
+
+def release_hold(
+    db: Session,
+    *,
+    account_id: Any,
+    hold_id: UUID,
+    reason: str,
+    user_id: Optional[UUID] = None,
+    now: Optional[datetime] = None,
+    commit: bool = True,
+) -> HoldOutcome:
+    """Lift one hold, recording who lifted it and why."""
+    cleaned_reason = _clean_reason(reason)
+    hold = crud.get(db, account_id=account_id, hold_id=hold_id)
+    if hold is None:
+        raise LegalHoldError("hold_not_found", f"no legal hold {hold_id}")
+    if hold.released_at is not None:
+        raise LegalHoldError(
+            "already_released", f"legal hold {hold_id} was already released"
+        )
+    stamp = now or datetime.now(UTC)
+    crud.release(
+        db,
+        hold=hold,
+        released_by_user_id=user_id,
+        released_at=stamp,
+        release_reason=cleaned_reason,
+    )
+    # The record is released first so the recompute below sees the remaining
+    # active holds, not this one.
+    flagged = _apply_flags(
+        db,
+        account_id=account_id,
+        resource_type=hold.resource_type,
+        resource_id=_coerce_uuid(hold.resource_id),
+        held=False,
+    )
+    crud_audit_log.log_action(
+        db,
+        account_id=account_id,
+        user_id=user_id,
+        action=AUDIT_ACTION_RELEASED,
+        resource_type=hold.resource_type,
+        resource_id=str(hold.resource_id),
+        status="success",
+        details={
+            "hold_id": str(hold.id),
+            "reason": cleaned_reason,
+            "placed_reason": hold.reason,
+            "flagged": flagged,
+        },
+        commit=False,
+    )
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    logger.info(
+        "Legal hold %s released on %s %s",
+        hold_id,
+        hold.resource_type,
+        hold.resource_id,
+    )
+    return HoldOutcome(hold=hold, flagged=flagged)
+
+
+def hold_summary(hold: LegalHold) -> dict[str, Any]:
+    """Serializable view of one hold for API responses and exports."""
+    return {
+        "id": str(hold.id),
+        "resource_type": hold.resource_type,
+        "resource_id": hold.resource_id,
+        "reason": hold.reason,
+        "placed_by_user_id": (
+            str(hold.placed_by_user_id) if hold.placed_by_user_id else None
+        ),
+        "placed_at": hold.placed_at.isoformat() if hold.placed_at else None,
+        "released_by_user_id": (
+            str(hold.released_by_user_id) if hold.released_by_user_id else None
+        ),
+        "released_at": hold.released_at.isoformat() if hold.released_at else None,
+        "release_reason": hold.release_reason,
+        "active": hold.released_at is None,
+    }

--- a/backend/preloop/services/legal_hold.py
+++ b/backend/preloop/services/legal_hold.py
@@ -113,9 +113,15 @@ def _require_resource(
         HOLD_RESOURCE_APPROVAL: ApprovalRequest,
         HOLD_RESOURCE_EVIDENCE_PACK: FlowArtifact,
     }[resource_type]
-    stmt = select(model.id).where(
-        model.id == identifier, model.account_id == account_id
-    )
+    if resource_type == HOLD_RESOURCE_EXECUTION:
+        # An execution is owned through its flow, not by a column of its own.
+        stmt = select(FlowExecution.id).where(
+            FlowExecution.id == identifier, crud.execution_in_account(account_id)
+        )
+    else:
+        stmt = select(model.id).where(
+            model.id == identifier, model.account_id == account_id
+        )
     if resource_type == HOLD_RESOURCE_EVIDENCE_PACK:
         stmt = stmt.where(FlowArtifact.kind == "evidence")
     if db.execute(stmt).scalar_one_or_none() is None:
@@ -143,7 +149,7 @@ def _stamp_evidence_receipts(
     rows = (
         db.execute(
             select(FlowExecution).where(
-                FlowExecution.account_id == account_id,
+                crud.execution_in_account(account_id),
                 FlowExecution.id.in_(list(execution_ids)),
             )
         )

--- a/backend/preloop/services/retention_export.py
+++ b/backend/preloop/services/retention_export.py
@@ -1,0 +1,406 @@
+"""Period export: audit rows, approvals and evidence receipts as one archive.
+
+The purpose is narrow and worth stating. Retention plus a purge means records
+eventually go. A customer whose obligation outlives our retention, or who
+simply wants their compliance evidence somewhere we cannot reach, needs to be
+able to take the period away with them and prove later that what they kept is
+what they were given. That is the whole feature: a tar with the rows, a
+manifest that names and digests every member, and a digest over the manifest's
+member list.
+
+The manifest deliberately reuses the shape #511 gave evidence packs
+(:func:`preloop.cra.evidence_pack.build_pack_manifest`): same ``members``
+entries, same ``members_digest`` computed over the same canonical JSON. Two
+manifest formats for the same idea would be one format too many, and #558
+(signed exports and the audit hash chain) then has one thing to sign.
+
+What this is not: it is not signed, and the digests prove that the archive was
+not altered after we built it, not that the rows were true when they were
+written. #558 is the issue for provenance. Saying so here is cheaper than
+having someone infer it.
+
+Bounded on purpose: ``RETENTION_EXPORT_MAX_ROWS`` per record class, and going
+over is an error telling the caller to narrow the period. A compliance export
+that silently drops the rows past a limit is worse than no export.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import tarfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Iterable, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models.crud import crud_audit_log
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.legal_hold import LegalHold
+from preloop.services.legal_hold import hold_summary
+from preloop.services.retention_policy import RECORD_CLASSES, resolve_retention
+
+logger = logging.getLogger(__name__)
+
+EXPORT_MANIFEST_SCHEMA = "preloop.retention.period_export_manifest/v1"
+EXPORT_MANIFEST_NAME = "manifest.json"
+
+MEMBER_AUDIT = "audit/audit_log.jsonl"
+MEMBER_APPROVALS = "approvals/approval_request.jsonl"
+MEMBER_EVIDENCE = "evidence/receipts.jsonl"
+MEMBER_HOLDS = "holds/legal_hold.jsonl"
+
+AUDIT_ACTION_EXPORT = "retention_period_export"
+
+
+class PeriodExportError(ValueError):
+    """The requested period cannot be exported as asked."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class PeriodExport:
+    """One built archive and the manifest that describes it."""
+
+    archive: bytes
+    manifest: dict[str, Any]
+    counts: dict[str, int]
+
+    @property
+    def sha256(self) -> str:
+        """Digest of the archive bytes as served."""
+        return hashlib.sha256(self.archive).hexdigest()
+
+    @property
+    def filename(self) -> str:
+        """Stable, sortable download name."""
+        period = self.manifest.get("period") or {}
+        start = str(period.get("start") or "")[:10]
+        end = str(period.get("end") or "")[:10]
+        return f"preloop-period-export-{start}-to-{end}.tar.gz"
+
+
+def _iso(value: Any) -> Optional[str]:
+    """ISO 8601 for a datetime, passthrough for anything already a string."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _max_rows() -> int:
+    return max(1, int(settings.retention_export_max_rows))
+
+
+def _fetch(db: Session, stmt) -> list[Any]:
+    """Read one class, refusing to truncate.
+
+    One extra row is asked for so "exactly at the limit" and "over the limit"
+    are distinguishable without a second COUNT.
+    """
+    limit = _max_rows()
+    rows = list(db.execute(stmt.limit(limit + 1)).scalars().all())
+    if len(rows) > limit:
+        raise PeriodExportError(
+            "period_too_large",
+            f"the period holds more than {limit} rows for one record class; "
+            "narrow the date range and export it in parts",
+        )
+    return rows
+
+
+def _audit_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(AuditLog)
+        .where(
+            AuditLog.account_id == account_id,
+            AuditLog.timestamp >= start,
+            AuditLog.timestamp < end,
+        )
+        .order_by(AuditLog.timestamp, AuditLog.id)
+    )
+    return [
+        {
+            "id": str(row.id),
+            "timestamp": _iso(row.timestamp),
+            "user_id": str(row.user_id) if row.user_id else None,
+            "action": row.action,
+            "resource_type": row.resource_type,
+            "resource_id": row.resource_id,
+            "status": row.status,
+            "ip_address": row.ip_address,
+            "user_agent": row.user_agent,
+            "details": row.details,
+        }
+        for row in _fetch(db, stmt)
+    ]
+
+
+def _approval_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(ApprovalRequest)
+        .where(
+            ApprovalRequest.account_id == account_id,
+            ApprovalRequest.requested_at >= start,
+            ApprovalRequest.requested_at < end,
+        )
+        .order_by(ApprovalRequest.requested_at, ApprovalRequest.id)
+    )
+    rows = []
+    for row in _fetch(db, stmt):
+        rows.append(
+            {
+                "id": str(row.id),
+                "tool_name": row.tool_name,
+                "status": row.status,
+                "summary": row.summary,
+                "requested_at": _iso(row.requested_at),
+                "resolved_at": _iso(row.resolved_at),
+                "expires_at": _iso(row.expires_at),
+                "execution_id": row.execution_id,
+                "managed_agent_id": (
+                    str(row.managed_agent_id) if row.managed_agent_id else None
+                ),
+                "managed_agent_name": row.managed_agent_name,
+                "runtime_session_id": (
+                    str(row.runtime_session_id) if row.runtime_session_id else None
+                ),
+                "api_key_id": str(row.api_key_id) if row.api_key_id else None,
+                "approver_comment": row.approver_comment,
+                "structured_answer": row.structured_answer,
+                "responses": row.responses,
+                "decided_by_ai": bool(row.decided_by_ai),
+                "ai_model": row.ai_model,
+                "ai_reasoning": row.ai_reasoning,
+                "auto_approved_reason": row.auto_approved_reason,
+                "rule_context": row.rule_context,
+                "legal_hold": bool(row.legal_hold),
+                # tool_args and tool_result are deliberately excluded: they
+                # carry the payload of whatever the agent was about to do,
+                # which is the least predictable content in the record and not
+                # what a retention export is for. The decision, the reason it
+                # was asked for, and who decided are.
+            }
+        )
+    return rows
+
+
+def _evidence_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Evidence *receipts*, never the packs.
+
+    A period bundle that inlined evidence payloads would be unbounded and
+    would duplicate bytes the evidence download already serves under its own
+    digest check. The receipt is the durable claim: which pack, what digest,
+    when it expires, whether it is held.
+    """
+    stmt = (
+        select(FlowArtifact)
+        .where(
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.kind == "evidence",
+            FlowArtifact.created_at >= start,
+            FlowArtifact.created_at < end,
+        )
+        .order_by(FlowArtifact.created_at, FlowArtifact.id)
+    )
+    rows = []
+    for row in _fetch(db, stmt):
+        manifest = row.manifest if isinstance(row.manifest, dict) else {}
+        rows.append(
+            {
+                "artifact_id": str(row.id),
+                "execution_id": str(row.execution_id),
+                "flow_id": str(row.flow_id),
+                "thread_id": row.thread_id,
+                "kind": row.kind,
+                "sha256": manifest.get("sha256"),
+                "manifest_sha256": row.manifest_sha256,
+                "size_bytes": manifest.get("size_bytes"),
+                "expanded_bytes": manifest.get("expanded_bytes"),
+                "created_at": _iso(row.created_at),
+                "expires_at": _iso(row.expires_at),
+                "availability": row.availability,
+                "payload_present": row.ciphertext is not None,
+                "legal_hold": bool(row.legal_hold),
+                # object_lock is not in here at all. Preloop does not assert
+                # it, and an absent field is more honest than a false one.
+            }
+        )
+    return rows
+
+
+def _hold_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Holds placed in the period, so a frozen record is explained in place."""
+    stmt = (
+        select(LegalHold)
+        .where(
+            LegalHold.account_id == account_id,
+            LegalHold.placed_at >= start,
+            LegalHold.placed_at < end,
+        )
+        .order_by(LegalHold.placed_at, LegalHold.id)
+    )
+    return [hold_summary(row) for row in _fetch(db, stmt)]
+
+
+def _jsonl(rows: Iterable[dict[str, Any]]) -> bytes:
+    """One JSON object per line, sorted keys, so a diff is readable."""
+    buffer = io.BytesIO()
+    for row in rows:
+        buffer.write(
+            json.dumps(row, sort_keys=True, default=str, ensure_ascii=False).encode(
+                "utf-8"
+            )
+        )
+        buffer.write(b"\n")
+    return buffer.getvalue()
+
+
+def _member_entry(name: str, body: bytes) -> dict[str, Any]:
+    return {
+        "name": name,
+        "size_bytes": len(body),
+        "sha256": hashlib.sha256(body).hexdigest(),
+    }
+
+
+def _add(tar: tarfile.TarFile, name: str, body: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(body)
+    info.mode = 0o600
+    # Fixed mtime so the same rows produce the same archive bytes twice.
+    info.mtime = 0
+    tar.addfile(info, io.BytesIO(body))
+
+
+def build_period_export(
+    db: Session,
+    *,
+    account: Any,
+    start: datetime,
+    end: datetime,
+    generated_at: Optional[datetime] = None,
+    record_classes: Sequence[str] = RECORD_CLASSES,
+) -> PeriodExport:
+    """Build the archive for one account and one half-open period.
+
+    ``start`` is inclusive and ``end`` exclusive, so consecutive periods tile
+    without a row landing in both bundles or in neither.
+    """
+    if end <= start:
+        raise PeriodExportError("invalid_period", "end must be after start")
+    account_id = account.id
+    bodies: dict[str, bytes] = {}
+    counts: dict[str, int] = {}
+
+    audit = _audit_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_AUDIT] = _jsonl(audit)
+    counts["audit"] = len(audit)
+
+    approvals = _approval_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_APPROVALS] = _jsonl(approvals)
+    counts["approvals"] = len(approvals)
+
+    evidence = _evidence_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_EVIDENCE] = _jsonl(evidence)
+    counts["evidence"] = len(evidence)
+
+    holds = _hold_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_HOLDS] = _jsonl(holds)
+    counts["legal_holds"] = len(holds)
+
+    members = [_member_entry(name, body) for name, body in sorted(bodies.items())]
+    stamp = generated_at or datetime.now(UTC)
+    manifest = {
+        "schema": EXPORT_MANIFEST_SCHEMA,
+        "account_id": str(account_id),
+        "generated_at": stamp.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "period": {
+            "start": start.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "end": end.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "boundary": "start inclusive, end exclusive",
+        },
+        "members": members,
+        # Same computation as the evidence pack manifest, so one verifier
+        # covers both and #558 has one thing to sign.
+        "members_digest": hashlib.sha256(canonical_manifest_json(members)).hexdigest(),
+        "counts": counts,
+        "retention": {
+            record_class: resolve_retention(
+                account.meta_data, record_class=record_class
+            ).days
+            for record_class in record_classes
+        },
+        "note": (
+            "sha256 values cover the members of this archive as packed. This "
+            "bundle is not signed: the digests show the archive was not "
+            "altered after Preloop built it, not that the records were true "
+            "when they were written. Evidence packs are referenced by receipt "
+            "(artifact id and digest), not inlined."
+        ),
+    }
+    manifest_body = canonical_manifest_json(manifest)
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        _add(tar, EXPORT_MANIFEST_NAME, manifest_body)
+        for name, body in sorted(bodies.items()):
+            _add(tar, name, body)
+    return PeriodExport(archive=buffer.getvalue(), manifest=manifest, counts=counts)
+
+
+def audit_period_export(
+    db: Session,
+    *,
+    account_id: Any,
+    user_id: Any,
+    export: PeriodExport,
+) -> None:
+    """Record that the period left the platform, and with what digest.
+
+    An export is a bulk read of an account's compliance record. Who took it,
+    when, for which period, and the digest of what they got are exactly the
+    questions asked afterwards.
+    """
+    period = export.manifest.get("period") or {}
+    try:
+        crud_audit_log.log_action(
+            db,
+            account_id=account_id,
+            user_id=user_id,
+            action=AUDIT_ACTION_EXPORT,
+            resource_type="retention",
+            resource_id="period_export",
+            status="success",
+            details={
+                "period_start": period.get("start"),
+                "period_end": period.get("end"),
+                "counts": export.counts,
+                "archive_sha256": export.sha256,
+                "members_digest": export.manifest.get("members_digest"),
+                "size_bytes": len(export.archive),
+            },
+        )
+    except Exception:
+        db.rollback()
+        logger.error("Failed to audit period export", exc_info=True)

--- a/backend/preloop/services/retention_policy.py
+++ b/backend/preloop/services/retention_policy.py
@@ -1,0 +1,256 @@
+"""Per-record-class retention settings for one account.
+
+The reason this module exists is a floor, not a default. AI Act Art. 26(6)
+asks a deployer to keep automatically generated logs for at least six months,
+and DORA asks for record keeping over a comparable horizon. Before this,
+audit rows, approvals, runtime sessions and usage rows had no retention job at
+all (they lived until the account was purged) and evidence packs had a 30 day
+operational window. "Forever" is not a retention policy any more than "30
+days" is: the first is a liability nobody chose and the second is shorter than
+the obligation.
+
+So an account states, per record class, how long it keeps records, and the
+platform refuses to be told anything under six months.
+
+Precedence, most specific first:
+
+1. ``account.meta_data["retention"][<class>]`` when the account sets one
+2. ``settings.retention_default_days`` (365, twelve months)
+
+and the result is clamped up to the effective floor, which is
+``max(ABSOLUTE_FLOOR_DAYS, settings.retention_floor_days)``. The absolute floor
+is a constant here rather than a setting because the regulation is the reason
+it exists; the setting can only make a deployment stricter. This is the
+mirror image of the account cap in
+:mod:`preloop.services.approval_window`, where an account may only tighten a
+ceiling.
+
+What this module does NOT govern: how long the encrypted evidence payload is
+kept. That stays ``FLOW_EVIDENCE_RETENTION_HOURS`` (30 days by default), an
+operational window sized for review, not for archive. The ``evidence`` record
+class here governs the ``flow_artifact`` row, its manifest and its digest.
+Raising the payload window is a separate, deliberate storage decision, and a
+legal hold pins the payload regardless. Said plainly in
+``docs/guide/flows/evidence-storage.md`` rather than left to be discovered.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from preloop.config import settings
+
+logger = logging.getLogger(__name__)
+
+#: Account metadata bucket holding per-class retention, in whole days.
+RETENTION_KEY = "retention"
+
+#: Six months. Not a setting: this is the obligation the floor exists for.
+#: 183 days is the longest six calendar months, so it cannot round short.
+ABSOLUTE_FLOOR_DAYS = 183
+
+#: Twelve months, used when neither the account nor the deployment says more.
+FALLBACK_DEFAULT_DAYS = 365
+
+#: An account that wants to keep records for longer than this should be
+#: exporting them (see the period export), not asking the platform to hold a
+#: growing table forever. Twenty years is past any retention obligation we
+#: have been shown and still finite.
+MAX_RETENTION_DAYS = 7300
+
+#: Audit rows: permission checks, decisions, retention decisions themselves.
+CLASS_AUDIT = "audit"
+#: Approval requests and their events.
+CLASS_APPROVALS = "approvals"
+#: Evidence pack rows (manifest, digest, receipt metadata), not the payload.
+CLASS_EVIDENCE = "evidence"
+#: Runtime sessions and their activity.
+CLASS_RUNTIME_SESSIONS = "runtime_sessions"
+#: API and gateway usage rows.
+CLASS_USAGE = "usage"
+
+RECORD_CLASSES: tuple[str, ...] = (
+    CLASS_AUDIT,
+    CLASS_APPROVALS,
+    CLASS_EVIDENCE,
+    CLASS_RUNTIME_SESSIONS,
+    CLASS_USAGE,
+)
+
+RECORD_CLASS_LABELS: dict[str, str] = {
+    CLASS_AUDIT: "Audit log rows",
+    CLASS_APPROVALS: "Approval requests and their events",
+    CLASS_EVIDENCE: "Evidence pack records (manifest and digest)",
+    CLASS_RUNTIME_SESSIONS: "Runtime sessions and session activity",
+    CLASS_USAGE: "API and gateway usage rows",
+}
+
+
+class RetentionFloorError(ValueError):
+    """Raised when a requested retention is below the effective floor."""
+
+    def __init__(self, record_class: str, requested_days: int, floor_days: int) -> None:
+        super().__init__(
+            f"retention for {record_class!r} must be at least {floor_days} days "
+            f"(six months); {requested_days} was requested"
+        )
+        self.record_class = record_class
+        self.requested_days = requested_days
+        self.floor_days = floor_days
+
+
+@dataclass(frozen=True)
+class RetentionSetting:
+    """The resolved retention for one record class of one account."""
+
+    record_class: str
+    days: int
+    #: ``account`` when the account set it, ``default`` otherwise.
+    source: str
+    #: True when the stored/requested value was raised to meet the floor.
+    floored: bool = False
+
+    def describe(self) -> str:
+        """Operator-facing sentence naming the setting that produced it."""
+        names = {
+            "account": "this account's retention setting",
+            "default": "the deployment default retention",
+        }
+        text = f"{self.days}d ({names.get(self.source, self.source)})"
+        return f"{text}, raised to the floor" if self.floored else text
+
+
+def floor_days() -> int:
+    """Effective floor: the constant, or a stricter deployment setting."""
+    try:
+        configured = int(settings.retention_floor_days)
+    except (TypeError, ValueError):
+        configured = ABSOLUTE_FLOOR_DAYS
+    return max(ABSOLUTE_FLOOR_DAYS, configured)
+
+
+def default_days() -> int:
+    """Deployment default, never below the floor."""
+    try:
+        configured = int(settings.retention_default_days)
+    except (TypeError, ValueError):
+        configured = FALLBACK_DEFAULT_DAYS
+    if configured <= 0:
+        configured = FALLBACK_DEFAULT_DAYS
+    return max(floor_days(), min(MAX_RETENTION_DAYS, configured))
+
+
+def _coerce_days(value: Any) -> Optional[int]:
+    """Positive int or None. A garbage setting must not decide retention."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return None
+    return days if days > 0 else None
+
+
+def normalize_retention_store(meta_data: Optional[Mapping[str, Any]]) -> dict[str, int]:
+    """Read the account bucket, keeping only known classes and sane values.
+
+    Values are returned as stored. Clamping happens in
+    :func:`resolve_retention`, so a caller can still see that a stored value
+    is under the floor (and the API can refuse to write one).
+    """
+    raw = (meta_data or {}).get(RETENTION_KEY)
+    if not isinstance(raw, Mapping):
+        return {}
+    store: dict[str, int] = {}
+    for record_class in RECORD_CLASSES:
+        days = _coerce_days(raw.get(record_class))
+        if days is not None:
+            store[record_class] = min(MAX_RETENTION_DAYS, days)
+    return store
+
+
+def resolve_retention(
+    meta_data: Optional[Mapping[str, Any]], *, record_class: str
+) -> RetentionSetting:
+    """Retention for one class: the account's value, floored, else the default."""
+    if record_class not in RECORD_CLASSES:
+        raise ValueError(f"unknown record class {record_class!r}")
+    minimum = floor_days()
+    stored = normalize_retention_store(meta_data).get(record_class)
+    if stored is None:
+        return RetentionSetting(
+            record_class=record_class, days=default_days(), source="default"
+        )
+    days = max(minimum, stored)
+    if days != stored:
+        # Reachable when the deployment raised its floor after the account
+        # chose, or when a row was written by hand. The floor wins; it is the
+        # only reason this module exists.
+        logger.info(
+            "Retention %sd for %s raised to the %sd floor",
+            stored,
+            record_class,
+            days,
+        )
+    return RetentionSetting(
+        record_class=record_class,
+        days=days,
+        source="account",
+        floored=days != stored,
+    )
+
+
+def resolve_all(meta_data: Optional[Mapping[str, Any]]) -> dict[str, RetentionSetting]:
+    """Resolved retention for every record class."""
+    return {
+        record_class: resolve_retention(meta_data, record_class=record_class)
+        for record_class in RECORD_CLASSES
+    }
+
+
+def validate_retention_request(values: Mapping[str, Any]) -> dict[str, int]:
+    """Sanitize an API payload, refusing anything under the floor.
+
+    A value of ``None`` clears the account's setting for that class (it falls
+    back to the deployment default, which is itself at or above the floor).
+    Unknown classes are refused rather than ignored: silently dropping a key
+    the caller named would let an operator believe they had set something.
+    """
+    minimum = floor_days()
+    cleaned: dict[str, int] = {}
+    for key, value in values.items():
+        if key not in RECORD_CLASSES:
+            raise ValueError(f"unknown record class {key!r}")
+        if value is None:
+            continue
+        days = _coerce_days(value)
+        if days is None:
+            raise ValueError(f"retention for {key!r} must be a positive number of days")
+        if days < minimum:
+            raise RetentionFloorError(key, days, minimum)
+        cleaned[key] = min(MAX_RETENTION_DAYS, days)
+    return cleaned
+
+
+def set_retention(
+    meta_data: Optional[Mapping[str, Any]],
+    *,
+    values: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return account metadata with the retention bucket replaced.
+
+    ``values`` is the full desired state: a class the caller omits or sets to
+    ``None`` goes back to the deployment default. Every other metadata key is
+    left untouched, because this bucket shares ``meta_data`` with subject
+    governance and the approval window cap.
+    """
+    cleaned = validate_retention_request(values)
+    updated = deepcopy(dict(meta_data or {}))
+    if cleaned:
+        updated[RETENTION_KEY] = cleaned
+    else:
+        updated.pop(RETENTION_KEY, None)
+    return updated

--- a/backend/preloop/services/retention_purge.py
+++ b/backend/preloop/services/retention_purge.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session
 
 from preloop.config import settings
 from preloop.models.crud import crud_audit_log
+from preloop.models.crud.legal_hold import execution_in_account
 from preloop.models.db.session import get_db_session
 from preloop.models.models.account import Account
 from preloop.models.models.api_usage import ApiUsage
@@ -267,7 +268,7 @@ def _expire_receipts_for_artifacts(
     rows = (
         db.execute(
             select(FlowExecution).where(
-                FlowExecution.account_id == account_id,
+                execution_in_account(account_id),
                 FlowExecution.id.in_(execution_ids),
             )
         )
@@ -304,7 +305,7 @@ def _drop_legacy_evidence_columns(
     result = db.execute(
         update(FlowExecution)
         .where(
-            FlowExecution.account_id == account_id,
+            execution_in_account(account_id),
             FlowExecution.created_at < cutoff,
             FlowExecution.legal_hold.is_(False),
             FlowExecution.evidence_archive.isnot(None),

--- a/backend/preloop/services/retention_purge.py
+++ b/backend/preloop/services/retention_purge.py
@@ -1,0 +1,584 @@
+"""The scheduled purge that makes a retention setting mean something.
+
+A retention policy nobody enforces is a paragraph in a trust centre. This is
+the job that enforces it, and it is written defensively because it is the only
+code in the product whose purpose is to delete a customer's records.
+
+Four properties it has to have, in order of how much they matter:
+
+**It never touches a held record.** Every statement carries the legal hold
+predicate. A hold that a purge could race past is not a hold.
+
+**It is off by default.** ``RETENTION_PURGE_ENABLED`` is false. An operator
+upgrading to this release does not discover afterwards that a background job
+started deleting audit history. ``RETENTION_PURGE_DRY_RUN`` counts and audits
+what would go without deleting it.
+
+**It is bounded.** Batches of ``RETENTION_PURGE_BATCH_SIZE`` rows, each its
+own transaction, at most ``RETENTION_PURGE_MAX_BATCHES`` per class per
+account per pass, the whole pass under a wall-clock budget, and only inside
+the off-peak UTC window. A backlog is drained across passes. It runs off the
+request path in a background task, the same shape as
+:class:`preloop.services.session_optimization_jobs.OptimizationJobSweeper`.
+
+**It audits itself.** Retention decisions are themselves records: one
+``audit_log`` row per account and record class that actually deleted
+something, with the cutoff, the counts and the setting that produced them.
+
+The record classes and the floor live in
+:mod:`preloop.services.retention_policy`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.models.crud import crud_audit_log
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.api_usage import ApiUsage
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.runtime_session import RuntimeSession
+from preloop.services.retention_policy import (
+    CLASS_APPROVALS,
+    CLASS_AUDIT,
+    CLASS_EVIDENCE,
+    CLASS_RUNTIME_SESSIONS,
+    CLASS_USAGE,
+    RECORD_CLASSES,
+    resolve_retention,
+)
+
+logger = logging.getLogger(__name__)
+
+AUDIT_ACTION_PURGE = "retention_purge"
+AUDIT_ACTION_PREVIEW = "retention_purge_preview"
+
+#: Approval requests still waiting on a human are never purged, whatever the
+#: retention says. A parked execution is waiting on that row; deleting it
+#: would strand the run, and a six month old pending approval is a bug to fix
+#: rather than a record to shred.
+_UNRESOLVED_APPROVAL_STATUS = "pending"
+
+
+@dataclass
+class ClassResult:
+    """What the purge did to one record class of one account."""
+
+    record_class: str
+    retention_days: int
+    cutoff: datetime
+    deleted: int = 0
+    batches: int = 0
+    #: True when the class still had matching rows when the pass stopped.
+    more_remaining: bool = False
+
+    def as_details(self) -> dict[str, Any]:
+        """Audit-row shape."""
+        return {
+            "record_class": self.record_class,
+            "retention_days": self.retention_days,
+            "cutoff": self.cutoff.isoformat(),
+            "deleted": self.deleted,
+            "batches": self.batches,
+            "more_remaining": self.more_remaining,
+        }
+
+
+@dataclass
+class PurgeResult:
+    """Totals for one pass across every account it reached."""
+
+    accounts: int = 0
+    deleted: int = 0
+    classes: dict[str, int] = field(default_factory=dict)
+    #: True when the pass ended on its time or batch budget, not on empty.
+    budget_exhausted: bool = False
+    skipped_reason: Optional[str] = None
+
+    def record(self, result: ClassResult) -> None:
+        """Fold one class result into the totals."""
+        self.deleted += result.deleted
+        self.classes[result.record_class] = (
+            self.classes.get(result.record_class, 0) + result.deleted
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Log/telemetry shape."""
+        return {
+            "accounts": self.accounts,
+            "deleted": self.deleted,
+            "classes": dict(self.classes),
+            "budget_exhausted": self.budget_exhausted,
+            "skipped_reason": self.skipped_reason,
+        }
+
+
+def parse_window(raw: Any) -> Optional[tuple[int, int]]:
+    """Parse ``"start-end"`` UTC hours. ``None`` means any hour.
+
+    A malformed window is treated as "any hour" and logged rather than
+    silently pinning the job to a window nobody meant, because the failure
+    mode of the alternative is a purge that never runs and a retention
+    promise that is quietly untrue.
+    """
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        start_text, end_text = text.split("-", 1)
+        start, end = int(start_text), int(end_text)
+    except (ValueError, AttributeError):
+        logger.warning("Ignoring unparseable RETENTION_PURGE_WINDOW_UTC %r", raw)
+        return None
+    if not (0 <= start <= 23 and 0 <= end <= 24) or start == end:
+        logger.warning("Ignoring out-of-range RETENTION_PURGE_WINDOW_UTC %r", raw)
+        return None
+    return start, end
+
+
+def in_window(now: datetime, window: Optional[tuple[int, int]]) -> bool:
+    """True when ``now`` is inside the half-open off-peak window."""
+    if window is None:
+        return True
+    start, end = window
+    hour = now.astimezone(UTC).hour
+    if start < end:
+        return start <= hour < end
+    # Wraps midnight, for example 22-4.
+    return hour >= start or hour < end
+
+
+def _audit_cutoff_filters(cutoff: datetime):
+    return (AuditLog.timestamp < cutoff,)
+
+
+def _approval_cutoff_filters(cutoff: datetime):
+    return (
+        ApprovalRequest.requested_at < cutoff,
+        ApprovalRequest.status != _UNRESOLVED_APPROVAL_STATUS,
+        ApprovalRequest.legal_hold.is_(False),
+    )
+
+
+def _evidence_cutoff_filters(cutoff: datetime):
+    return (
+        FlowArtifact.created_at < cutoff,
+        FlowArtifact.kind == "evidence",
+        FlowArtifact.legal_hold.is_(False),
+    )
+
+
+def _runtime_session_cutoff_filters(cutoff: datetime):
+    # A session that never ended is dated by when it started. Using ended_at
+    # alone would make an abandoned session immortal.
+    return (func.coalesce(RuntimeSession.ended_at, RuntimeSession.started_at) < cutoff,)
+
+
+def _usage_cutoff_filters(cutoff: datetime):
+    return (ApiUsage.timestamp < cutoff,)
+
+
+_CLASS_MODELS: dict[str, Any] = {
+    CLASS_AUDIT: AuditLog,
+    CLASS_APPROVALS: ApprovalRequest,
+    CLASS_EVIDENCE: FlowArtifact,
+    CLASS_RUNTIME_SESSIONS: RuntimeSession,
+    CLASS_USAGE: ApiUsage,
+}
+
+_CLASS_FILTERS = {
+    CLASS_AUDIT: _audit_cutoff_filters,
+    CLASS_APPROVALS: _approval_cutoff_filters,
+    CLASS_EVIDENCE: _evidence_cutoff_filters,
+    CLASS_RUNTIME_SESSIONS: _runtime_session_cutoff_filters,
+    CLASS_USAGE: _usage_cutoff_filters,
+}
+
+
+def _candidate_ids_stmt(
+    record_class: str, *, account_id: Any, cutoff: datetime, limit: int
+):
+    """Ids of the next batch to remove for one class, account scoped."""
+    model = _CLASS_MODELS[record_class]
+    return (
+        select(model.id)
+        .where(model.account_id == account_id, *_CLASS_FILTERS[record_class](cutoff))
+        .order_by(model.id)
+        .limit(limit)
+    )
+
+
+def count_purgeable(
+    db: Session, *, account_id: Any, record_class: str, cutoff: datetime
+) -> int:
+    """How many rows the purge would remove. Used by dry runs and tests."""
+    model = _CLASS_MODELS[record_class]
+    return int(
+        db.execute(
+            select(func.count())
+            .select_from(model)
+            .where(
+                model.account_id == account_id,
+                *_CLASS_FILTERS[record_class](cutoff),
+            )
+        ).scalar_one()
+    )
+
+
+def _expire_receipts_for_artifacts(
+    db: Session, *, account_id: Any, artifact_ids: Sequence[Any]
+) -> int:
+    """Retire the execution receipts that name packs this batch removes.
+
+    ``inspect_evidence`` resolves a terminal receipt through its stored
+    ``artifact_id``. Deleting the row underneath and leaving the receipt as it
+    was would answer ``failed`` / ``artifact_scope_mismatch``, which reads like
+    corruption. It was retention, so the receipt says ``expired`` and carries
+    the reason.
+    """
+    if not artifact_ids:
+        return 0
+    execution_ids = list(
+        db.execute(
+            select(FlowArtifact.execution_id).where(
+                FlowArtifact.id.in_(list(artifact_ids)),
+                FlowArtifact.account_id == account_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not execution_ids:
+        return 0
+    wanted = {str(value) for value in artifact_ids}
+    rows = (
+        db.execute(
+            select(FlowExecution).where(
+                FlowExecution.account_id == account_id,
+                FlowExecution.id.in_(execution_ids),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stamped = 0
+    for execution in rows:
+        receipt = execution.evidence_receipt
+        if not isinstance(receipt, dict):
+            continue
+        if str(receipt.get("artifact_id") or "") not in wanted:
+            continue
+        updated = dict(receipt)
+        updated["status"] = "expired"
+        updated["error"] = "retention_purged"
+        updated["legal_hold"] = False
+        execution.evidence_receipt = updated
+        db.add(execution)
+        stamped += 1
+    return stamped
+
+
+def _drop_legacy_evidence_columns(
+    db: Session, *, account_id: Any, cutoff: datetime
+) -> int:
+    """Clear pre-artifact evidence blobs on executions past the cutoff.
+
+    Legacy captures live in ``flow_execution.evidence_archive`` rather than in
+    a ``flow_artifact`` row, so the evidence class would otherwise purge the
+    modern packs and leave the old bytes forever. Held executions are skipped.
+    The execution row itself stays: it is a run record, not an evidence record.
+    """
+    result = db.execute(
+        update(FlowExecution)
+        .where(
+            FlowExecution.account_id == account_id,
+            FlowExecution.created_at < cutoff,
+            FlowExecution.legal_hold.is_(False),
+            FlowExecution.evidence_archive.isnot(None),
+        )
+        .values(evidence_archive=None)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def purge_class(
+    db: Session,
+    *,
+    account: Account,
+    record_class: str,
+    now: datetime,
+    batch_size: int,
+    max_batches: int,
+    dry_run: bool,
+    deadline: Optional[float] = None,
+) -> ClassResult:
+    """Delete one record class for one account, in bounded batches."""
+    setting = resolve_retention(account.meta_data, record_class=record_class)
+    cutoff = now - timedelta(days=setting.days)
+    result = ClassResult(
+        record_class=record_class,
+        retention_days=setting.days,
+        cutoff=cutoff,
+    )
+    model = _CLASS_MODELS[record_class]
+    if dry_run:
+        result.deleted = count_purgeable(
+            db, account_id=account.id, record_class=record_class, cutoff=cutoff
+        )
+        return result
+    for _ in range(max_batches):
+        if deadline is not None and time.monotonic() >= deadline:
+            result.more_remaining = True
+            break
+        ids = list(
+            db.execute(
+                _candidate_ids_stmt(
+                    record_class,
+                    account_id=account.id,
+                    cutoff=cutoff,
+                    limit=batch_size,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not ids:
+            break
+        if record_class == CLASS_EVIDENCE:
+            _expire_receipts_for_artifacts(db, account_id=account.id, artifact_ids=ids)
+        deleted = db.execute(
+            delete(model)
+            .where(model.id.in_(ids))
+            .execution_options(synchronize_session=False)
+        )
+        # One transaction per batch. A long-running DELETE over a retention
+        # backlog would hold locks on tables the request path writes to.
+        db.commit()
+        result.deleted += int(deleted.rowcount or 0)
+        result.batches += 1
+        if len(ids) < batch_size:
+            break
+    else:
+        result.more_remaining = True
+    if record_class == CLASS_EVIDENCE:
+        cleared = _drop_legacy_evidence_columns(
+            db, account_id=account.id, cutoff=cutoff
+        )
+        if cleared:
+            db.commit()
+            result.deleted += cleared
+    return result
+
+
+def purge_account(
+    db: Session,
+    *,
+    account: Account,
+    now: datetime,
+    batch_size: int,
+    max_batches: int,
+    dry_run: bool,
+    deadline: Optional[float] = None,
+    record_classes: Sequence[str] = RECORD_CLASSES,
+) -> list[ClassResult]:
+    """Run every record class for one account and audit what was removed."""
+    results: list[ClassResult] = []
+    for record_class in record_classes:
+        try:
+            result = purge_class(
+                db,
+                account=account,
+                record_class=record_class,
+                now=now,
+                batch_size=batch_size,
+                max_batches=max_batches,
+                dry_run=dry_run,
+                deadline=deadline,
+            )
+        except Exception:
+            # One bad class must not stop the others, and must not take the
+            # sweeper down. The failure is loud in the log and the class is
+            # retried on the next pass.
+            db.rollback()
+            logger.error(
+                "Retention purge failed for account %s class %s",
+                account.id,
+                record_class,
+                exc_info=True,
+            )
+            continue
+        results.append(result)
+        if result.deleted:
+            try:
+                crud_audit_log.log_action(
+                    db,
+                    account_id=account.id,
+                    user_id=None,
+                    action=AUDIT_ACTION_PREVIEW if dry_run else AUDIT_ACTION_PURGE,
+                    resource_type="retention",
+                    resource_id=record_class,
+                    status="success",
+                    details=result.as_details(),
+                )
+            except Exception:
+                db.rollback()
+                logger.error(
+                    "Retention purge audit row failed for account %s class %s",
+                    account.id,
+                    record_class,
+                    exc_info=True,
+                )
+    return results
+
+
+def run_retention_purge(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    account_ids: Optional[Sequence[Any]] = None,
+    ignore_window: bool = False,
+    ignore_enabled: bool = False,
+) -> PurgeResult:
+    """One bounded pass over every active account.
+
+    Returns totals rather than raising: the caller is a background loop, and
+    an exception per pass would be noise on top of the per class logging that
+    already happened.
+    """
+    stamp = now or datetime.now(UTC)
+    summary = PurgeResult()
+    if not (ignore_enabled or settings.retention_purge_enabled):
+        summary.skipped_reason = "disabled"
+        return summary
+    window = parse_window(settings.retention_purge_window_utc)
+    if not ignore_window and not in_window(stamp, window):
+        summary.skipped_reason = "outside_window"
+        return summary
+    dry_run = bool(settings.retention_purge_dry_run)
+    batch_size = max(1, int(settings.retention_purge_batch_size))
+    max_batches = max(1, int(settings.retention_purge_max_batches))
+    deadline = time.monotonic() + max(1, int(settings.retention_purge_max_seconds))
+
+    stmt = select(Account).where(Account.is_active.is_(True)).order_by(Account.id)
+    if account_ids:
+        stmt = stmt.where(Account.id.in_(list(account_ids)))
+    accounts = list(db.execute(stmt).scalars().all())
+    for account in accounts:
+        if time.monotonic() >= deadline:
+            summary.budget_exhausted = True
+            break
+        summary.accounts += 1
+        for result in purge_account(
+            db,
+            account=account,
+            now=stamp,
+            batch_size=batch_size,
+            max_batches=max_batches,
+            dry_run=dry_run,
+            deadline=deadline,
+        ):
+            summary.record(result)
+            if result.more_remaining:
+                summary.budget_exhausted = True
+    if summary.deleted:
+        logger.info(
+            "Retention purge pass: %s",
+            summary.as_dict(),
+        )
+    return summary
+
+
+class RetentionPurgeSweeper:
+    """Periodic asyncio purge pass, modeled on the optimization job sweeper.
+
+    Started from the app lifespan on the API role only. The DB work is
+    synchronous CRUD, so each pass runs in a thread and the event loop stays
+    responsive. The pass itself decides whether it is inside the off-peak
+    window, so the interval can stay short without the purge running at noon.
+    """
+
+    def __init__(self, check_interval_seconds: Optional[int] = None) -> None:
+        self.check_interval = int(
+            check_interval_seconds
+            if check_interval_seconds is not None
+            else settings.retention_purge_interval_seconds
+        )
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start the purge background task."""
+        if self._running:
+            logger.warning("Retention purge sweeper is already running")
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._sweep_loop())
+        logger.info(
+            "Retention purge sweeper started (check_interval=%ss, window=%s)",
+            self.check_interval,
+            settings.retention_purge_window_utc or "any",
+        )
+
+    async def stop(self) -> None:
+        """Stop the purge background task."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected when stop() cancels the sweep loop task.
+                pass
+
+    async def _sweep_loop(self) -> None:
+        """Wait one interval first, then purge on every tick.
+
+        Unlike the optimization sweeper this does not run immediately on
+        startup: nothing is being recovered, and a delete pass firing during
+        every deploy would tie data loss to restart timing.
+        """
+        while self._running:
+            try:
+                await asyncio.sleep(self.check_interval)
+            except asyncio.CancelledError:
+                break
+            try:
+                await asyncio.to_thread(self._sweep_once)
+            except Exception:
+                logger.error("Error in retention purge pass", exc_info=True)
+
+    @staticmethod
+    def _sweep_once() -> None:
+        """One synchronous pass with its own session."""
+        db = next(get_db_session())
+        try:
+            run_retention_purge(db)
+        finally:
+            db.close()
+
+
+_sweeper_instance: Optional[RetentionPurgeSweeper] = None
+
+
+def get_retention_purge_sweeper() -> RetentionPurgeSweeper:
+    """Get or create the global retention purge sweeper."""
+    global _sweeper_instance
+    if _sweeper_instance is None:
+        _sweeper_instance = RetentionPurgeSweeper()
+    return _sweeper_instance

--- a/backend/tests/api/test_retention_api.py
+++ b/backend/tests/api/test_retention_api.py
@@ -1,0 +1,408 @@
+"""API surface for retention settings, legal holds and the period export."""
+
+import io
+import json
+import tarfile
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+
+BASE = "/api/v1/retention"
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+@pytest.fixture
+def pack(db_session, test_user):
+    """An execution with one evidence pack, so holds have something to hold."""
+    flow = models.Flow(
+        name=f"api-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "e" * 64, "size_bytes": 32},
+        manifest_sha256="f" * 64,
+        ciphertext=b"cipher",
+        expires_at=datetime.now(UTC) + timedelta(days=1),
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- settings --------------------------------------------------------------
+
+
+def test_settings_report_the_floor_and_the_defaults(client):
+    response = client.get(f"{BASE}/settings")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["floor_days"] == 183
+    assert body["default_days"] == 365
+    classes = {item["record_class"]: item for item in body["classes"]}
+    assert set(classes) == {
+        "audit",
+        "approvals",
+        "evidence",
+        "runtime_sessions",
+        "usage",
+    }
+    assert classes["audit"]["days"] == 365
+    assert classes["audit"]["source"] == "default"
+    assert all(item["label"] for item in body["classes"])
+
+
+def test_settings_say_whether_anything_actually_deletes(client, monkeypatch):
+    """Retention nobody enforces is a sentence, and the API admits it."""
+    monkeypatch.setattr(settings, "retention_purge_enabled", False, raising=False)
+
+    body = client.get(f"{BASE}/settings").json()
+
+    assert body["purge_enabled"] is False
+    assert body["evidence_payload_hours"] == settings.flow_evidence_retention_hours
+
+
+def test_a_retention_above_the_floor_is_stored(client, db_session, account):
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    assert response.status_code == 200
+    classes = {item["record_class"]: item for item in response.json()["classes"]}
+    assert classes["audit"]["days"] == 400
+    assert classes["audit"]["source"] == "account"
+    db_session.refresh(account)
+    assert account.meta_data["retention"] == {"audit": 400}
+
+
+def test_a_retention_below_the_floor_is_refused_with_the_floor_named(client):
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": 30}})
+
+    assert response.status_code == 422
+    assert "183" in response.json()["detail"]
+
+
+def test_an_unknown_record_class_is_refused(client):
+    response = client.put(f"{BASE}/settings", json={"classes": {"logs": 400}})
+
+    assert response.status_code == 422
+
+
+def test_updating_retention_leaves_other_account_metadata_alone(
+    client, db_session, account
+):
+    account.meta_data = {"approval_window_max_seconds": 900}
+    db_session.add(account)
+    db_session.flush()
+
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    db_session.refresh(account)
+    assert account.meta_data["approval_window_max_seconds"] == 900
+    assert account.meta_data["retention"] == {"audit": 400}
+
+
+def test_a_retention_change_is_audited_with_the_before_and_after(
+    client, db_session, account, test_user
+):
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_settings_updated",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["changed"]["audit"] == {"from": 365, "to": 400}
+
+
+def test_clearing_a_class_returns_it_to_the_default(client, db_session, account):
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": None}})
+
+    classes = {item["record_class"]: item for item in response.json()["classes"]}
+    assert classes["audit"]["days"] == 365
+    assert classes["audit"]["source"] == "default"
+
+
+# --- purge preview ---------------------------------------------------------
+
+
+def test_purge_preview_counts_without_deleting(client, db_session, account):
+    old = AuditLog(
+        account_id=account.id,
+        action="permission_check",
+        status="success",
+        timestamp=datetime.now(UTC) - timedelta(days=400),
+    )
+    db_session.add(old)
+    db_session.flush()
+
+    body = client.get(f"{BASE}/purge-preview").json()
+
+    audit = next(row for row in body["classes"] if row["record_class"] == "audit")
+    assert audit["purgeable"] >= 1
+    assert audit["retention_days"] == 365
+    assert db_session.get(AuditLog, old.id) is not None
+
+
+# --- holds -----------------------------------------------------------------
+
+
+def test_placing_a_hold_returns_the_record_and_what_it_froze(client, pack):
+    execution, _ = pack
+
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["active"] is True
+    assert body["reason"] == "incident review INC-114"
+    assert body["flagged"]["flow_execution"] == 1
+    assert body["flagged"]["flow_artifact"] == 1
+
+
+def test_a_hold_without_a_real_reason_is_refused(client, pack):
+    execution, _ = pack
+
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "x",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_a_hold_on_an_unknown_record_is_a_404(client):
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(uuid.uuid4()),
+            "reason": "matter 2026-04 discovery",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_a_second_hold_on_the_same_record_is_a_conflict(client, pack):
+    execution, _ = pack
+    payload = {
+        "resource_type": "execution",
+        "resource_id": str(execution.id),
+        "reason": "incident review INC-114",
+    }
+    client.post(f"{BASE}/holds", json=payload)
+
+    response = client.post(f"{BASE}/holds", json=payload)
+
+    assert response.status_code == 409
+
+
+def test_an_unknown_resource_type_is_refused(client, pack):
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "invoice",
+            "resource_id": str(pack[0].id),
+            "reason": "matter 2026-04 discovery",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_holds_are_listed_and_released(client, pack):
+    execution, _ = pack
+    created = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    ).json()
+
+    listed = client.get(f"{BASE}/holds").json()
+    assert [row["id"] for row in listed] == [created["id"]]
+
+    released = client.post(
+        f"{BASE}/holds/{created['id']}/release",
+        json={"reason": "review closed, nothing found"},
+    )
+    assert released.status_code == 200
+    assert released.json()["active"] is False
+
+    assert client.get(f"{BASE}/holds").json() == []
+    history = client.get(f"{BASE}/holds", params={"active_only": False}).json()
+    assert len(history) == 1
+    assert history[0]["release_reason"] == "review closed, nothing found"
+
+
+def test_releasing_an_unknown_hold_is_a_404(client):
+    response = client.post(
+        f"{BASE}/holds/{uuid.uuid4()}/release",
+        json={"reason": "review closed, nothing found"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_releasing_twice_is_a_conflict(client, pack):
+    execution, _ = pack
+    created = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    ).json()
+    body = {"reason": "review closed, nothing found"}
+    client.post(f"{BASE}/holds/{created['id']}/release", json=body)
+
+    response = client.post(f"{BASE}/holds/{created['id']}/release", json=body)
+
+    assert response.status_code == 409
+
+
+# --- period export ---------------------------------------------------------
+
+
+def test_the_export_streams_a_tar_with_a_manifest(client, db_session, account):
+    db_session.add(
+        AuditLog(
+            account_id=account.id,
+            action="permission_check",
+            status="success",
+            timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+        )
+    )
+    db_session.flush()
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/gzip"
+    assert (
+        "preloop-period-export-2026-04-01-to-2026-05-01.tar.gz"
+        in (response.headers["content-disposition"])
+    )
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
+        manifest = json.loads(tar.extractfile("manifest.json").read())
+    assert manifest["schema"] == "preloop.retention.period_export_manifest/v1"
+    assert manifest["counts"]["audit"] == 1
+    assert manifest["members_digest"] == response.headers["x-preloop-members-digest"]
+
+
+def test_the_response_carries_the_digest_of_the_bytes_served(client):
+    import hashlib
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.headers["x-preloop-archive-sha256"] == (
+        hashlib.sha256(response.content).hexdigest()
+    )
+
+
+def test_an_export_is_audited(client, db_session, account, test_user):
+    client.post(f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"})
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_period_export",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["period_start"] == "2026-04-01T00:00:00Z"
+    assert row.details["archive_sha256"]
+
+
+def test_an_inverted_period_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-05-01", "end": "2026-04-01"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_a_period_over_a_year_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2024-01-01", "end": "2026-01-01"}
+    )
+
+    assert response.status_code == 400
+    assert "366" in response.json()["detail"]
+
+
+def test_an_unparseable_date_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "last april", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_a_period_over_the_row_cap_is_refused(client, db_session, account, monkeypatch):
+    monkeypatch.setattr(settings, "retention_export_max_rows", 1, raising=False)
+    for _ in range(2):
+        db_session.add(
+            AuditLog(
+                account_id=account.id,
+                action="permission_check",
+                status="success",
+                timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+            )
+        )
+    db_session.flush()
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 413

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -172,4 +172,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert event_webhooks.down_revision == "20260908_approval_park"
     delivery_key = script.get_revision("20260908_webhook_delivery_key")
     assert delivery_key.down_revision == "20260908_event_webhooks"
-    assert script.get_heads() == ["20260908_webhook_delivery_key"]
+    retention = script.get_revision("20260910_retention_hold")
+    assert retention.down_revision == "20260908_webhook_delivery_key"
+    assert script.get_heads() == ["20260910_retention_hold"]

--- a/backend/tests/models/test_retention_legal_hold_migration.py
+++ b/backend/tests/models/test_retention_legal_hold_migration.py
@@ -1,0 +1,146 @@
+"""Run the retention migration's downgrade/upgrade cycle on real Postgres.
+
+`test_alembic_single_head.py` only walks the revision graph, and the test
+database is built from ORM metadata, so neither one ever executes this
+migration's DDL. This one does, in the test transaction: down then up, then
+diff the rebuilt table and the added columns against the ORM definition.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import inspect
+
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import LegalHold
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "preloop"
+    / "models"
+    / "alembic"
+    / "versions"
+    / "20260910_retention_legal_hold.py"
+)
+
+FLAGGED = {
+    "flow_execution": FlowExecution,
+    "approval_request": ApprovalRequest,
+    "flow_artifact": FlowArtifact,
+}
+
+
+def _load_migration():
+    """Import the migration module by path (its name starts with digits)."""
+    spec = importlib.util.spec_from_file_location(
+        "retention_legal_hold_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(db_session):
+    """An Alembic operations context bound to the test transaction."""
+    context = MigrationContext.configure(db_session.connection())
+    return Operations.context(context)
+
+
+def _column_names(db_session, table: str) -> set[str]:
+    return {
+        column["name"] for column in inspect(db_session.connection()).get_columns(table)
+    }
+
+
+def test_downgrade_removes_the_table_and_every_flag(db_session):
+    migration = _load_migration()
+    assert inspect(db_session.connection()).has_table("legal_hold")
+
+    with _operations(db_session):
+        migration.downgrade()
+
+    assert not inspect(db_session.connection()).has_table("legal_hold")
+    for table in FLAGGED:
+        assert "legal_hold" not in _column_names(db_session, table)
+
+
+def test_upgrade_after_downgrade_rebuilds_the_orm_shape(db_session):
+    """A full down/up cycle leaves exactly the columns the ORM expects."""
+    migration = _load_migration()
+    expected = {column.name for column in LegalHold.__table__.columns}
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    assert _column_names(db_session, "legal_hold") == expected
+    for table, model in FLAGGED.items():
+        assert "legal_hold" in _column_names(db_session, table)
+        assert model.__table__.columns["legal_hold"].nullable is False
+
+
+def test_the_flag_defaults_to_false_on_existing_rows(db_session, test_user):
+    """An upgrade must not freeze the records an account already has."""
+    from preloop.models import models
+
+    migration = _load_migration()
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    flow = models.Flow(
+        name="migration-default",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(flow_id=flow.id, status="COMPLETED")
+    db_session.add(execution)
+    db_session.flush()
+
+    assert execution.legal_hold is False
+
+
+def test_upgrade_recreates_the_one_active_hold_per_resource_index(db_session):
+    """The partial unique index is what stops two active holds on one row."""
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(db_session.connection()).get_indexes("legal_hold")
+    }
+    active = indexes["uq_legal_hold_active_resource"]
+    assert active["unique"] is True
+    assert active["column_names"] == ["account_id", "resource_type", "resource_id"]
+    # Partial: a released hold must not block holding the same record again.
+    assert "released_at IS NULL" in str(active.get("dialect_options", {}))
+
+
+def test_upgrade_keeps_the_cascade_that_stops_orphan_holds(db_session):
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    rules = {
+        tuple(fk["constrained_columns"]): fk["options"].get("ondelete")
+        for fk in inspect(db_session.connection()).get_foreign_keys("legal_hold")
+    }
+
+    assert rules[("account_id",)] == "CASCADE"
+    # A deleted operator must not take the hold they placed with them: the
+    # record of who froze the data is the point.
+    assert rules[("placed_by_user_id",)] == "SET NULL"
+    assert rules[("released_by_user_id",)] == "SET NULL"

--- a/backend/tests/services/test_legal_hold.py
+++ b/backend/tests/services/test_legal_hold.py
@@ -1,0 +1,428 @@
+"""Legal hold: actor, reason, what it freezes and what release restores."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.models import models
+from preloop.models.crud import flow_artifact as crud_artifact
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.legal_hold import LegalHold
+from preloop.services.flow_artifacts import evidence_receipt
+from preloop.services.legal_hold import (
+    LegalHoldError,
+    place_hold,
+    release_hold,
+)
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+@pytest.fixture
+def pack(db_session, test_user):
+    """One execution with one evidence pack whose payload expires shortly."""
+    flow = models.Flow(
+        name=f"hold-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "a" * 64, "size_bytes": 12},
+        manifest_sha256="b" * 64,
+        ciphertext=b"cipher",
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+        availability="available",
+    )
+    db_session.add(artifact)
+    execution.evidence_receipt = {
+        "status": "available",
+        "artifact_id": str(artifact.id),
+        "kind": "evidence",
+        "legal_hold": False,
+    }
+    db_session.add(execution)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- the record ------------------------------------------------------------
+
+
+def test_a_hold_records_the_actor_and_the_reason(db_session, test_user, account, pack):
+    execution, _ = pack
+
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    assert outcome.hold.reason == "incident review INC-114"
+    assert outcome.hold.placed_by_user_id == test_user.id
+    assert outcome.hold.active is True
+    assert outcome.flagged["flow_execution"] == 1
+
+
+def test_a_hold_without_a_real_reason_is_refused(db_session, account, pack):
+    execution, _ = pack
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(execution.id),
+            reason="asdf",
+        )
+
+    assert excinfo.value.code == "reason_required"
+
+
+def test_a_hold_on_another_accounts_record_is_refused(db_session, account, pack):
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=uuid.uuid4(),
+            resource_type="execution",
+            resource_id=str(pack[0].id),
+            reason="fishing for someone else's records",
+        )
+
+    assert excinfo.value.code == "resource_not_found"
+
+
+def test_a_hold_on_a_nonexistent_record_is_refused(db_session, account):
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(uuid.uuid4()),
+            reason="matter 2026-04 discovery",
+        )
+
+    assert excinfo.value.code == "resource_not_found"
+
+
+def test_holding_the_same_record_twice_is_refused(db_session, account, pack):
+    execution, _ = pack
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(execution.id),
+            reason="incident review INC-114 again",
+        )
+
+    assert excinfo.value.code == "already_held"
+
+
+def test_a_released_record_can_be_held_again(db_session, account, pack):
+    execution, _ = pack
+    first = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=first.hold.id,
+        reason="review closed, nothing found",
+    )
+
+    second = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="reopened as INC-114b",
+    )
+
+    assert second.hold.id != first.hold.id
+    rows = (
+        db_session.execute(select(LegalHold).where(LegalHold.account_id == account.id))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+
+
+# --- what it freezes -------------------------------------------------------
+
+
+def test_a_held_pack_survives_the_janitor(db_session, account, pack):
+    """The whole point: expiry must not take bytes a hold is protecting."""
+    execution, artifact = pack
+    artifact_id = artifact.id
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact_id),
+        reason="regulator request 2026-05",
+    )
+
+    cleared = crud_artifact.cleanup(db_session, now=datetime.now(UTC))
+
+    row = db_session.get(models.FlowArtifact, artifact_id)
+    assert row.ciphertext is not None
+    assert row.availability == "available"
+    assert cleared == 0
+
+
+def test_an_unheld_pack_still_expires(db_session, account, pack):
+    _, artifact = pack
+    artifact_id = artifact.id
+
+    crud_artifact.cleanup(db_session, now=datetime.now(UTC))
+
+    row = db_session.get(models.FlowArtifact, artifact_id)
+    assert row.ciphertext is None
+    assert row.availability == "expired"
+
+
+def test_the_receipt_reports_the_hold(db_session, account, pack):
+    execution, artifact = pack
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+    db_session.refresh(artifact)
+
+    receipt = evidence_receipt(
+        status="available",
+        execution_id=execution.id,
+        transport="direct",
+        artifact=artifact,
+    )
+
+    assert receipt["legal_hold"] is True
+    # Preloop cannot verify a property of the storage layer beneath it.
+    assert receipt["object_lock"] is False
+
+
+def test_the_persisted_receipt_is_stamped_so_polling_agrees(db_session, account, pack):
+    execution, artifact = pack
+
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+
+    db_session.refresh(execution)
+    assert execution.evidence_receipt["legal_hold"] is True
+
+
+def test_an_execution_hold_reaches_its_packs(db_session, account, pack):
+    execution, artifact = pack
+
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    db_session.refresh(artifact)
+    assert artifact.legal_hold is True
+    assert outcome.flagged["flow_artifact"] == 1
+
+
+# --- release ---------------------------------------------------------------
+
+
+def test_release_clears_the_flags_and_keeps_the_record(
+    db_session, test_user, account, pack
+):
+    execution, artifact = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    released = release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+        user_id=test_user.id,
+    )
+
+    db_session.refresh(execution)
+    db_session.refresh(artifact)
+    assert execution.legal_hold is False
+    assert artifact.legal_hold is False
+    assert released.hold.released_at is not None
+    assert released.hold.release_reason == "review closed, nothing found"
+    assert released.hold.reason == "incident review INC-114"
+
+
+def test_overlapping_holds_do_not_cancel_each_other(db_session, account, pack):
+    """A pack under its own hold stays frozen when the execution hold lifts."""
+    execution, artifact = pack
+    execution_hold = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=execution_hold.hold.id,
+        reason="review closed, the regulator matter is separate",
+    )
+
+    db_session.refresh(artifact)
+    db_session.refresh(execution)
+    assert artifact.legal_hold is True
+    assert execution.legal_hold is False
+
+
+def test_releasing_twice_is_refused(db_session, account, pack):
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        release_hold(
+            db_session,
+            account_id=account.id,
+            hold_id=outcome.hold.id,
+            reason="review closed, nothing found",
+        )
+
+    assert excinfo.value.code == "already_released"
+
+
+def test_releasing_another_accounts_hold_is_refused(db_session, account, pack):
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        release_hold(
+            db_session,
+            account_id=uuid.uuid4(),
+            hold_id=outcome.hold.id,
+            reason="lifting somebody else's hold",
+        )
+
+    assert excinfo.value.code == "hold_not_found"
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_placing_and_releasing_are_both_audited(db_session, test_user, account, pack):
+    """A hold that can be lifted without a trace proves nothing."""
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+        user_id=test_user.id,
+    )
+
+    rows = (
+        db_session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.account_id == account.id,
+                AuditLog.action.in_(["legal_hold_placed", "legal_hold_released"]),
+            )
+            .order_by(AuditLog.timestamp)
+        )
+        .scalars()
+        .all()
+    )
+
+    assert [row.action for row in rows] == [
+        "legal_hold_placed",
+        "legal_hold_released",
+    ]
+    assert all(row.user_id == test_user.id for row in rows)
+    assert rows[0].details["reason"] == "incident review INC-114"
+    assert rows[0].details["hold_id"] == str(outcome.hold.id)
+    assert rows[1].details["placed_reason"] == "incident review INC-114"

--- a/backend/tests/services/test_retention_export.py
+++ b/backend/tests/services/test_retention_export.py
@@ -1,0 +1,427 @@
+"""Period export: manifest shape, digests, boundaries and the row cap."""
+
+import hashlib
+import io
+import json
+import tarfile
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from preloop.config import settings
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+from preloop.services.legal_hold import place_hold
+from preloop.services.retention_export import (
+    EXPORT_MANIFEST_SCHEMA,
+    MEMBER_APPROVALS,
+    MEMBER_AUDIT,
+    MEMBER_EVIDENCE,
+    MEMBER_HOLDS,
+    PeriodExportError,
+    audit_period_export,
+    build_period_export,
+)
+
+PERIOD_START = datetime(2026, 4, 1, tzinfo=UTC)
+PERIOD_END = datetime(2026, 5, 1, tzinfo=UTC)
+INSIDE = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _audit_row(db_session, account_id, when, action="permission_check"):
+    row = AuditLog(
+        account_id=account_id,
+        action=action,
+        resource_type="tool",
+        resource_id="send_payment",
+        status="success",
+        timestamp=when,
+        details={"decision": "allow"},
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _approval(db_session, test_user, when, *, status="approved"):
+    workflow = models.ApprovalWorkflow(
+        account_id=test_user.account_id,
+        name=f"wf-{uuid.uuid4().hex[:8]}",
+        approval_type="manual",
+        channel="email",
+    )
+    db_session.add(workflow)
+    db_session.flush()
+    config = models.ToolConfiguration(
+        account_id=test_user.account_id,
+        tool_name="send_payment",
+        tool_source="mcp",
+        approval_workflow_id=workflow.id,
+        is_enabled=True,
+        custom_config={},
+    )
+    db_session.add(config)
+    db_session.flush()
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="send_payment",
+        tool_args={"amount": 1000, "iban": "secret account number"},
+        summary="Pay invoice 12",
+        status=status,
+        requested_at=when.replace(tzinfo=None),
+    )
+    db_session.add(request)
+    db_session.flush()
+    return request
+
+
+def _evidence(db_session, test_user, when):
+    flow = models.Flow(
+        name=f"flow-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "c" * 64, "size_bytes": 4096},
+        manifest_sha256="d" * 64,
+        ciphertext=b"cipher-bytes-nobody-should-see",
+        expires_at=when + timedelta(days=30),
+        created_at=when,
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+def _members(archive: bytes) -> dict[str, bytes]:
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        return {
+            member.name: tar.extractfile(member).read() for member in tar.getmembers()
+        }
+
+
+def _manifest(archive: bytes) -> dict:
+    return json.loads(_members(archive)["manifest.json"])
+
+
+# --- shape -----------------------------------------------------------------
+
+
+def test_the_archive_carries_a_manifest_and_one_file_per_class(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    _approval(db_session, test_user, INSIDE)
+    _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    names = set(_members(export.archive))
+    assert names == {
+        "manifest.json",
+        MEMBER_AUDIT,
+        MEMBER_APPROVALS,
+        MEMBER_EVIDENCE,
+        MEMBER_HOLDS,
+    }
+
+
+def test_the_manifest_digests_every_member(db_session, test_user, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    members = _members(export.archive)
+    manifest = _manifest(export.archive)
+    assert manifest["schema"] == EXPORT_MANIFEST_SCHEMA
+    for entry in manifest["members"]:
+        body = members[entry["name"]]
+        assert entry["size_bytes"] == len(body)
+        assert entry["sha256"] == hashlib.sha256(body).hexdigest()
+
+
+def test_the_members_digest_is_computed_the_way_evidence_packs_do_it(
+    db_session, test_user, account
+):
+    """#511's shape, so one verifier covers both and #558 signs one format."""
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    manifest = _manifest(export.archive)
+    expected = hashlib.sha256(canonical_manifest_json(manifest["members"])).hexdigest()
+    assert manifest["members_digest"] == expected
+
+
+def test_tampering_with_a_member_breaks_its_digest(db_session, test_user, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+    manifest = _manifest(export.archive)
+    entry = next(m for m in manifest["members"] if m["name"] == MEMBER_AUDIT)
+
+    altered = _members(export.archive)[MEMBER_AUDIT].replace(b"allow", b"deny_")
+
+    assert hashlib.sha256(altered).hexdigest() != entry["sha256"]
+
+
+def test_the_manifest_says_plainly_that_it_is_not_signed(
+    db_session, test_user, account
+):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert "not signed" in _manifest(export.archive)["note"]
+
+
+def test_the_manifest_records_the_retention_in_force(db_session, account):
+    account.meta_data = {"retention": {"audit": 400}}
+    db_session.add(account)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert _manifest(export.archive)["retention"]["audit"] == 400
+
+
+def test_the_same_rows_produce_the_same_archive_bytes(db_session, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    stamp = datetime(2026, 5, 2, 9, 0, tzinfo=UTC)
+
+    first = build_period_export(
+        db_session,
+        account=account,
+        start=PERIOD_START,
+        end=PERIOD_END,
+        generated_at=stamp,
+    )
+    second = build_period_export(
+        db_session,
+        account=account,
+        start=PERIOD_START,
+        end=PERIOD_END,
+        generated_at=stamp,
+    )
+
+    assert first.sha256 == second.sha256
+
+
+# --- contents --------------------------------------------------------------
+
+
+def test_only_rows_inside_the_period_are_exported(db_session, account):
+    _audit_row(db_session, account.id, PERIOD_START - timedelta(seconds=1), "before")
+    _audit_row(db_session, account.id, PERIOD_START, "at_start")
+    _audit_row(db_session, account.id, PERIOD_END, "at_end")
+    _audit_row(db_session, account.id, INSIDE, "inside")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_AUDIT].decode()
+    actions = {json.loads(line)["action"] for line in body.splitlines()}
+    # Start inclusive, end exclusive, so consecutive periods tile exactly.
+    assert actions == {"at_start", "inside"}
+
+
+def test_another_accounts_rows_are_never_exported(db_session, account):
+    from preloop.models.crud import crud_account
+
+    other = crud_account.create(
+        db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+    )
+    _audit_row(db_session, other.id, INSIDE, "theirs")
+    _audit_row(db_session, account.id, INSIDE, "ours")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_AUDIT].decode()
+    assert "theirs" not in body
+    assert "ours" in body
+
+
+def test_evidence_is_exported_by_receipt_not_by_payload(db_session, test_user, account):
+    """Inlining packs would be unbounded and would duplicate the download."""
+    execution, artifact = _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert b"cipher-bytes-nobody-should-see" not in export.archive
+    row = json.loads(_members(export.archive)[MEMBER_EVIDENCE].decode().strip())
+    assert row["artifact_id"] == str(artifact.id)
+    assert row["sha256"] == "c" * 64
+    assert row["payload_present"] is True
+    assert "object_lock" not in row
+
+
+def test_approval_tool_arguments_stay_out_of_the_export(db_session, test_user, account):
+    _approval(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_APPROVALS].decode()
+    assert "secret account number" not in body
+    assert json.loads(body.strip())["summary"] == "Pay invoice 12"
+
+
+def test_holds_placed_in_the_period_explain_a_frozen_record(
+    db_session, test_user, account
+):
+    execution, _ = _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        now=INSIDE,
+        user_id=test_user.id,
+    )
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    row = json.loads(_members(export.archive)[MEMBER_HOLDS].decode().strip())
+    assert row["reason"] == "incident review INC-114"
+    assert row["active"] is True
+
+
+def test_an_empty_period_is_an_archive_not_an_error(db_session, account):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert export.counts == {
+        "audit": 0,
+        "approvals": 0,
+        "evidence": 0,
+        "legal_holds": 0,
+    }
+    assert _members(export.archive)[MEMBER_AUDIT] == b""
+
+
+# --- bounds ----------------------------------------------------------------
+
+
+def test_a_period_over_the_row_cap_is_refused_not_truncated(
+    db_session, account, monkeypatch
+):
+    """A silently short compliance export is worse than no export."""
+    monkeypatch.setattr(settings, "retention_export_max_rows", 2, raising=False)
+    for index in range(3):
+        _audit_row(db_session, account.id, INSIDE, f"row-{index}")
+    db_session.flush()
+
+    with pytest.raises(PeriodExportError) as excinfo:
+        build_period_export(
+            db_session, account=account, start=PERIOD_START, end=PERIOD_END
+        )
+
+    assert excinfo.value.code == "period_too_large"
+    assert "narrow" in str(excinfo.value)
+
+
+def test_exactly_at_the_cap_still_exports(db_session, account, monkeypatch):
+    monkeypatch.setattr(settings, "retention_export_max_rows", 2, raising=False)
+    for index in range(2):
+        _audit_row(db_session, account.id, INSIDE, f"row-{index}")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert export.counts["audit"] == 2
+
+
+def test_an_inverted_period_is_refused(db_session, account):
+    with pytest.raises(PeriodExportError) as excinfo:
+        build_period_export(
+            db_session, account=account, start=PERIOD_END, end=PERIOD_START
+        )
+
+    assert excinfo.value.code == "invalid_period"
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_the_export_is_audited_with_the_digest_of_what_was_taken(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    audit_period_export(
+        db_session, account_id=account.id, user_id=test_user.id, export=export
+    )
+
+    from sqlalchemy import select
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_period_export",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["archive_sha256"] == export.sha256
+    assert row.details["period_start"] == "2026-04-01T00:00:00Z"
+    assert row.details["counts"]["audit"] == 1

--- a/backend/tests/services/test_retention_policy.py
+++ b/backend/tests/services/test_retention_policy.py
@@ -1,0 +1,118 @@
+"""The six month floor, and what a stored value under it resolves to."""
+
+import pytest
+
+from preloop.config import settings
+from preloop.services import retention_policy as policy
+
+
+def test_default_is_twelve_months_when_the_account_says_nothing():
+    resolved = policy.resolve_retention({}, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 365
+    assert resolved.source == "default"
+    assert resolved.floored is False
+
+
+def test_every_record_class_resolves():
+    resolved = policy.resolve_all(None)
+
+    assert set(resolved) == set(policy.RECORD_CLASSES)
+    assert all(
+        setting.days >= policy.ABSOLUTE_FLOOR_DAYS for setting in resolved.values()
+    )
+
+
+def test_account_value_above_the_floor_is_used_as_written():
+    meta = {"retention": {"audit": 800}}
+
+    resolved = policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 800
+    assert resolved.source == "account"
+    assert resolved.floored is False
+
+
+def test_a_write_below_the_floor_is_refused():
+    with pytest.raises(policy.RetentionFloorError) as excinfo:
+        policy.validate_retention_request({"audit": 30})
+
+    assert excinfo.value.floor_days == 183
+    assert excinfo.value.requested_days == 30
+    assert "183" in str(excinfo.value)
+
+
+def test_the_floor_is_exactly_six_months_and_inclusive():
+    assert policy.validate_retention_request({"audit": 183}) == {"audit": 183}
+    with pytest.raises(policy.RetentionFloorError):
+        policy.validate_retention_request({"audit": 182})
+
+
+def test_a_stored_value_under_the_floor_still_resolves_to_the_floor():
+    """A hand-edited row, or a deployment that raised its floor afterwards.
+
+    The floor is the reason this module exists, so it wins at read time too,
+    not only at write time.
+    """
+    meta = {"retention": {"audit": 10}}
+
+    resolved = policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 183
+    assert resolved.floored is True
+
+
+def test_a_deployment_may_raise_the_floor_but_not_lower_it(monkeypatch):
+    monkeypatch.setattr(settings, "retention_floor_days", 400, raising=False)
+    assert policy.floor_days() == 400
+    with pytest.raises(policy.RetentionFloorError):
+        policy.validate_retention_request({"audit": 200})
+
+    monkeypatch.setattr(settings, "retention_floor_days", 10, raising=False)
+    assert policy.floor_days() == policy.ABSOLUTE_FLOOR_DAYS
+
+
+def test_a_default_below_the_floor_is_raised_to_it(monkeypatch):
+    monkeypatch.setattr(settings, "retention_default_days", 30, raising=False)
+
+    assert policy.default_days() == policy.ABSOLUTE_FLOOR_DAYS
+
+
+def test_an_unknown_record_class_is_refused_not_ignored():
+    with pytest.raises(ValueError, match="unknown record class"):
+        policy.validate_retention_request({"logs": 400})
+    with pytest.raises(ValueError, match="unknown record class"):
+        policy.resolve_retention({}, record_class="logs")
+
+
+def test_garbage_in_the_bucket_does_not_decide_retention():
+    meta = {"retention": {"audit": "soon", "usage": -5, "approvals": True}}
+
+    assert policy.normalize_retention_store(meta) == {}
+    assert policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT).days == 365
+
+
+def test_set_retention_leaves_the_rest_of_account_metadata_alone():
+    meta = {"approval_window_max_seconds": 900, "retention": {"audit": 400}}
+
+    updated = policy.set_retention(meta, values={"usage": 200})
+
+    assert updated["approval_window_max_seconds"] == 900
+    assert updated["retention"] == {"usage": 200}
+    # The input is not mutated: callers hold the account's live dict.
+    assert meta["retention"] == {"audit": 400}
+
+
+def test_clearing_every_class_removes_the_bucket():
+    meta = {"retention": {"audit": 400}, "other": 1}
+
+    updated = policy.set_retention(meta, values={"audit": None})
+
+    assert "retention" not in updated
+    assert updated["other"] == 1
+
+
+def test_retention_is_capped_so_a_table_is_not_kept_forever():
+    cleaned = policy.validate_retention_request({"audit": 99999})
+
+    assert cleaned["audit"] == policy.MAX_RETENTION_DAYS

--- a/backend/tests/services/test_retention_purge.py
+++ b/backend/tests/services/test_retention_purge.py
@@ -1,0 +1,473 @@
+"""The purge: bounds, holds, audit rows and the off-peak window."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+from preloop.services import retention_purge as purge
+from preloop.services.legal_hold import place_hold
+from preloop.services.retention_policy import CLASS_AUDIT
+
+
+@pytest.fixture(autouse=True)
+def enabled_purge(monkeypatch):
+    """Tests exercise the job itself; the deployment default is off."""
+    monkeypatch.setattr(settings, "retention_purge_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_dry_run", False, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_window_utc", "", raising=False)
+
+
+def _exists(db_session, model, identifier) -> bool:
+    """Row presence read fresh.
+
+    ``Session.get`` would answer from the identity map and raise
+    ObjectDeletedError for a row the purge removed under it, which says the
+    same thing far less clearly.
+    """
+    return (
+        db_session.execute(
+            select(model.id).where(model.id == identifier)
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _audit_row(db_session, account_id, *, age_days: int, action="permission_check"):
+    row = AuditLog(
+        account_id=account_id,
+        action=action,
+        resource_type="tool",
+        resource_id="x",
+        status="success",
+        timestamp=datetime.now(UTC) - timedelta(days=age_days),
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _approval(db_session, test_user, *, age_days: int, status: str = "approved"):
+    workflow = models.ApprovalWorkflow(
+        account_id=test_user.account_id,
+        name=f"wf-{uuid.uuid4().hex[:8]}",
+        approval_type="manual",
+        channel="email",
+    )
+    db_session.add(workflow)
+    db_session.flush()
+    config = models.ToolConfiguration(
+        account_id=test_user.account_id,
+        tool_name="send_payment",
+        tool_source="mcp",
+        approval_workflow_id=workflow.id,
+        is_enabled=True,
+        custom_config={},
+    )
+    db_session.add(config)
+    db_session.flush()
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="send_payment",
+        tool_args={"amount": 1},
+        status=status,
+        requested_at=datetime.utcnow() - timedelta(days=age_days),
+    )
+    db_session.add(request)
+    db_session.flush()
+    return request
+
+
+def _evidence(db_session, test_user, *, age_days: int):
+    flow = models.Flow(
+        name=f"flow-{age_days}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    created = datetime.now(UTC) - timedelta(days=age_days)
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "a" * 64, "size_bytes": 10},
+        manifest_sha256="b" * 64,
+        ciphertext=b"cipher",
+        expires_at=created + timedelta(hours=1),
+        created_at=created,
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- what gets removed -----------------------------------------------------
+
+
+def test_rows_inside_retention_are_left_alone(db_session, account):
+    keep = _audit_row(db_session, account.id, age_days=10)
+    db_session.commit()
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted == 0
+    assert _exists(db_session, AuditLog, keep.id) is True
+
+
+def test_rows_past_retention_are_removed(db_session, account):
+    old = _audit_row(db_session, account.id, age_days=400).id
+    recent = _audit_row(db_session, account.id, age_days=5).id
+    db_session.commit()
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.classes[CLASS_AUDIT] >= 1
+    assert _exists(db_session, AuditLog, old) is False
+    assert _exists(db_session, AuditLog, recent) is True
+
+
+def test_a_shorter_account_retention_removes_more(db_session, account):
+    row = _audit_row(db_session, account.id, age_days=200).id
+    account.meta_data = {"retention": {CLASS_AUDIT: 183}}
+    db_session.add(account)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, AuditLog, row) is False
+
+
+# --- holds -----------------------------------------------------------------
+
+
+def test_a_held_approval_survives_the_purge(db_session, test_user, account):
+    held = _approval(db_session, test_user, age_days=400).id
+    unheld = _approval(db_session, test_user, age_days=400).id
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="approval",
+        resource_id=str(held),
+        reason="litigation hold, matter 2026-04",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, held) is True
+    assert _exists(db_session, models.ApprovalRequest, unheld) is False
+
+
+def test_a_held_evidence_pack_survives_the_purge(db_session, test_user, account):
+    held = _evidence(db_session, test_user, age_days=500)[1].id
+    unheld = _evidence(db_session, test_user, age_days=500)[1].id
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(held),
+        reason="regulator request 2026-05",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.FlowArtifact, held) is True
+    assert _exists(db_session, models.FlowArtifact, unheld) is False
+
+
+def test_an_execution_hold_covers_that_executions_packs(db_session, test_user, account):
+    execution, artifact = _evidence(db_session, test_user, age_days=500)
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.FlowArtifact, artifact.id) is True
+
+
+def test_a_released_hold_stops_protecting_the_row(db_session, test_user, account):
+    approval = _approval(db_session, test_user, age_days=400).id
+    db_session.commit()
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="approval",
+        resource_id=str(approval),
+        reason="litigation hold, matter 2026-04",
+        user_id=test_user.id,
+    )
+    from preloop.services.legal_hold import release_hold
+
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="matter closed 2026-06",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, approval) is False
+
+
+# --- what is never purged --------------------------------------------------
+
+
+def test_a_pending_approval_is_never_purged(db_session, test_user, account):
+    """A parked execution is waiting on that row."""
+    pending = _approval(db_session, test_user, age_days=900, status="pending")
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, pending.id) is True
+
+
+def test_a_purged_pack_leaves_the_receipt_explained(db_session, test_user, account):
+    execution, artifact = _evidence(db_session, test_user, age_days=500)
+    execution.evidence_receipt = {
+        "status": "available",
+        "artifact_id": str(artifact.id),
+        "kind": "evidence",
+    }
+    db_session.add(execution)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+    db_session.expire(execution)
+
+    receipt = db_session.get(models.FlowExecution, execution.id).evidence_receipt
+    assert receipt["status"] == "expired"
+    assert receipt["error"] == "retention_purged"
+
+
+# --- bounds ----------------------------------------------------------------
+
+
+def test_the_pass_stops_at_the_batch_ceiling_and_says_so(
+    db_session, account, monkeypatch
+):
+    for _ in range(5):
+        _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_batch_size", 1, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_max_batches", 2, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted == 2
+    assert result.budget_exhausted is True
+    remaining = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == "permission_check",
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(remaining) == 3
+
+
+def test_the_purge_is_off_unless_the_deployment_enables_it(
+    db_session, account, monkeypatch
+):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_enabled", False, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.skipped_reason == "disabled"
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+def test_a_dry_run_counts_without_deleting(db_session, account, monkeypatch):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_dry_run", True, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted >= 1
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+def test_another_accounts_rows_are_never_touched(db_session, account, test_user):
+    from preloop.models.crud import crud_account
+
+    other = crud_account.create(
+        db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+    )
+    theirs = _audit_row(db_session, other.id, age_days=900)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, AuditLog, theirs.id) is True
+
+
+# --- the off-peak window ---------------------------------------------------
+
+
+def test_outside_the_window_the_pass_does_nothing(db_session, account, monkeypatch):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_window_utc", "1-5", raising=False)
+
+    result = purge.run_retention_purge(
+        db_session,
+        account_ids=[account.id],
+        now=datetime(2026, 5, 5, 14, 0, tzinfo=UTC),
+    )
+
+    assert result.skipped_reason == "outside_window"
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1-5", (1, 5)),
+        ("22-3", (22, 3)),
+        ("", None),
+        (None, None),
+        ("nonsense", None),
+        ("1-99", None),
+    ],
+)
+def test_window_parsing(raw, expected):
+    assert purge.parse_window(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "hour,window,inside",
+    [
+        (3, (1, 5), True),
+        (14, (1, 5), False),
+        (23, (22, 3), True),
+        (2, (22, 3), True),
+        (12, (22, 3), False),
+        (12, None, True),
+    ],
+)
+def test_window_membership_handles_midnight(hour, window, inside):
+    now = datetime(2026, 5, 5, hour, 30, tzinfo=UTC)
+    assert purge.in_window(now, window) is inside
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_the_purge_writes_an_audit_row_with_the_count(db_session, account):
+    for _ in range(3):
+        _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PURGE,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    audit_class = [row for row in rows if row.resource_id == CLASS_AUDIT]
+    assert len(audit_class) == 1
+    details = audit_class[0].details
+    assert details["deleted"] == 3
+    assert details["retention_days"] == 365
+    assert details["cutoff"]
+
+
+def test_the_audit_row_the_purge_writes_is_not_purged_by_the_same_pass(
+    db_session, account
+):
+    """The record of a deletion must outlive the deletion it records."""
+    _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PURGE,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+def test_a_dry_run_audits_under_its_own_action(db_session, account, monkeypatch):
+    _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_dry_run", True, raising=False)
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PREVIEW,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows

--- a/docs/guide/flows/evidence-storage.md
+++ b/docs/guide/flows/evidence-storage.md
@@ -3,9 +3,12 @@
 Audit-style flows write a human-readable pack under `/workspace/evidence/`
 plus `/workspace/result.json`. This page is the operator runbook for how
 that pack is transported, stored, retrieved and retained. It does **not**
-claim legal hold, WORM, object-lock, certification, or CRA Article 14
-filing. Cross-link the [security audit presets](security-audit-presets.md)
-guide for the JSON contracts themselves.
+claim WORM, object-lock, certification, or CRA Article 14 filing. It does
+now carry a legal hold, which is a Preloop-level control and not a storage
+guarantee: see [Retention and legal hold](#retention-and-legal-hold) for
+exactly what that does and does not mean. Cross-link the
+[security audit presets](security-audit-presets.md) guide for the JSON
+contracts themselves.
 
 ## Two transports
 
@@ -123,7 +126,11 @@ Receipt fields include `kind=evidence`, `artifact_id`, `sha256`/`digest`,
 from a poll as insufficient; they must use the stored artifact id and digest,
 then confirm on download.
 
-`object_lock` and `legal_hold` are always `false`. Do not treat a passing
+`object_lock` is always `false` (see
+[Retention and legal hold](#retention-and-legal-hold)). `legal_hold` is
+`true` while a hold covers the pack or its execution, and false otherwise.
+A held pack is not reported `expired` and its ciphertext is not cleared,
+so `available` on a held pack means the bytes are still there. Do not treat a passing
 CRA `result.json` as proof the pack is available: check the receipt, then
 download. Fail-result runs retain evidence the same way as pass runs.
 
@@ -141,6 +148,120 @@ Direct-upload failure emits `evidence error` / `result error` markers
 and a `failed` or `missing` receipt — never cleartext pack bytes on the
 log channel.
 
+## Retention and legal hold
+
+Two different clocks, and confusing them is the mistake this section exists
+to prevent.
+
+**The evidence payload window** is `FLOW_EVIDENCE_RETENTION_HOURS` (720, 30
+days). It governs the encrypted bytes and it is an operational review window,
+sized for the people who read packs, not for an archive.
+
+**Record retention** is per account and per record class, in days, with a
+**floor of 183 days (six months)** and a default of 365. It governs the
+records: audit rows, approval requests, evidence pack rows (manifest, digest,
+receipt metadata), runtime sessions and usage rows. The floor exists because
+AI Act Art. 26(6) asks a deployer to keep automatically generated logs for at
+least six months and DORA asks for comparable record keeping. Nothing can be
+set below it. A deployment may raise the floor with `RETENTION_FLOOR_DAYS`; it
+cannot lower it.
+
+So an evidence pack row survives for the record retention while the encrypted
+pack itself is cleared after the payload window. That is deliberate. Keeping
+every pack for six months by default would multiply stored bytes against the
+per-account artifact quota on upgrade, without anybody asking for it. If a
+specific pack has to survive, place a legal hold on it or export the period.
+
+| Record class | Covers |
+| --- | --- |
+| `audit` | Audit log rows |
+| `approvals` | Approval requests and their events |
+| `evidence` | Evidence pack records (manifest and digest), not the payload |
+| `runtime_sessions` | Runtime sessions and session activity |
+| `usage` | API and gateway usage rows |
+
+```
+GET  /api/v1/retention/settings        # resolved days per class, plus the floor
+PUT  /api/v1/retention/settings        # {"classes": {"audit": 400}}; below the floor is a 422
+GET  /api/v1/retention/purge-preview   # what today's purge would remove, per class
+```
+
+### The purge
+
+Records past retention are deleted by a background sweeper, never on a
+request. It is **off by default**: set `RETENTION_PURGE_ENABLED=true` to turn
+it on. An upgrade must not silently start deleting audit history, so until an
+operator enables it, retention is a stated policy that nothing enforces, and
+`GET /api/v1/retention/settings` says so in `purge_enabled`.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `RETENTION_PURGE_ENABLED` | `false` | Nothing is deleted while this is false |
+| `RETENTION_PURGE_DRY_RUN` | `false` | Count and audit, delete nothing |
+| `RETENTION_PURGE_WINDOW_UTC` | `1-5` | Off-peak UTC hours; empty means any hour |
+| `RETENTION_PURGE_INTERVAL_SECONDS` | `3600` | Time between passes |
+| `RETENTION_PURGE_BATCH_SIZE` | `1000` | Rows per DELETE |
+| `RETENTION_PURGE_MAX_BATCHES` | `50` | Batch ceiling per class per pass |
+| `RETENTION_PURGE_MAX_SECONDS` | `300` | Wall-clock budget per pass |
+
+A pass that hits a bound stops and resumes next time rather than running long.
+Every pass that removed anything writes an audit row per record class with the
+cutoff and the count, so the deletion of records is itself a record.
+
+### Legal hold
+
+A hold freezes one execution, approval request or evidence pack. While it is
+in force the purge skips the row and the janitor leaves the ciphertext alone
+past `expires_at`, so a held pack stays downloadable. A reason is mandatory,
+the actor is recorded, and both placing and releasing write audit rows.
+
+```
+GET  /api/v1/retention/holds
+POST /api/v1/retention/holds                  # {"resource_type": "execution", "resource_id": "...", "reason": "..."}
+POST /api/v1/retention/holds/{id}/release     # {"reason": "..."}
+```
+
+A hold on an execution also covers that execution's evidence packs. Holds
+overlap safely: releasing an execution hold does not unfreeze a pack that
+carries its own hold.
+
+**What a legal hold is not.** It is a Preloop control, enforced by Preloop
+code against the Preloop database. It is not WORM, and it is not S3 Object
+Lock. `object_lock` stays `false` on every receipt because Preloop cannot
+verify a property of the storage layer beneath it: an operator with database
+access can still delete a held row, and a backup restore can still reintroduce
+a purged one. If your obligation requires immutability that survives a
+platform administrator, put that control in the storage layer and use the
+period export to hold the record somewhere Preloop cannot reach.
+
+### Period export
+
+`POST /api/v1/retention/exports?start=YYYY-MM-DD&end=YYYY-MM-DD` returns a
+`tar.gz` of one period (start inclusive, end exclusive, so consecutive
+periods tile without double counting).
+
+```
+manifest.json                    schema preloop.retention.period_export_manifest/v1
+approvals/approval_request.jsonl
+audit/audit_log.jsonl
+evidence/receipts.jsonl          receipts, not payloads: artifact id and digest
+holds/legal_hold.jsonl
+```
+
+`manifest.json` carries `members` with a `sha256` and `size_bytes` per member
+and a `members_digest` over that list, the same shape and the same computation
+an evidence pack manifest uses, so one verifier covers both. The response
+headers repeat the digests (`X-Preloop-Archive-Sha256`,
+`X-Preloop-Members-Digest`). Every export writes an audit row naming the
+period, the counts and the archive digest.
+
+The bundle is **not signed**. The digests show the archive was not altered
+after Preloop built it. They do not show the records were true when they were
+written; that is the audit hash chain in #558. Exports are capped at
+`RETENTION_EXPORT_MAX_ROWS` (100000) per record class and 366 days per
+archive, and going over is an error asking for a narrower period rather than a
+truncated archive somebody later mistakes for the whole period.
+
 ## Operator checklist
 
 1. Enable `FLOW_ARTIFACT_DIRECT_UPLOAD` only after runners can reach the
@@ -154,3 +275,10 @@ log channel.
    skippable warning.
 5. Keep Kubernetes RBAC for pod logs tight on clusters that still run the
    legacy log channel (`FLOW_ARTIFACT_DIRECT_UPLOAD=false`).
+6. Decide record retention per class and set `RETENTION_PURGE_ENABLED`
+   deliberately. Until it is on, nothing is deleted and the stated retention
+   is not enforced. Run `GET /api/v1/retention/purge-preview` before the
+   first enabled pass.
+7. Place a legal hold before an incident review starts, not after the
+   payload window has closed. A hold pins bytes that are still there; it
+   cannot bring back bytes already cleared.

--- a/docs/guide/flows/product-evidence.md
+++ b/docs/guide/flows/product-evidence.md
@@ -112,11 +112,15 @@ it could:
 - Human approval invented from model output. Reviewer names and
   timestamps come from the approval audit trail, or they are omitted.
 - Certification, CE marking, or a completed conformity assessment.
-- Legal hold, object-lock, or WORM retention of evidence blobs. The
-  dossier copies a server-owned `kind=evidence` receipt (`sha256`,
-  status, retention hours, `integrity_verified`) from
-  `inspect_evidence` / `load_evidence`. Availability polls are not
-  download integrity. `retained` is true only after a verified receipt.
+- Object-lock or WORM retention of evidence blobs. A Preloop legal hold
+  does exist now (see
+  [evidence storage](evidence-storage.md#retention-and-legal-hold)): it
+  blocks purge and payload expiry inside Preloop, and it is not a
+  storage-layer guarantee. The dossier copies a server-owned
+  `kind=evidence` receipt (`sha256`, status, retention hours,
+  `legal_hold`, `integrity_verified`) from `inspect_evidence` /
+  `load_evidence`. Availability polls are not download integrity.
+  `retained` is true only after a verified receipt.
 - A successful **product** publication when any one repository failed
   to push or open its pull request. Local commits are not success.
   Partial remote receipts stay on the execution; the run is failed.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4768,6 +4768,235 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/settings:
+    get:
+      tags:
+      - Retention
+      summary: Get Retention Settings
+      description: Return this account's retention per record class, and the floor.
+      operationId: get_retention_settings_api_v1_retention_settings_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionSettingsRead'
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - Retention
+      summary: Update Retention Settings
+      description: 'Set retention per record class, never below the six month floor.
+
+
+        The body is the full desired state: a class the caller omits, or sets to
+
+        null, goes back to the deployment default.'
+      operationId: update_retention_settings_api_v1_retention_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetentionSettingsUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionSettingsRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /api/v1/retention/purge-preview:
+    get:
+      tags:
+      - Retention
+      summary: Preview Retention Purge
+      description: 'Count what the purge would remove today, without removing anything.
+
+
+        Nobody should discover the effect of a retention setting by watching rows
+
+        disappear. Rows under a legal hold are already excluded by the same
+
+        filters the purge uses, so the count is the count.'
+      operationId: preview_retention_purge_api_v1_retention_purge_preview_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPurgePreview'
+      security:
+      - bearerAuth: []
+  /api/v1/retention/holds:
+    get:
+      tags:
+      - Retention
+      summary: List Legal Holds
+      description: List this account's legal holds, newest first.
+      operationId: list_legal_holds_api_v1_retention_holds_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: active_only
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Hide released holds
+          default: true
+          title: Active Only
+        description: Hide released holds
+      - name: resource_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resource Type
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalHoldRead'
+                title: Response List Legal Holds Api V1 Retention Holds Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - Retention
+      summary: Create Legal Hold
+      description: Freeze one execution, approval or evidence pack until released.
+      operationId: create_legal_hold_api_v1_retention_holds_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalHoldCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalHoldRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/holds/{hold_id}/release:
+    post:
+      tags:
+      - Retention
+      summary: Release Legal Hold
+      description: Lift a hold. The record stays, with who lifted it and why.
+      operationId: release_legal_hold_api_v1_retention_holds__hold_id__release_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: hold_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Hold Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalHoldRelease'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalHoldRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/exports:
+    post:
+      tags:
+      - Retention
+      summary: Create Period Export
+      description: 'Build a tar.gz of one period: audit rows, approvals, receipts,
+        holds.
+
+
+        The archive carries ``manifest.json`` with a sha256 per member and a
+
+        digest over the member list, in the same shape an evidence pack manifest
+
+        uses, so one verifier covers both.'
+      operationId: create_period_export_api_v1_retention_exports_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: start
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Period start, inclusive (YYYY-MM-DD)
+          title: Start
+        description: Period start, inclusive (YYYY-MM-DD)
+      - name: end
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Period end, exclusive (YYYY-MM-DD)
+          title: End
+        description: Period end, exclusive (YYYY-MM-DD)
+      responses:
+        '200':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/notification-preferences/me:
     get:
       tags:
@@ -9135,9 +9364,13 @@ paths:
 
         Served from the persisted execution receipt (no decrypt). Availability
 
-        is not integrity proof. ``object_lock`` and ``legal_hold`` are always
+        is not integrity proof. ``object_lock`` is always false: this API does
 
-        false: this API does not implement WORM retention.'
+        not implement WORM retention and cannot verify a property of the storage
+
+        layer beneath it. ``legal_hold`` is true while a hold covers the pack or
+
+        its execution, which blocks payload expiry and purge inside Preloop.'
       operationId: get_flow_execution_evidence_status_api_v1_flows_executions__execution_id__evidence_status_get
       security:
       - bearerAuth: []
@@ -18351,6 +18584,105 @@ components:
       - row_count
       title: LedgerBackfillUnmatched
       description: Unpriced usage rows whose family had no ledger spend that day.
+    LegalHoldCreate:
+      properties:
+        resource_type:
+          type: string
+          title: Resource Type
+          description: One of execution, approval, evidence_pack
+        resource_id:
+          type: string
+          maxLength: 255
+          title: Resource Id
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 8
+          title: Reason
+          description: Why this record is frozen. Written to the audit log.
+      type: object
+      required:
+      - resource_type
+      - resource_id
+      - reason
+      title: LegalHoldCreate
+      description: Place a hold on one execution, approval or evidence pack.
+    LegalHoldRead:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        resource_type:
+          type: string
+          title: Resource Type
+        resource_id:
+          type: string
+          title: Resource Id
+        reason:
+          type: string
+          title: Reason
+        placed_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Placed By User Id
+        placed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Placed At
+        released_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Released By User Id
+        released_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Released At
+        release_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Release Reason
+        active:
+          type: boolean
+          title: Active
+        flagged:
+          anyOf:
+          - additionalProperties:
+              type: integer
+            type: object
+          - type: 'null'
+          title: Flagged
+      type: object
+      required:
+      - id
+      - resource_type
+      - resource_id
+      - reason
+      - active
+      title: LegalHoldRead
+      description: One hold, active or released.
+    LegalHoldRelease:
+      properties:
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 8
+          title: Reason
+          description: Why the hold is being lifted. Written to the audit log.
+      type: object
+      required:
+      - reason
+      title: LegalHoldRelease
+      description: Lift a hold. The release reason is recorded too.
     LoginRequest:
       properties:
         username:
@@ -21215,6 +21547,123 @@ components:
       - reason
       title: ResumeRequest
       description: Explicit human retry. Historical decisions stay append-only.
+    RetentionClassRead:
+      properties:
+        record_class:
+          type: string
+          title: Record Class
+        label:
+          type: string
+          title: Label
+        days:
+          type: integer
+          title: Days
+        source:
+          type: string
+          title: Source
+          description: '''account'' when this account set it, ''default'' otherwise'
+        floored:
+          type: boolean
+          title: Floored
+          description: True when the stored value was raised to meet the floor
+          default: false
+      type: object
+      required:
+      - record_class
+      - label
+      - days
+      - source
+      title: RetentionClassRead
+      description: Resolved retention for one record class.
+    RetentionPurgePreview:
+      properties:
+        account_id:
+          type: string
+          format: uuid
+          title: Account Id
+        purge_enabled:
+          type: boolean
+          title: Purge Enabled
+        classes:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Classes
+        total:
+          type: integer
+          title: Total
+      type: object
+      required:
+      - account_id
+      - purge_enabled
+      - classes
+      - total
+      title: RetentionPurgePreview
+      description: What a purge would remove right now, without removing it.
+    RetentionSettingsRead:
+      properties:
+        floor_days:
+          type: integer
+          title: Floor Days
+          description: No record class can be set below this many days
+        default_days:
+          type: integer
+          title: Default Days
+          description: Applied to any class this account has not set
+        max_days:
+          type: integer
+          title: Max Days
+        classes:
+          items:
+            $ref: '#/components/schemas/RetentionClassRead'
+          type: array
+          title: Classes
+        purge_enabled:
+          type: boolean
+          title: Purge Enabled
+          description: False when this deployment never deletes. Retention is then
+            a stated policy that nothing enforces.
+        purge_dry_run:
+          type: boolean
+          title: Purge Dry Run
+        purge_window_utc:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Purge Window Utc
+          description: Off-peak UTC hour window the purge runs in, e.g. '1-5'
+        evidence_payload_hours:
+          type: integer
+          title: Evidence Payload Hours
+          description: How long encrypted evidence payloads are kept. Separate from
+            the 'evidence' record class, which governs the record row.
+      type: object
+      required:
+      - floor_days
+      - default_days
+      - max_days
+      - classes
+      - purge_enabled
+      - purge_dry_run
+      - evidence_payload_hours
+      title: RetentionSettingsRead
+      description: Everything the console needs to render the retention panel.
+    RetentionSettingsUpdate:
+      properties:
+        classes:
+          additionalProperties:
+            anyOf:
+            - type: integer
+            - type: 'null'
+          type: object
+          title: Classes
+          description: 'Record class to days. null clears the account''s setting for
+            that class. Known classes: audit, approvals, evidence, runtime_sessions,
+            usage'
+      type: object
+      title: RetentionSettingsUpdate
+      description: Full desired state. An omitted class falls back to the default.
     RollbackRequest:
       properties:
         preview_only:


### PR DESCRIPTION
Closes #557.

Records had no retention at all (audit rows, approvals, sessions and usage lived until the account was deleted) and evidence packs had a 30 day operational window. "Forever" is not a retention policy any more than "30 days" is: the first is a liability nobody chose, the second is shorter than the obligation. There was also no way to stop the clock on a record under investigation: `legal_hold` was documented as always false, and a run under an incident review expired on the same schedule as one nobody would look at again.

## Settings, with a floor

An account states retention per record class in days. Five classes: `audit`, `approvals`, `evidence` (the pack record, manifest and digest), `runtime_sessions`, `usage`. Floor 183 days (six months, the AI Act Art. 26(6) horizon), default 365. The floor is a module constant, not a setting; `RETENTION_FLOOR_DAYS` can only raise it, and a stored value under the floor resolves up to the floor at read time as well as write time. This is the mirror image of the account cap in `services/approval_window.py`, where an account may only tighten a ceiling.

Stored in `account.meta_data["retention"]`, the bucket #510 established for `approval_window_max_seconds`.

```
GET  /api/v1/retention/settings        resolved days per class, plus the floor
PUT  /api/v1/retention/settings        {"classes": {"audit": 400}}; below the floor is 422
GET  /api/v1/retention/purge-preview   what today's pass would remove, per class
```

## The purge

A bounded sweeper, off the request path, modeled on the optimization job sweeper. Bounded four ways: 1000 row batches, a batch ceiling per class, a wall clock budget per pass, and an off-peak UTC window (default 01:00-05:00). One transaction per batch, so a retention backlog never holds a long lock on a table the request path writes to. A pass that hits a bound stops and resumes next time.

**Off by default.** `RETENTION_PURGE_ENABLED=false` so an upgrade never silently starts deleting audit history, and the settings endpoint says so in `purge_enabled` rather than letting an operator believe a stated policy is enforced. `RETENTION_PURGE_DRY_RUN` gives the counts and the audit rows without the deletes.

Every pass that removed anything writes an audit row per record class with the cutoff and the count, so the deletion of records is itself a record. Never purged: approvals still `pending` (a parked execution is waiting on that row), anything under a hold, another account's rows.

## Legal hold

A `legal_hold` record row carries the actor and a mandatory reason; a derived boolean on `flow_execution`, `approval_request` and `flow_artifact` is what the purge and the janitor test, so both stay single table queries over a partial index. A partial unique index (`WHERE released_at IS NULL`) allows one active hold per resource and lets a released record be held again.

The hold blocks payload expiry, not only deletion: `crud/flow_artifact.cleanup()` skips held rows, so a pack a regulator may ask for is still downloadable. "The record row survived but the bytes are gone" is not what anyone means by a hold. Placing a hold also stamps the persisted execution receipt so the cheap `evidence-status` poll and the live inspect agree.

Release recomputes the flags from the holds that remain active rather than clearing them: an execution hold and a pack hold can cover the same pack, and lifting one must leave the other in force. Both place and release are audited; a hold that can be lifted without a trace proves nothing.

## Period export

`POST /api/v1/retention/exports?start=&end=` streams a tar.gz: `manifest.json`, `audit/audit_log.jsonl`, `approvals/approval_request.jsonl`, `evidence/receipts.jsonl`, `holds/legal_hold.jsonl`. Start inclusive, end exclusive, so consecutive periods tile without a row landing in both bundles or neither.

The manifest reuses #511's evidence pack shape: same `members` entries, same `members_digest` over the same `canonical_manifest_json`. One verifier covers both formats, and the signing work in #558 has one thing to sign. Response headers repeat the digests. Every export is audited with the period, the counts and the archive digest, because an export is a bulk read of an account's compliance record.

Evidence goes in **by receipt** (artifact id, digest, expiry, hold state), never inlined: payloads would be unbounded and would duplicate bytes the evidence download already serves under its own digest check. `tool_args` and `tool_result` are excluded from approval rows; they carry whatever the agent was about to do, which is not what a retention export is for. Bounded at 100000 rows per class and 366 days per archive, and over the bound is an error asking for a narrower period rather than a truncated archive somebody later mistakes for the whole period.

Fixed tar mtime and sorted members, so the same rows produce byte identical archives.

## The honest WORM statement

`docs/guide/flows/evidence-storage.md` gains a "Retention and legal hold" section. It says plainly that a hold is a Preloop control enforced by Preloop code against the Preloop database: it is not WORM and not S3 Object Lock, `object_lock` stays false because Preloop cannot verify a property of the storage layer beneath it, an operator with database access can still delete a held row, and a backup restore can still reintroduce a purged one. If your obligation needs immutability that survives a platform administrator, put that control in the storage layer and use the export.

It also separates the two clocks that are easy to confuse: `FLOW_EVIDENCE_RETENTION_HOURS` governs the encrypted payload (an operational review window), record retention governs the pack record. Keeping every payload for six months by default would multiply stored bytes against the per-account artifact quota on upgrade without anyone asking for it. A hold pins the payload when it matters.

The two stale "always false" claims (`api/endpoints/flows.py`, `docs/guide/flows/product-evidence.md`) are corrected.

## Not in this PR

Hash chain over audit rows, signed exports, signing key management (that is #558). The export manifest is shaped so a signature can be added beside the digest without changing the member list. No console surface: the settings panel belongs on the EE side, and OSS is served by the API plus env defaults.

## Testing

104 new tests on real Postgres 16, all passing:

- `tests/services/test_retention_policy.py` (13): floor enforcement at the boundary, a stored value under the floor, a deployment raising but not lowering it, unknown classes refused, other metadata untouched.
- `tests/services/test_legal_hold.py` (16): a held pack survives the janitor and an unheld one does not, receipt reporting, overlapping holds, release, refusals, audit rows for both directions.
- `tests/services/test_retention_purge.py` (29): holds respected per class, pending approvals never purged, batch ceiling, disabled, dry run, cross account isolation, the window including midnight wrap, audit rows with counts, and the purge audit row surviving the next pass.
- `tests/services/test_retention_export.py` (17): manifest digests every member, the members digest matches the evidence pack computation, period boundaries, payloads absent, tool args absent, reproducible bytes, the row cap refused rather than truncated.
- `tests/api/test_retention_api.py` (24): the 422 naming the floor, hold conflict and 404 codes, listing and release, the tar over the wire, the digest headers, the 413.
- `tests/models/test_retention_legal_hold_migration.py` (5): downgrade then upgrade on real Postgres, diffed against the ORM, plus the partial unique index and the SET NULL on the actor columns.

Whole backend suite: 9575 passed, 53 skipped, 11 failed. All 11 fail identically on `main` at 86457e59 (`test_issue_compliance.py`, `test_issue_duplicates.py`, `test_model_pricing.py`); none are touched by this branch. Frontend unchanged: 2376 tests pass, `tsc --noEmit` clean, build clean.
