### PR TITLE
Tamper-evident audit log and signed, verifiable exports

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -62,6 +62,22 @@ regexes = [
 ]
 
 # ---------------------------------------------------------------------------
+# Cryptography type names
+# ---------------------------------------------------------------------------
+# generic-api-key treats `private_key: <TypeName>` as a committed secret.
+# Ed25519PrivateKey / Ed25519PublicKey are cryptography class names, not
+# PEM or raw key material. The match first appeared on the audit-chain
+# branch (480bd991) and Secret Scan walks full history (fetch-depth: 0),
+# so every PR that fetches that commit fails until this class is allowed.
+[[allowlists]]
+description = "Cryptography type names, not key material"
+regexTarget = "secret"
+regexes = [
+  '''^Ed25519PrivateKey$''',
+  '''^Ed25519PublicKey$''',
+]
+
+# ---------------------------------------------------------------------------
 # Generated example payloads
 # ---------------------------------------------------------------------------
 # scripts/generate_example_session.py builds a fake GitHub Actions session for

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,13 @@ The [account kill switch](docs/guide/account-kill-switch.md) serializes halt tra
 Database worker ownership, row-lock compatibility, and cancellation rules are
 documented in [Transactions and asynchronous request handling](docs/architecture/data-model.md#transactions-and-asynchronous-request-handling).
 
+Audit rows are sealed into a per-account hash chain with signed checkpoints.
+Period exports and evidence packs carry detached Ed25519 signatures.
+`preloop audit verify` and `preloop evidence verify` recompute both on the
+caller's machine. See [Evidence storage and signed records](docs/guide/flows/evidence-storage.md).
+The chain proves order and non-deletion in the range it names, not that the
+records were true when written; the signing key lives beside the records.
+
 ## High-Level Architecture
 
 ```mermaid
@@ -72,7 +79,7 @@ graph LR
 | [Data model](docs/architecture/data-model.md) | `preloop.models`, PostgreSQL + PGVector, schema, and backend project layout. |
 | [MCP](docs/architecture/mcp.md) | FastMCP integration, dynamic tool filtering, and the HTTP MCP request path. |
 | [Realtime](docs/architecture/realtime.md) | Unified WebSocket, MessageRouter topics, and account-scoped pub/sub. |
-| [Security](docs/architecture/security.md) | Auth and tenancy, redaction, secret custody, security-screen scoring, and `preloop.security`. |
+| [Security](docs/architecture/security.md) | Auth and tenancy, redaction, secret custody, audit hash chain, record signing, security-screen scoring, and `preloop.security`. |
 | [Decisions](docs/architecture/decisions.md) | Why FastAPI, Python, and PostgreSQL, and how the stack is deployed (Compose, Helm, service roles). |
 | [Flows](docs/architecture/flows.md) | Event-driven agentic flows, remote runners, matrix/batch fan-out, label-based model routing, eval artifacts, and evidence packs. |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `POST /api/v1/retention/exports?start=&end=` returns a tar.gz of one period
   (audit rows, approvals, evidence receipts, holds) with a `manifest.json`
   carrying a sha256 per member and a digest over the member list, in the same
-  shape an evidence pack manifest uses. The bundle is not signed; the digests
-  show the archive was not altered after Preloop built it, not that the
-  records were true when they were written.
+  shape an evidence pack manifest uses. The bundle is signed as of the entry
+  below; the digests and the signature show the archive is the one Preloop
+  built and has not been altered since, not that the records were true when
+  they were written.
+
+- **Tamper-evident audit log and signed, verifiable exports**: audit rows are
+  now sealed into a per-account hash chain. A bounded background pass gives
+  each row a `chain_seq`, the previous row's `row_hash` as `prev_hash`, and
+  its own `row_hash` over a canonical serialisation, so an edit, a deletion
+  from the middle or a reordering breaks every hash from that point on
+  (`AUDIT_CHAIN_ENABLED`, on by default: it only adds hashes, it never
+  removes a record). `GET /api/v1/audit/chain/status`, `/chain/verify`,
+  `/chain/segment` and `/chain/checkpoints`; the segment endpoint serves the
+  canonical payloads and stored hashes so `preloop audit verify` recomputes
+  every hash locally, reports the first break with its sequence and row id,
+  exits non-zero on a break, and says so when its verdict differs from ours.
+  Every `AUDIT_CHAIN_CHECKPOINT_INTERVAL` sealed rows a checkpoint over the
+  chain head is signed, which is the anchor a customer keeps off the
+  platform. The retention purge raises the chain's `pruned_below_seq` floor
+  as it deletes, so enforcing retention does not read as tampering.
+  Each account gets an Ed25519 signing key, stored encrypted like other
+  secrets, with the public half on `GET /api/v1/signing/keys` and rotation
+  through `POST /api/v1/signing/keys/rotate` (retired keys stay published and
+  their signatures stay valid). Period exports carry a detached
+  `signature.json` over the manifest digest, and evidence packs are signed at
+  capture with the signature served on the receipt and the download headers.
+  `preloop evidence verify <archive>` checks both, and `--public-key` checks
+  a bundle against a key you kept yourself, without contacting us.
+  What this does not do, stated in the docs as well: a compromised server can
+  forge a record before it is signed, and the chain proves order and
+  non-deletion within the range it names, not that the server told the truth.
 
 - **Approval windows on a human timescale, with parked executions**: an
   approval or question can now stay open for hours or days instead of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Record retention, legal hold and period export**: an account now states
+  how long it keeps each class of record (audit rows, approvals, evidence
+  pack records, runtime sessions, usage) in days, with a floor of 183 days
+  (six months, the AI Act Art. 26(6) horizon) that a deployment can raise and
+  nothing can lower, and a 365 day default.
+  `GET/PUT /api/v1/retention/settings` and `GET /api/v1/retention/purge-preview`.
+  A bounded background sweeper deletes what is past retention: batches of
+  1000, a batch ceiling, a wall clock budget per pass and an off-peak UTC
+  window, one audit row per class per pass with the cutoff and the count. It
+  is **off by default** (`RETENTION_PURGE_ENABLED`), so an upgrade never
+  silently starts deleting audit history, and `RETENTION_PURGE_DRY_RUN` gives
+  the counts without the deletes. A legal hold
+  (`POST /api/v1/retention/holds`, mandatory reason, actor recorded, audited
+  on both place and release) freezes one execution, approval or evidence
+  pack: the purge skips it and the evidence janitor leaves the ciphertext
+  alone past `expires_at`, so a held pack is still downloadable. Evidence
+  receipts now report the real `legal_hold` state instead of a hardcoded
+  false; `object_lock` stays false because Preloop cannot verify a property
+  of the storage layer beneath it.
+  `POST /api/v1/retention/exports?start=&end=` returns a tar.gz of one period
+  (audit rows, approvals, evidence receipts, holds) with a `manifest.json`
+  carrying a sha256 per member and a digest over the member list, in the same
+  shape an evidence pack manifest uses. The bundle is not signed; the digests
+  show the archive was not altered after Preloop built it, not that the
+  records were true when they were written.
+
 - **Approval windows on a human timescale, with parked executions**: an
   approval or question can now stay open for hours or days instead of the
   fixed 5 minutes. `approval_window_seconds` is a per-flow setting (flow form

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -37,6 +37,7 @@ from preloop.api.endpoints import (
     anthropic_gateway,
     audio,
     approval_bypass,
+    audit_chain,
     approval_requests,
     comments,
     cost,
@@ -385,6 +386,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             service_role,
         )
 
+    # Start the audit chain sealer (skip in testing mode). It chains audit
+    # rows written since the last pass. Off the request path on purpose: the
+    # alternative is a per-account lock held for the duration of every audited
+    # action. See preloop.services.audit_chain for why (issue #558).
+    audit_chain_sealer = None
+    if not is_testing and is_api_role and settings.audit_chain_enabled:
+        from preloop.services.audit_chain import get_audit_chain_sealer
+
+        audit_chain_sealer = get_audit_chain_sealer()
+        await audit_chain_sealer.start()
+        logger.info("Audit chain sealer started.")
+    else:
+        logger.info(
+            "Audit chain sealer not started (enabled=%s, role=%s).",
+            settings.audit_chain_enabled,
+            service_role,
+        )
+
     # Start the webhook delivery worker (skip in testing mode). Outbound
     # deliveries never run on the request path; this drains the outbox.
     webhook_delivery_worker = None
@@ -596,6 +615,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("Webhook delivery worker stopped.")
         except Exception as e:
             logger.error(f"Error stopping webhook delivery worker: {e}", exc_info=True)
+
+    # Stop the audit chain sealer. Rows it did not reach stay unsealed and are
+    # picked up by the next process; the chain is append only, so an
+    # interrupted pass costs nothing but lag.
+    if not is_testing and audit_chain_sealer:
+        try:
+            await audit_chain_sealer.stop()
+            logger.info("Audit chain sealer stopped.")
+        except Exception as e:
+            logger.error(f"Error stopping audit chain sealer: {e}", exc_info=True)
 
     # Stop the retention purge sweeper. A pass in flight finishes its current
     # batch and stops at the next check; batches are small on purpose so this
@@ -1052,6 +1081,16 @@ def create_app() -> FastAPI:
         )
         app.include_router(
             retention.router,
+            prefix="/api/v1",
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            audit_chain.router,
+            prefix="/api/v1",
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            audit_chain.signing_router,
             prefix="/api/v1",
             dependencies=[Depends(get_current_active_user)],
         )

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -53,6 +53,7 @@ from preloop.api.endpoints import (
     projects,
     public_approval,
     pull_requests,
+    retention,
     roles,
     search as search_router,
     security_maintenance,
@@ -365,6 +366,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     else:
         logger.info("Skipping optimization job sweeper for %s role.", service_role)
 
+    # Start the retention purge sweeper (skip in testing mode). Off the
+    # request path by construction, and it sleeps before its first pass rather
+    # than deleting on boot: a crash loop must not turn into a delete loop.
+    # Disabled unless RETENTION_PURGE_ENABLED is set, so an upgrade never
+    # silently starts removing audit history.
+    retention_purge_sweeper = None
+    if not is_testing and is_api_role and settings.retention_purge_enabled:
+        from preloop.services.retention_purge import get_retention_purge_sweeper
+
+        retention_purge_sweeper = get_retention_purge_sweeper()
+        await retention_purge_sweeper.start()
+        logger.info("Retention purge sweeper started.")
+    else:
+        logger.info(
+            "Retention purge sweeper not started (enabled=%s, role=%s).",
+            settings.retention_purge_enabled,
+            service_role,
+        )
+
     # Start the webhook delivery worker (skip in testing mode). Outbound
     # deliveries never run on the request path; this drains the outbox.
     webhook_delivery_worker = None
@@ -576,6 +596,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("Webhook delivery worker stopped.")
         except Exception as e:
             logger.error(f"Error stopping webhook delivery worker: {e}", exc_info=True)
+
+    # Stop the retention purge sweeper. A pass in flight finishes its current
+    # batch and stops at the next check; batches are small on purpose so this
+    # is a short wait, and a half-done purge is simply resumed next pass.
+    if not is_testing and retention_purge_sweeper:
+        try:
+            await retention_purge_sweeper.stop()
+            logger.info("Retention purge sweeper stopped.")
+        except Exception as e:
+            logger.error(f"Error stopping retention purge sweeper: {e}", exc_info=True)
 
     # Stop the optimization-job sweeper and abandon in-flight optimization
     # jobs (skip in testing mode). shutdown(wait=False) on purpose: a model
@@ -1017,6 +1047,11 @@ def create_app() -> FastAPI:
         )
         app.include_router(
             event_webhooks.router,
+            prefix="/api/v1",
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            retention.router,
             prefix="/api/v1",
             dependencies=[Depends(get_current_active_user)],
         )

--- a/backend/preloop/api/endpoints/audit_chain.py
+++ b/backend/preloop/api/endpoints/audit_chain.py
@@ -1,0 +1,240 @@
+"""The audit chain surface and the account's signing keys (#558).
+
+Two routers, one file, because they are one feature: the chain is what the
+signatures anchor to and the keys are what makes a checkpoint mean anything
+outside this database.
+
+The design choice worth naming is ``/audit/chain/segment``. A verification
+endpoint that returns only its own verdict is worth exactly the trust the
+caller already places in the server, which for a tamper evidence feature is
+the wrong amount. The segment endpoint hands back the canonical payload and
+the stored hashes so ``preloop audit verify`` recomputes every hash locally
+and can disagree with us.
+
+Permissions follow #559 rather than inventing a fourth one: ``view_audit_logs``
+for reading the chain, since it is the audit trail, and ``manage_policies``
+for rotating a key, since that is an account wide security setting. A new
+permission would need seeding in the EE role matrix, which is not part of
+this change.
+
+Handlers are plain ``def``: they hold a synchronous session, and FastAPI
+dispatches sync handlers on the anyio threadpool, so a wait for a pool
+connection blocks a worker thread rather than the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from preloop.api.auth import get_current_active_user
+from preloop.api.common import get_account_for_user
+from preloop.models.crud import crud_audit_log
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.user import User
+from preloop.schemas.audit_chain import (
+    ChainCheckpointRead,
+    ChainSegmentRead,
+    ChainStatusRead,
+    ChainVerifyRead,
+    SigningKeyListRead,
+    SigningKeyRotateRead,
+)
+from preloop.services import audit_chain, record_signing
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/audit", tags=["Audit chain"])
+signing_router = APIRouter(prefix="/signing", tags=["Signing keys"])
+
+VIEW_PERMISSION = "view_audit_logs"
+MANAGE_PERMISSION = "manage_policies"
+
+AUDIT_ACTION_VERIFY = "audit_chain_verified"
+AUDIT_ACTION_KEY_ROTATED = "signing_key_rotated"
+
+#: Documented once, served with the keys, so a verifier never has to read our
+#: source to know what a signature covers.
+SIGNED_BYTES_FORMAT = "preloop.signature/v1\\n<payload_type>\\n<digest>\\n<signed_at>"
+
+
+@router.get("/chain/status", response_model=ChainStatusRead)
+@require_permission(VIEW_PERMISSION)
+def get_chain_status(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Head, purge floor, sealing lag and the newest signed checkpoint."""
+    return audit_chain.chain_status(db, account_id=account.id)
+
+
+@router.get("/chain/verify", response_model=ChainVerifyRead)
+@require_permission(VIEW_PERMISSION)
+def verify_chain(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    start_seq: Optional[int] = Query(
+        None, ge=1, description="First sequence to check. Defaults to the purge floor."
+    ),
+    end_seq: Optional[int] = Query(
+        None, ge=1, description="Last sequence to check. Defaults to the head."
+    ),
+    max_rows: Optional[int] = Query(
+        None, ge=1, description="Cut the range at this many rows and say so."
+    ),
+):
+    """Walk a range of the chain and report the first break.
+
+    The range matters: rows below the purge floor are gone under a stated
+    retention policy and rows written since the last seal are not chained
+    yet. Claiming to verify either would be a lie of scope.
+
+    The verification is itself audited. A read of the audit trail that leaves
+    no trace is a gap in the audit trail.
+    """
+    report = audit_chain.verify_chain(
+        db,
+        account_id=account.id,
+        start_seq=start_seq,
+        end_seq=end_seq,
+        max_rows=max_rows,
+    )
+    try:
+        crud_audit_log.log_action(
+            db,
+            account_id=account.id,
+            user_id=current_user.id,
+            action=AUDIT_ACTION_VERIFY,
+            resource_type="audit_chain",
+            resource_id="verify",
+            status="success"
+            if report["status"] != audit_chain.STATUS_BROKEN
+            else "failure",
+            details={
+                "chain_status": report["status"],
+                "start_seq": report["start_seq"],
+                "end_seq": report["end_seq"],
+                "checked_rows": report["checked_rows"],
+                "first_break": report["first_break"],
+                "checkpoint_failures": len(report["checkpoint_failures"]),
+            },
+        )
+    except Exception:
+        db.rollback()
+        logger.error("Failed to audit a chain verification", exc_info=True)
+    return report
+
+
+@router.get("/chain/segment", response_model=ChainSegmentRead)
+@require_permission(VIEW_PERMISSION)
+def get_chain_segment(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    after_seq: int = Query(0, ge=0, description="Exclusive lower bound"),
+    limit: int = Query(500, ge=1, le=1000),
+):
+    """Canonical payloads and stored hashes, for a client side walk."""
+    return audit_chain.chain_segment(
+        db, account_id=account.id, after_seq=after_seq, limit=limit
+    )
+
+
+@router.get("/chain/checkpoints", response_model=list[ChainCheckpointRead])
+@require_permission(VIEW_PERMISSION)
+def list_chain_checkpoints(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    after_seq: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=1000),
+):
+    """Signed checkpoints in sequence order.
+
+    Worth keeping your own copies of. A checkpoint you stored last quarter is
+    the only thing here that a rewritten chain cannot reproduce.
+    """
+    return audit_chain.list_checkpoints(
+        db, account_id=account.id, after_seq=after_seq, limit=limit
+    )
+
+
+@signing_router.get("/keys", response_model=SigningKeyListRead)
+@require_permission(VIEW_PERMISSION)
+def list_signing_keys(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Public halves of every key this account has held.
+
+    Retired keys stay listed: every signature they made is still valid, and a
+    verifier holding a bundle from last year needs the key that signed it.
+    """
+    keys = record_signing.list_keys(db, account_id=account.id)
+    active = next((key for key in keys if key.retired_at is None), None)
+    return {
+        "active_key_id": active.key_id if active else None,
+        "signature_schema": record_signing.SIGNATURE_SCHEMA,
+        "signed_bytes_format": SIGNED_BYTES_FORMAT,
+        "keys": [record_signing.public_key_summary(key) for key in keys],
+    }
+
+
+@signing_router.post(
+    "/keys/rotate",
+    response_model=SigningKeyRotateRead,
+    status_code=status.HTTP_201_CREATED,
+)
+@require_permission(MANAGE_PERMISSION)
+def rotate_signing_key(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Retire the active key and mint its replacement.
+
+    Signatures made by the retired key keep verifying. Rotation that
+    invalidated them would revoke the customer's own evidence, which is the
+    opposite of the point.
+    """
+    try:
+        retired, active = record_signing.rotate_key(
+            db, account_id=account.id, user_id=current_user.id
+        )
+    except Exception as exc:
+        db.rollback()
+        logger.error("Signing key rotation failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="could not rotate the signing key",
+        ) from exc
+    try:
+        crud_audit_log.log_action(
+            db,
+            account_id=account.id,
+            user_id=current_user.id,
+            action=AUDIT_ACTION_KEY_ROTATED,
+            resource_type="signing_key",
+            resource_id=active.key_id,
+            status="success",
+            details={
+                "retired_key_id": retired.key_id if retired else None,
+                "new_key_id": active.key_id,
+                "algorithm": active.algorithm,
+            },
+        )
+    except Exception:
+        db.rollback()
+        logger.error("Failed to audit a signing key rotation", exc_info=True)
+    return {
+        "retired": record_signing.public_key_summary(retired) if retired else None,
+        "active": record_signing.public_key_summary(active),
+    }

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -904,8 +904,10 @@ def get_flow_execution_evidence_status(
 
     Status is one of ``available``, ``missing``, ``expired``, or ``failed``.
     Served from the persisted execution receipt (no decrypt). Availability
-    is not integrity proof. ``object_lock`` and ``legal_hold`` are always
-    false: this API does not implement WORM retention.
+    is not integrity proof. ``object_lock`` is always false: this API does
+    not implement WORM retention and cannot verify a property of the storage
+    layer beneath it. ``legal_hold`` is true while a hold covers the pack or
+    its execution, which blocks payload expiry and purge inside Preloop.
     """
     execution = crud_flow_execution.get(
         db=db, id=execution_id, account_id=current_user.account_id

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -64,6 +64,7 @@ from preloop.services.flow_continuation_adoption import (
 )
 from preloop.services.flow_artifacts import (
     EvidenceUnavailableError,
+    attach_evidence_signature,
     load_evidence,
     public_evidence_status,
 )
@@ -908,13 +909,22 @@ def get_flow_execution_evidence_status(
     not implement WORM retention and cannot verify a property of the storage
     layer beneath it. ``legal_hold`` is true while a hold covers the pack or
     its execution, which blocks payload expiry and purge inside Preloop.
+
+    ``signature`` is the detached Ed25519 signature made when the pack was
+    captured, with the payload it covers, or null for a pack captured before
+    signing existed. ``preloop evidence verify`` checks it against the
+    account's public key.
     """
     execution = crud_flow_execution.get(
         db=db, id=execution_id, account_id=current_user.account_id
     )
     if not execution:
         raise HTTPException(status_code=404, detail="Flow execution not found")
-    return public_evidence_status(execution)
+    return attach_evidence_signature(
+        db,
+        account_id=current_user.account_id,
+        receipt=public_evidence_status(execution),
+    )
 
 
 @router.get("/flows/executions/{execution_id}/evidence")
@@ -944,7 +954,11 @@ def get_flow_execution_evidence(
         )
     except EvidenceUnavailableError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    receipt = attach_evidence_signature(
+        db, account_id=current_user.account_id, receipt=receipt
+    )
     digest = receipt.get("sha256") or receipt.get("digest") or ""
+    signature = receipt.get("signature") or {}
     headers = {
         "Content-Disposition": (
             f'attachment; filename="evidence-{execution.id}.tar.gz"'
@@ -958,6 +972,13 @@ def get_flow_execution_evidence(
     }
     if digest:
         headers["X-Preloop-Evidence-SHA256"] = str(digest)
+    if signature:
+        # The signature covers a small payload the caller can rebuild from
+        # the bytes it just downloaded, so these headers are checkable
+        # without trusting the response that carried them (#558).
+        headers["X-Preloop-Signature"] = str(signature.get("signature") or "")
+        headers["X-Preloop-Signing-Key-Id"] = str(signature.get("key_id") or "")
+        headers["X-Preloop-Signed-At"] = str(signature.get("signed_at") or "")
     return Response(
         content=archive,
         media_type="application/gzip",

--- a/backend/preloop/api/endpoints/retention.py
+++ b/backend/preloop/api/endpoints/retention.py
@@ -353,7 +353,9 @@ def create_period_export(
 
     The archive carries ``manifest.json`` with a sha256 per member and a
     digest over the member list, in the same shape an evidence pack manifest
-    uses, so one verifier covers both.
+    uses, so one verifier covers both, plus ``signature.json``: a detached
+    Ed25519 signature over the manifest bytes, checkable against the account's
+    published public key.
     """
     period_start = _parse_day(start, "start")
     period_end = _parse_day(end, "end")
@@ -386,16 +388,22 @@ def create_period_export(
     audit_period_export(
         db, account_id=account.id, user_id=current_user.id, export=export
     )
+    headers = {
+        "Content-Disposition": f'attachment; filename="{export.filename}"',
+        # The digest of the bytes served, so a caller can check the
+        # download before they file it.
+        "X-Preloop-Archive-Sha256": export.sha256,
+        "X-Preloop-Members-Digest": str(export.manifest.get("members_digest") or ""),
+        # What the signature covers, so a caller who has only the headers can
+        # still tell which digest to check (#558).
+        "X-Preloop-Manifest-Sha256": export.manifest_sha256,
+    }
+    if export.signature:
+        headers["X-Preloop-Signature"] = str(export.signature.get("signature") or "")
+        headers["X-Preloop-Signing-Key-Id"] = str(export.signature.get("key_id") or "")
+        headers["X-Preloop-Signed-At"] = str(export.signature.get("signed_at") or "")
     return Response(
         content=export.archive,
         media_type="application/gzip",
-        headers={
-            "Content-Disposition": f'attachment; filename="{export.filename}"',
-            # The digest of the bytes served, so a caller can check the
-            # download before they file it.
-            "X-Preloop-Archive-Sha256": export.sha256,
-            "X-Preloop-Members-Digest": str(
-                export.manifest.get("members_digest") or ""
-            ),
-        },
+        headers=headers,
     )

--- a/backend/preloop/api/endpoints/retention.py
+++ b/backend/preloop/api/endpoints/retention.py
@@ -179,7 +179,7 @@ def update_retention_settings(
         # substance, and the message names the floor so the console can show
         # it without a second round trip.
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     except ValueError as exc:
         raise HTTPException(
@@ -376,7 +376,7 @@ def create_period_export(
         )
     except PeriodExportError as exc:
         codes = {
-            "period_too_large": status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "period_too_large": status.HTTP_413_CONTENT_TOO_LARGE,
             "invalid_period": status.HTTP_400_BAD_REQUEST,
         }
         raise HTTPException(

--- a/backend/preloop/api/endpoints/retention.py
+++ b/backend/preloop/api/endpoints/retention.py
@@ -1,0 +1,401 @@
+"""Retention settings, legal holds and the period export.
+
+Three surfaces that only make sense together. The settings say how long
+records are kept, the holds say which records are exempt while a matter is
+open, and the export is how a period leaves the platform before retention
+catches up with it.
+
+Every handler here is a plain ``def``. They all hold a synchronous session,
+and FastAPI dispatches sync handlers on the anyio threadpool, so a wait for a
+pool connection blocks a worker thread rather than the event loop
+(``tests/api/test_event_loop_pool_wait.py`` ratchets that count).
+
+Permissions reuse ``view_policies`` / ``manage_policies`` for settings and
+holds, and ``view_audit_logs`` for the export, which is a bulk read of the
+audit trail. A new permission would need seeding in the EE role matrix, which
+is not part of this change; the same choice was made for outbound webhooks.
+
+The export streams a tar built in memory. That is deliberate and bounded:
+``RETENTION_EXPORT_MAX_ROWS`` per record class, and going over is a 413
+telling the caller to narrow the period rather than a truncated archive
+somebody later mistakes for the whole period.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time, timedelta
+from typing import Annotated, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from preloop.api.auth import get_current_active_user
+from preloop.api.common import get_account_for_user
+from preloop.config import settings
+from preloop.models.crud import crud_audit_log
+from preloop.models.crud import legal_hold as crud_legal_hold
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.user import User
+from preloop.schemas.retention import (
+    LegalHoldCreate,
+    LegalHoldRead,
+    LegalHoldRelease,
+    RetentionClassRead,
+    RetentionPurgePreview,
+    RetentionSettingsRead,
+    RetentionSettingsUpdate,
+)
+from preloop.services import retention_policy
+from preloop.services.legal_hold import (
+    HoldOutcome,
+    LegalHoldError,
+    hold_summary,
+    place_hold,
+    release_hold,
+)
+from preloop.services.retention_export import (
+    PeriodExportError,
+    audit_period_export,
+    build_period_export,
+)
+from preloop.services.retention_purge import count_purgeable
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/retention", tags=["Retention"])
+
+VIEW_PERMISSION = "view_policies"
+MANAGE_PERMISSION = "manage_policies"
+EXPORT_PERMISSION = "view_audit_logs"
+
+AUDIT_ACTION_SETTINGS = "retention_settings_updated"
+
+#: One year of days. A period export is a compliance artifact, not a data
+#: dump: a caller who wants five years takes five archives, and each one stays
+#: small enough to hash and store.
+MAX_PERIOD_DAYS = 366
+
+
+def _settings_payload(account: Account) -> RetentionSettingsRead:
+    """Resolved retention plus the deployment facts that constrain it."""
+    resolved = retention_policy.resolve_all(account.meta_data)
+    return RetentionSettingsRead(
+        floor_days=retention_policy.floor_days(),
+        default_days=retention_policy.default_days(),
+        max_days=retention_policy.MAX_RETENTION_DAYS,
+        classes=[
+            RetentionClassRead(
+                record_class=record_class,
+                label=retention_policy.RECORD_CLASS_LABELS[record_class],
+                days=setting.days,
+                source=setting.source,
+                floored=setting.floored,
+            )
+            for record_class, setting in resolved.items()
+        ],
+        purge_enabled=bool(settings.retention_purge_enabled),
+        purge_dry_run=bool(settings.retention_purge_dry_run),
+        purge_window_utc=settings.retention_purge_window_utc or None,
+        evidence_payload_hours=int(settings.flow_evidence_retention_hours),
+    )
+
+
+def _hold_read(outcome_or_hold, flagged: Optional[dict] = None) -> LegalHoldRead:
+    """Render a hold row, optionally with what a mutation just changed."""
+    if isinstance(outcome_or_hold, HoldOutcome):
+        summary = hold_summary(outcome_or_hold.hold)
+        flagged = outcome_or_hold.flagged
+    else:
+        summary = hold_summary(outcome_or_hold)
+    return LegalHoldRead(**summary, flagged=flagged)
+
+
+def _parse_day(value: str, field: str) -> datetime:
+    """Accept a date or a full timestamp, always land in UTC."""
+    raw = (value or "").strip()
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field} is required (YYYY-MM-DD)",
+        )
+    try:
+        if len(raw) == 10:
+            parsed = datetime.combine(
+                datetime.strptime(raw, "%Y-%m-%d").date(), time.min
+            )
+        else:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field} must be YYYY-MM-DD or an ISO 8601 timestamp",
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+@router.get("/settings", response_model=RetentionSettingsRead)
+@require_permission(VIEW_PERMISSION)
+def get_retention_settings(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Return this account's retention per record class, and the floor."""
+    return _settings_payload(account)
+
+
+@router.put("/settings", response_model=RetentionSettingsRead)
+@require_permission(MANAGE_PERMISSION)
+def update_retention_settings(
+    payload: RetentionSettingsUpdate,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Set retention per record class, never below the six month floor.
+
+    The body is the full desired state: a class the caller omits, or sets to
+    null, goes back to the deployment default.
+    """
+    before = {
+        record_class: setting.days
+        for record_class, setting in retention_policy.resolve_all(
+            account.meta_data
+        ).items()
+    }
+    try:
+        updated = retention_policy.set_retention(
+            account.meta_data, values=payload.classes
+        )
+    except retention_policy.RetentionFloorError as exc:
+        # 422 rather than 400: the value is well formed and refused on
+        # substance, and the message names the floor so the console can show
+        # it without a second round trip.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    account.meta_data = updated
+    flag_modified(account, "meta_data")
+    db.add(account)
+    after = {
+        record_class: setting.days
+        for record_class, setting in retention_policy.resolve_all(updated).items()
+    }
+    changed = {
+        record_class: {"from": before[record_class], "to": days}
+        for record_class, days in after.items()
+        if before.get(record_class) != days
+    }
+    crud_audit_log.log_action(
+        db,
+        account_id=account.id,
+        user_id=current_user.id,
+        action=AUDIT_ACTION_SETTINGS,
+        resource_type="retention",
+        resource_id="settings",
+        status="success",
+        details={"changed": changed, "floor_days": retention_policy.floor_days()},
+        commit=False,
+    )
+    db.commit()
+    db.refresh(account)
+    return _settings_payload(account)
+
+
+@router.get("/purge-preview", response_model=RetentionPurgePreview)
+@require_permission(VIEW_PERMISSION)
+def preview_retention_purge(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Count what the purge would remove today, without removing anything.
+
+    Nobody should discover the effect of a retention setting by watching rows
+    disappear. Rows under a legal hold are already excluded by the same
+    filters the purge uses, so the count is the count.
+    """
+    now = datetime.now(UTC)
+    rows = []
+    total = 0
+    for record_class, setting in retention_policy.resolve_all(
+        account.meta_data
+    ).items():
+        cutoff = now - timedelta(days=setting.days)
+        count = count_purgeable(
+            db, account_id=account.id, record_class=record_class, cutoff=cutoff
+        )
+        total += count
+        rows.append(
+            {
+                "record_class": record_class,
+                "label": retention_policy.RECORD_CLASS_LABELS[record_class],
+                "retention_days": setting.days,
+                "cutoff": cutoff.isoformat(),
+                "purgeable": count,
+            }
+        )
+    return RetentionPurgePreview(
+        account_id=account.id,
+        purge_enabled=bool(settings.retention_purge_enabled),
+        classes=rows,
+        total=total,
+    )
+
+
+@router.get("/holds", response_model=List[LegalHoldRead])
+@require_permission(VIEW_PERMISSION)
+def list_legal_holds(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    active_only: bool = Query(True, description="Hide released holds"),
+    resource_type: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """List this account's legal holds, newest first."""
+    rows = crud_legal_hold.list_for_account(
+        db,
+        account_id=account.id,
+        active_only=active_only,
+        resource_type=resource_type,
+        limit=limit,
+    )
+    return [_hold_read(row) for row in rows]
+
+
+@router.post(
+    "/holds", response_model=LegalHoldRead, status_code=status.HTTP_201_CREATED
+)
+@require_permission(MANAGE_PERMISSION)
+def create_legal_hold(
+    payload: LegalHoldCreate,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Freeze one execution, approval or evidence pack until released."""
+    try:
+        outcome = place_hold(
+            db,
+            account_id=account.id,
+            resource_type=payload.resource_type,
+            resource_id=payload.resource_id,
+            reason=payload.reason,
+            user_id=current_user.id,
+        )
+    except LegalHoldError as exc:
+        db.rollback()
+        codes = {
+            "resource_not_found": status.HTTP_404_NOT_FOUND,
+            "already_held": status.HTTP_409_CONFLICT,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    return _hold_read(outcome)
+
+
+@router.post("/holds/{hold_id}/release", response_model=LegalHoldRead)
+@require_permission(MANAGE_PERMISSION)
+def release_legal_hold(
+    hold_id: UUID,
+    payload: LegalHoldRelease,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+):
+    """Lift a hold. The record stays, with who lifted it and why."""
+    try:
+        outcome = release_hold(
+            db,
+            account_id=account.id,
+            hold_id=hold_id,
+            reason=payload.reason,
+            user_id=current_user.id,
+        )
+    except LegalHoldError as exc:
+        db.rollback()
+        codes = {
+            "hold_not_found": status.HTTP_404_NOT_FOUND,
+            "already_released": status.HTTP_409_CONFLICT,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    return _hold_read(outcome)
+
+
+@router.post("/exports", response_class=Response)
+@require_permission(EXPORT_PERMISSION)
+def create_period_export(
+    account: Annotated[Account, Depends(get_account_for_user)],
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+    start: str = Query(..., description="Period start, inclusive (YYYY-MM-DD)"),
+    end: str = Query(..., description="Period end, exclusive (YYYY-MM-DD)"),
+):
+    """Build a tar.gz of one period: audit rows, approvals, receipts, holds.
+
+    The archive carries ``manifest.json`` with a sha256 per member and a
+    digest over the member list, in the same shape an evidence pack manifest
+    uses, so one verifier covers both.
+    """
+    period_start = _parse_day(start, "start")
+    period_end = _parse_day(end, "end")
+    if period_end <= period_start:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="end must be after start",
+        )
+    if (period_end - period_start).days > MAX_PERIOD_DAYS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"a period export covers at most {MAX_PERIOD_DAYS} days; "
+                "take consecutive periods for a longer range"
+            ),
+        )
+    try:
+        export = build_period_export(
+            db, account=account, start=period_start, end=period_end
+        )
+    except PeriodExportError as exc:
+        codes = {
+            "period_too_large": status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "invalid_period": status.HTTP_400_BAD_REQUEST,
+        }
+        raise HTTPException(
+            status_code=codes.get(exc.code, status.HTTP_400_BAD_REQUEST),
+            detail=str(exc),
+        ) from exc
+    audit_period_export(
+        db, account_id=account.id, user_id=current_user.id, export=export
+    )
+    return Response(
+        content=export.archive,
+        media_type="application/gzip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{export.filename}"',
+            # The digest of the bytes served, so a caller can check the
+            # download before they file it.
+            "X-Preloop-Archive-Sha256": export.sha256,
+            "X-Preloop-Members-Digest": str(
+                export.manifest.get("members_digest") or ""
+            ),
+        },
+    )

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -550,6 +550,98 @@ class Settings(BaseSettings):
     )
     flow_environment_profiles_file: str = ""
 
+    # Record retention, legal hold and the purge job
+    # (docs/guide/flows/evidence-storage.md). These govern how long *records*
+    # are kept (audit rows, approvals, evidence pack rows, runtime sessions,
+    # usage), which is a different question from how long the encrypted
+    # evidence payload is kept (FLOW_EVIDENCE_RETENTION_HOURS above).
+    retention_default_days: int = Field(
+        365,
+        ge=1,
+        description=(
+            "Default retention per record class, in days, for accounts that "
+            "set nothing. Twelve months. Resolved values are clamped up to "
+            "the effective floor, so a shorter default cannot take effect "
+            "(RETENTION_DEFAULT_DAYS)."
+        ),
+    )
+    retention_floor_days: int = Field(
+        183,
+        ge=1,
+        description=(
+            "Deployment floor for any retention setting, in days. The "
+            "absolute floor of 183 days (six months, AI Act Art. 26(6)) is a "
+            "module constant in preloop.services.retention_policy: this "
+            "setting can only raise it, never lower it "
+            "(RETENTION_FLOOR_DAYS)."
+        ),
+    )
+    retention_purge_enabled: bool = Field(
+        False,
+        description=(
+            "Run the scheduled retention purge. Off by default on purpose: a "
+            "job that starts deleting an account's audit history on upgrade "
+            "is not something an operator should discover afterwards. Turn it "
+            "on deliberately (RETENTION_PURGE_ENABLED)."
+        ),
+    )
+    retention_purge_dry_run: bool = Field(
+        False,
+        description=(
+            "Count and audit what the purge would delete without deleting "
+            "anything. Audit rows are written with action "
+            "'retention_purge_preview' (RETENTION_PURGE_DRY_RUN)."
+        ),
+    )
+    retention_purge_interval_seconds: int = Field(
+        3600,
+        ge=60,
+        description="Seconds between retention purge passes.",
+    )
+    retention_purge_batch_size: int = Field(
+        1000,
+        ge=1,
+        le=100000,
+        description=(
+            "Rows deleted per statement. Each batch is its own transaction so "
+            "the purge never holds a long lock."
+        ),
+    )
+    retention_purge_max_batches: int = Field(
+        50,
+        ge=1,
+        description=(
+            "Maximum batches per record class per account per pass. The "
+            "backlog is drained across passes rather than in one long "
+            "transaction."
+        ),
+    )
+    retention_purge_max_seconds: int = Field(
+        300,
+        ge=1,
+        description=(
+            "Wall-clock budget for one purge pass. The pass stops cleanly at "
+            "the budget and resumes on the next tick."
+        ),
+    )
+    retention_purge_window_utc: str = Field(
+        "1-5",
+        description=(
+            "Off-peak UTC hour window the purge may run in, as 'start-end' "
+            "(half open, so '1-5' means 01:00 to 04:59 UTC). Empty string "
+            "means any hour (RETENTION_PURGE_WINDOW_UTC)."
+        ),
+    )
+    retention_export_max_rows: int = Field(
+        100000,
+        ge=1,
+        description=(
+            "Maximum rows per record class in one period export. Exceeding it "
+            "is an error telling the caller to narrow the period; a compliance "
+            "export is never silently truncated (RETENTION_EXPORT_MAX_ROWS)."
+        ),
+    )
+
     # Outbound event webhooks (docs/guide/webhooks.md). Every default is
     # usable as-is; a deployment only tunes these when a receiver is slow or
     # an account produces a lot of events.

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -642,6 +642,82 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Audit hash chain and record signing (issue #558,
+    # docs/guide/flows/evidence-storage.md). The chain gives audit rows an
+    # order and makes a later edit or deletion visible; the signing key lets
+    # evidence that has left the platform be checked by someone who does not
+    # trust the platform's copy of it.
+    audit_chain_enabled: bool = Field(
+        True,
+        description=(
+            "Seal audit rows into the per-account hash chain. On by default: "
+            "unlike the retention purge this only adds hashes, it never "
+            "removes a record, so an upgrade cannot lose anything by running "
+            "it (AUDIT_CHAIN_ENABLED)."
+        ),
+    )
+    audit_chain_seal_interval_seconds: int = Field(
+        60,
+        ge=5,
+        description=(
+            "Seconds between sealing passes. Rows written since the last pass "
+            "are not in the chain yet; this is the size of that window "
+            "(AUDIT_CHAIN_SEAL_INTERVAL_SECONDS)."
+        ),
+    )
+    audit_chain_seal_lag_seconds: int = Field(
+        60,
+        ge=0,
+        description=(
+            "How far behind now the sealer stays, so a transaction that "
+            "started before the pass can still commit its audit row in "
+            "timestamp order (AUDIT_CHAIN_SEAL_LAG_SECONDS)."
+        ),
+    )
+    audit_chain_seal_batch_size: int = Field(
+        500,
+        ge=1,
+        le=10000,
+        description=(
+            "Rows sealed per transaction. Each batch commits on its own so a "
+            "backlog never holds a long lock on audit_log."
+        ),
+    )
+    audit_chain_seal_max_batches: int = Field(
+        20,
+        ge=1,
+        description=(
+            "Batch ceiling per account per pass. A backlog is drained across "
+            "passes rather than in one long transaction."
+        ),
+    )
+    audit_chain_seal_max_seconds: int = Field(
+        60,
+        ge=1,
+        description=(
+            "Wall-clock budget for one sealing pass. The pass stops cleanly "
+            "at the budget and resumes on the next tick."
+        ),
+    )
+    audit_chain_checkpoint_interval: int = Field(
+        1000,
+        ge=1,
+        description=(
+            "Sealed rows between signed checkpoints. A checkpoint is the "
+            "anchor a customer can keep off the platform "
+            "(AUDIT_CHAIN_CHECKPOINT_INTERVAL)."
+        ),
+    )
+    audit_chain_verify_max_rows: int = Field(
+        50000,
+        ge=1,
+        description=(
+            "Maximum rows one verification request walks. Over the bound the "
+            "response is truncated and says so, so the caller can continue "
+            "from the last sequence it checked."
+        ),
+    )
+
     # Outbound event webhooks (docs/guide/webhooks.md). Every default is
     # usable as-is; a deployment only tunes these when a receiver is slow or
     # an account produces a lot of events.

--- a/backend/preloop/models/alembic/versions/20260910_audit_chain_signing.py
+++ b/backend/preloop/models/alembic/versions/20260910_audit_chain_signing.py
@@ -17,7 +17,10 @@ table that is one of the largest in the product.
 account. ``audit_chain_checkpoint`` is a signed anchor every N rows.
 ``account_signing_key`` holds the Ed25519 key, public part in the clear and
 private part Fernet-encrypted, with a partial unique index enforcing one
-active key per account.
+active key per account. ``record_signature`` holds detached signatures over
+records that cannot carry their own, which today means evidence packs: the
+archive is content addressed when it is stored, so appending a signature
+member would change the digest the receipt already promised.
 
 Downgrade drops all of it. That loses the chain, which cannot be recomputed
 afterwards for rows that were sealed and then edited, and that is the honest
@@ -30,7 +33,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 revision: str = "20260910_audit_chain"
 down_revision: Union[str, None] = "20260910_retention_hold"
@@ -174,9 +177,56 @@ def upgrade() -> None:
         postgresql_where=sa.text("retired_at IS NULL"),
     )
 
+    op.create_table(
+        "record_signature",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("payload_type", sa.String(120), nullable=False),
+        sa.Column("subject_type", sa.String(40), nullable=False),
+        sa.Column("subject_id", sa.String(120), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.Column("digest", sa.String(64), nullable=False),
+        sa.Column("algorithm", sa.String(32), nullable=False),
+        sa.Column("signing_key_id", sa.String(64), nullable=False),
+        sa.Column("signature", sa.Text(), nullable=False),
+        sa.Column("signed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_record_signature_id", "record_signature", ["id"])
+    op.create_index(
+        "ix_record_signature_account_id", "record_signature", ["account_id"]
+    )
+    op.create_index(
+        "ix_record_signature_signing_key_id", "record_signature", ["signing_key_id"]
+    )
+    # One signature per record. Re-signing an immutable record either repeats
+    # itself or replaces evidence a customer already holds.
+    op.create_index(
+        "uq_record_signature_subject",
+        "record_signature",
+        ["account_id", "payload_type", "subject_id"],
+        unique=True,
+    )
+
 
 def downgrade() -> None:
-    """Drop the keys, the checkpoints, the head and the chain columns."""
+    """Drop the signatures, keys, checkpoints, head and chain columns."""
+    op.drop_index("uq_record_signature_subject", table_name="record_signature")
+    op.drop_index("ix_record_signature_signing_key_id", table_name="record_signature")
+    op.drop_index("ix_record_signature_account_id", table_name="record_signature")
+    op.drop_index("ix_record_signature_id", table_name="record_signature")
+    op.drop_table("record_signature")
+
     op.drop_index("uq_account_signing_key_active", table_name="account_signing_key")
     op.drop_index("ix_account_signing_key_key_id", table_name="account_signing_key")
     op.drop_index("ix_account_signing_key_account_id", table_name="account_signing_key")

--- a/backend/preloop/models/alembic/versions/20260910_audit_chain_signing.py
+++ b/backend/preloop/models/alembic/versions/20260910_audit_chain_signing.py
@@ -1,0 +1,207 @@
+"""Audit hash chain columns, chain state, checkpoints and account signing keys.
+
+Revision ID: 20260910_audit_chain
+Revises: 20260910_retention_hold
+Create Date: 2026-09-10
+
+Four pieces of one feature (issue #558).
+
+``audit_log`` gains ``chain_seq``, ``prev_hash``, ``row_hash`` and
+``sealed_at``, all nullable. Nullable is not laziness: every row written
+before this migration has no chain position and never will, and a row written
+after it is unsealed until the sealer reaches it. A NOT NULL column here would
+have forced a backfill of the whole audit table inside the migration, on a
+table that is one of the largest in the product.
+
+``audit_chain_state`` is the head and the sequence allocator, one row per
+account. ``audit_chain_checkpoint`` is a signed anchor every N rows.
+``account_signing_key`` holds the Ed25519 key, public part in the clear and
+private part Fernet-encrypted, with a partial unique index enforcing one
+active key per account.
+
+Downgrade drops all of it. That loses the chain, which cannot be recomputed
+afterwards for rows that were sealed and then edited, and that is the honest
+limit of reversing a tamper-evidence feature: a downgrade is itself a way to
+erase the evidence, which is why the docs say the chain protects against a
+careless writer and not against a platform administrator.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260910_audit_chain"
+down_revision: Union[str, None] = "20260910_retention_hold"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+_GENESIS_HASH = "0" * 64
+
+
+def upgrade() -> None:
+    """Add the chain columns and the three supporting tables."""
+    op.add_column("audit_log", sa.Column("chain_seq", sa.BigInteger(), nullable=True))
+    op.add_column("audit_log", sa.Column("prev_hash", sa.String(64), nullable=True))
+    op.add_column("audit_log", sa.Column("row_hash", sa.String(64), nullable=True))
+    op.add_column(
+        "audit_log",
+        sa.Column("sealed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Serves the chain walk (account, sequence order) and the sealer's own
+    # "next unsealed rows for this account" query, where NULLs sort last.
+    op.create_index(
+        "ix_audit_log_account_chain_seq", "audit_log", ["account_id", "chain_seq"]
+    )
+
+    op.create_table(
+        "audit_chain_state",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("last_seq", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "last_hash", sa.String(64), nullable=False, server_default=_GENESIS_HASH
+        ),
+        sa.Column("last_sealed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "pruned_below_seq", sa.BigInteger(), nullable=False, server_default="0"
+        ),
+        sa.Column("pruned_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_audit_chain_state_id", "audit_chain_state", ["id"])
+    # Unique, not merely indexed: the head is the sequence allocator, and two
+    # head rows for one account would hand out the same sequence twice.
+    op.create_index(
+        "ix_audit_chain_state_account_id",
+        "audit_chain_state",
+        ["account_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "audit_chain_checkpoint",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("seq", sa.BigInteger(), nullable=False),
+        sa.Column("chain_hash", sa.String(64), nullable=False),
+        sa.Column("row_count", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("checkpointed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("signing_key_id", sa.String(64), nullable=True),
+        sa.Column("signature", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_audit_chain_checkpoint_id", "audit_chain_checkpoint", ["id"])
+    op.create_index(
+        "ix_audit_chain_checkpoint_account_id", "audit_chain_checkpoint", ["account_id"]
+    )
+    op.create_index(
+        "ix_audit_chain_checkpoint_checkpointed_at",
+        "audit_chain_checkpoint",
+        ["checkpointed_at"],
+    )
+    op.create_index(
+        "uq_audit_chain_checkpoint_account_seq",
+        "audit_chain_checkpoint",
+        ["account_id", "seq"],
+        unique=True,
+    )
+
+    op.create_table(
+        "account_signing_key",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("key_id", sa.String(64), nullable=False),
+        sa.Column("algorithm", sa.String(32), nullable=False, server_default="ed25519"),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("private_key_encrypted", sa.Text(), nullable=False),
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "rotated_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_account_signing_key_id", "account_signing_key", ["id"])
+    op.create_index(
+        "ix_account_signing_key_account_id", "account_signing_key", ["account_id"]
+    )
+    op.create_index(
+        "ix_account_signing_key_key_id", "account_signing_key", ["key_id"], unique=True
+    )
+    # One active key per account, in the index rather than in a service check,
+    # for the same reason #559 put the one-active-hold rule in an index.
+    op.create_index(
+        "uq_account_signing_key_active",
+        "account_signing_key",
+        ["account_id"],
+        unique=True,
+        postgresql_where=sa.text("retired_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the keys, the checkpoints, the head and the chain columns."""
+    op.drop_index("uq_account_signing_key_active", table_name="account_signing_key")
+    op.drop_index("ix_account_signing_key_key_id", table_name="account_signing_key")
+    op.drop_index("ix_account_signing_key_account_id", table_name="account_signing_key")
+    op.drop_index("ix_account_signing_key_id", table_name="account_signing_key")
+    op.drop_table("account_signing_key")
+
+    op.drop_index(
+        "uq_audit_chain_checkpoint_account_seq", table_name="audit_chain_checkpoint"
+    )
+    op.drop_index(
+        "ix_audit_chain_checkpoint_checkpointed_at",
+        table_name="audit_chain_checkpoint",
+    )
+    op.drop_index(
+        "ix_audit_chain_checkpoint_account_id", table_name="audit_chain_checkpoint"
+    )
+    op.drop_index("ix_audit_chain_checkpoint_id", table_name="audit_chain_checkpoint")
+    op.drop_table("audit_chain_checkpoint")
+
+    op.drop_index("ix_audit_chain_state_account_id", table_name="audit_chain_state")
+    op.drop_index("ix_audit_chain_state_id", table_name="audit_chain_state")
+    op.drop_table("audit_chain_state")
+
+    op.drop_index("ix_audit_log_account_chain_seq", table_name="audit_log")
+    op.drop_column("audit_log", "sealed_at")
+    op.drop_column("audit_log", "row_hash")
+    op.drop_column("audit_log", "prev_hash")
+    op.drop_column("audit_log", "chain_seq")

--- a/backend/preloop/models/alembic/versions/20260910_retention_legal_hold.py
+++ b/backend/preloop/models/alembic/versions/20260910_retention_legal_hold.py
@@ -1,0 +1,126 @@
+"""Legal hold records plus the derived enforcement flags they drive.
+
+Revision ID: 20260910_retention_hold
+Revises: 20260908_webhook_delivery_key
+Create Date: 2026-09-10
+
+``legal_hold`` is the account-visible record: who froze what, why, and the
+release with its own actor and reason. The boolean columns added to
+``flow_execution``, ``approval_request`` and ``flow_artifact`` are the derived
+enforcement state the retention purge and the evidence janitor test, written
+in the same transaction as the record so a batch DELETE stays a single table
+query.
+
+Retention settings themselves need no migration: they live in
+``account.meta_data`` under ``retention``, the same place the approval window
+cap and subject governance live.
+
+Downgrade drops the flags and the table. It does not resurrect anything a
+purge already removed, which is the honest limit of a reversible migration
+over a destructive feature.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260910_retention_hold"
+down_revision: Union[str, None] = "20260908_webhook_delivery_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+_FLAGGED_TABLES = ("flow_execution", "approval_request", "flow_artifact")
+
+
+def upgrade() -> None:
+    """Create the hold record table and the three enforcement flags."""
+    op.create_table(
+        "legal_hold",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("resource_type", sa.String(32), nullable=False),
+        sa.Column("resource_id", sa.String(255), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "placed_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("placed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "released_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("release_reason", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_legal_hold_id", "legal_hold", ["id"])
+    op.create_index("ix_legal_hold_account_id", "legal_hold", ["account_id"])
+    op.create_index(
+        "ix_legal_hold_placed_by_user_id", "legal_hold", ["placed_by_user_id"]
+    )
+    op.create_index("ix_legal_hold_placed_at", "legal_hold", ["placed_at"])
+    op.create_index(
+        "ix_legal_hold_account_released", "legal_hold", ["account_id", "released_at"]
+    )
+    # One active hold per resource. Two teams asking for the same freeze is
+    # one freeze, and concurrent callers race past a service-level check.
+    op.create_index(
+        "uq_legal_hold_active_resource",
+        "legal_hold",
+        ["account_id", "resource_type", "resource_id"],
+        unique=True,
+        postgresql_where=sa.text("released_at IS NULL"),
+    )
+
+    for table in _FLAGGED_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "legal_hold",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        # Partial index: the purge and the janitor only ever ask "is this one
+        # held?", and held rows are the rare case. A full index on a boolean
+        # that is false for every historical row would be dead weight.
+        op.create_index(
+            f"ix_{table}_legal_hold",
+            table,
+            ["legal_hold"],
+            postgresql_where=sa.text("legal_hold"),
+        )
+
+
+def downgrade() -> None:
+    """Drop the flags and the hold records."""
+    for table in _FLAGGED_TABLES:
+        op.drop_index(f"ix_{table}_legal_hold", table_name=table)
+        op.drop_column(table, "legal_hold")
+    op.drop_index("uq_legal_hold_active_resource", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_account_released", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_placed_at", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_placed_by_user_id", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_account_id", table_name="legal_hold")
+    op.drop_index("ix_legal_hold_id", table_name="legal_hold")
+    op.drop_table("legal_hold")

--- a/backend/preloop/models/crud/flow_artifact.py
+++ b/backend/preloop/models/crud/flow_artifact.py
@@ -120,11 +120,18 @@ def lease(
 
 
 def cleanup(db: Session, *, now: datetime) -> int:
-    """Release expired unleased payloads while retaining honest availability."""
+    """Release expired unleased payloads while retaining honest availability.
+
+    A row under a legal hold is skipped whatever its ``expires_at`` says. The
+    hold has to block payload expiry, not only deletion: an evidence pack a
+    regulator may ask for has to still be downloadable, and "the record row
+    survived but the bytes are gone" is not what anyone means by a hold.
+    """
     count = (
         db.query(models.FlowArtifact)
         .filter(
             models.FlowArtifact.expires_at <= now,
+            models.FlowArtifact.legal_hold.is_(False),
             or_(
                 models.FlowArtifact.lease_until.is_(None),
                 models.FlowArtifact.lease_until <= now,

--- a/backend/preloop/models/crud/legal_hold.py
+++ b/backend/preloop/models/crud/legal_hold.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.models.approval_request import ApprovalRequest
 from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow import Flow
 from preloop.models.models.flow_execution import FlowExecution
 from preloop.models.models.legal_hold import (
     HOLD_RESOURCE_APPROVAL,
@@ -24,6 +25,19 @@ from preloop.models.models.legal_hold import (
     HOLD_RESOURCE_EXECUTION,
     LegalHold,
 )
+
+
+def execution_in_account(account_id: Any):
+    """Account filter for an execution.
+
+    ``flow_execution`` carries no ``account_id`` of its own: an execution
+    belongs to an account through its flow. Every execution-scoped query here
+    goes through this so the ownership check cannot be forgotten in one place
+    and remembered in another.
+    """
+    return FlowExecution.flow_id.in_(
+        select(Flow.id).where(Flow.account_id == account_id)
+    )
 
 
 def get(db: Session, *, account_id: Any, hold_id: UUID) -> Optional[LegalHold]:
@@ -142,7 +156,7 @@ def set_execution_flag(
         update(FlowExecution)
         .where(
             FlowExecution.id == execution_id,
-            FlowExecution.account_id == account_id,
+            execution_in_account(account_id),
         )
         .values(legal_hold=held)
         .execution_options(synchronize_session=False)

--- a/backend/preloop/models/crud/legal_hold.py
+++ b/backend/preloop/models/crud/legal_hold.py
@@ -1,0 +1,230 @@
+"""Legal hold persistence: the record rows and the derived enforcement flags.
+
+Every function here is account scoped. A hold that could be placed on, listed
+with, or released from another account's records would be worse than no hold
+at all, so the account id is a required argument on every call rather than
+something a caller may pass.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    LegalHold,
+)
+
+
+def get(db: Session, *, account_id: Any, hold_id: UUID) -> Optional[LegalHold]:
+    """One hold, never outside the account that owns it."""
+    return db.execute(
+        select(LegalHold).where(
+            LegalHold.id == hold_id,
+            LegalHold.account_id == str(account_id),
+        )
+    ).scalar_one_or_none()
+
+
+def get_active(
+    db: Session, *, account_id: Any, resource_type: str, resource_id: str
+) -> Optional[LegalHold]:
+    """The active hold on one resource, if there is one."""
+    return db.execute(
+        select(LegalHold).where(
+            LegalHold.account_id == str(account_id),
+            LegalHold.resource_type == resource_type,
+            LegalHold.resource_id == str(resource_id),
+            LegalHold.released_at.is_(None),
+        )
+    ).scalar_one_or_none()
+
+
+def list_for_account(
+    db: Session,
+    *,
+    account_id: Any,
+    active_only: bool = False,
+    resource_type: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[LegalHold]:
+    """Holds for one account, newest first."""
+    stmt = select(LegalHold).where(LegalHold.account_id == str(account_id))
+    if active_only:
+        stmt = stmt.where(LegalHold.released_at.is_(None))
+    if resource_type:
+        stmt = stmt.where(LegalHold.resource_type == resource_type)
+    stmt = stmt.order_by(LegalHold.placed_at.desc()).offset(skip).limit(limit)
+    return list(db.execute(stmt).scalars().all())
+
+
+def active_resource_ids(
+    db: Session, *, account_id: Any, resource_type: str
+) -> set[str]:
+    """Resource ids under an active hold, for recomputing derived flags."""
+    rows = db.execute(
+        select(LegalHold.resource_id).where(
+            LegalHold.account_id == str(account_id),
+            LegalHold.resource_type == resource_type,
+            LegalHold.released_at.is_(None),
+        )
+    ).scalars()
+    return {str(value) for value in rows}
+
+
+def create(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: str,
+    reason: str,
+    placed_by_user_id: Optional[UUID],
+    placed_at: datetime,
+    commit: bool = False,
+) -> LegalHold:
+    """Insert the hold record. The caller sets the derived flags."""
+    hold = LegalHold(
+        account_id=str(account_id),
+        resource_type=resource_type,
+        resource_id=str(resource_id),
+        reason=reason,
+        placed_by_user_id=placed_by_user_id,
+        placed_at=placed_at,
+    )
+    db.add(hold)
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    else:
+        db.flush()
+    return hold
+
+
+def release(
+    db: Session,
+    *,
+    hold: LegalHold,
+    released_by_user_id: Optional[UUID],
+    released_at: datetime,
+    release_reason: str,
+    commit: bool = False,
+) -> LegalHold:
+    """Mark the hold released. The caller recomputes the derived flags."""
+    hold.released_at = released_at
+    hold.released_by_user_id = released_by_user_id
+    hold.release_reason = release_reason
+    db.add(hold)
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    else:
+        db.flush()
+    return hold
+
+
+def set_execution_flag(
+    db: Session, *, account_id: Any, execution_id: Any, held: bool
+) -> int:
+    """Set the flag on one execution. Returns rows touched (0 or 1)."""
+    result = db.execute(
+        update(FlowExecution)
+        .where(
+            FlowExecution.id == execution_id,
+            FlowExecution.account_id == account_id,
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_approval_flag(
+    db: Session, *, account_id: Any, approval_id: Any, held: bool
+) -> int:
+    """Set the flag on one approval request."""
+    result = db.execute(
+        update(ApprovalRequest)
+        .where(
+            ApprovalRequest.id == approval_id,
+            ApprovalRequest.account_id == account_id,
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_artifact_flag(
+    db: Session, *, account_id: Any, artifact_id: Any, held: bool
+) -> int:
+    """Set the flag on one evidence pack row."""
+    result = db.execute(
+        update(FlowArtifact)
+        .where(
+            FlowArtifact.id == artifact_id,
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.kind == "evidence",
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def set_execution_evidence_flags(
+    db: Session, *, account_id: Any, execution_id: Any, held: bool
+) -> int:
+    """Cascade a hold to every evidence pack of one execution.
+
+    Freezing a run and letting its evidence expire on the operational window
+    would be a hold in name only, so the execution hold reaches the packs.
+    When clearing, packs that carry their own active pack-level hold are left
+    alone by the caller (see services/legal_hold.py).
+    """
+    result = db.execute(
+        update(FlowArtifact)
+        .where(
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.execution_id == execution_id,
+            FlowArtifact.kind == "evidence",
+        )
+        .values(legal_hold=held)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def execution_artifact_ids(
+    db: Session, *, account_id: Any, execution_id: Any
+) -> Sequence[UUID]:
+    """Evidence pack ids belonging to one execution."""
+    return list(
+        db.execute(
+            select(FlowArtifact.id).where(
+                FlowArtifact.account_id == account_id,
+                FlowArtifact.execution_id == execution_id,
+                FlowArtifact.kind == "evidence",
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+RESOURCE_FLAG_SETTERS = {
+    HOLD_RESOURCE_EXECUTION: set_execution_flag,
+    HOLD_RESOURCE_APPROVAL: set_approval_flag,
+    HOLD_RESOURCE_EVIDENCE_PACK: set_artifact_flag,
+}

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -40,6 +40,10 @@ from .audit_chain import (
     AuditChainCheckpoint,
     AuditChainState,
 )
+from .record_signature import (
+    SUBJECT_EVIDENCE_PACK,
+    RecordSignature,
+)
 from .legal_hold import (
     HOLD_RESOURCE_APPROVAL,
     HOLD_RESOURCE_EVIDENCE_PACK,
@@ -159,6 +163,8 @@ __all__ = [
     "AccountSigningKey",
     "AuditChainCheckpoint",
     "AuditChainState",
+    "RecordSignature",
+    "SUBJECT_EVIDENCE_PACK",
     "GENESIS_HASH",
     "KEY_ID_PREFIX",
     "SIGNING_ALGORITHM_ED25519",

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -30,6 +30,16 @@ from .issue_compliance_result import IssueComplianceResult
 from .plan import Plan, Subscription, MonthlyUsage
 from .issue_relationship import IssueRelationship
 from .issue_set import IssueSet
+from .account_signing_key import (
+    KEY_ID_PREFIX,
+    SIGNING_ALGORITHM_ED25519,
+    AccountSigningKey,
+)
+from .audit_chain import (
+    GENESIS_HASH,
+    AuditChainCheckpoint,
+    AuditChainState,
+)
 from .legal_hold import (
     HOLD_RESOURCE_APPROVAL,
     HOLD_RESOURCE_EVIDENCE_PACK,
@@ -146,6 +156,12 @@ __all__ = [
     "MonthlyUsage",
     "IssueRelationship",
     "IssueSet",
+    "AccountSigningKey",
+    "AuditChainCheckpoint",
+    "AuditChainState",
+    "GENESIS_HASH",
+    "KEY_ID_PREFIX",
+    "SIGNING_ALGORITHM_ED25519",
     "LegalHold",
     "HOLD_RESOURCE_APPROVAL",
     "HOLD_RESOURCE_EVIDENCE_PACK",

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -30,6 +30,13 @@ from .issue_compliance_result import IssueComplianceResult
 from .plan import Plan, Subscription, MonthlyUsage
 from .issue_relationship import IssueRelationship
 from .issue_set import IssueSet
+from .legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_TYPES,
+    LegalHold,
+)
 from .managed_agent import ManagedAgent
 from .managed_agent_ai_model_binding import ManagedAgentAIModelBinding
 from .managed_agent_credential import ManagedAgentCredential
@@ -139,6 +146,11 @@ __all__ = [
     "MonthlyUsage",
     "IssueRelationship",
     "IssueSet",
+    "LegalHold",
+    "HOLD_RESOURCE_APPROVAL",
+    "HOLD_RESOURCE_EVIDENCE_PACK",
+    "HOLD_RESOURCE_EXECUTION",
+    "HOLD_RESOURCE_TYPES",
     "ManagedAgent",
     "ManagedAgentAIModelBinding",
     "ManagedAgentCredential",

--- a/backend/preloop/models/models/account_signing_key.py
+++ b/backend/preloop/models/models/account_signing_key.py
@@ -1,0 +1,102 @@
+"""The per-account Ed25519 key Preloop signs records with.
+
+One active key per account, enforced by a partial unique index rather than by
+a service check, for the same reason #559 put the one-active-hold rule in an
+index: concurrent callers race past service checks.
+
+Retired keys are kept, public key and all. Rotation that made every signature
+ever issued unverifiable would not be rotation, it would be revocation of the
+customer's own evidence. The key id travels with every signature so a verifier
+knows which public key to ask for.
+
+The private key is stored the way every other secret in this product is
+stored: Fernet-encrypted through :mod:`preloop.utils.encryption`, under
+``SECURITY__ENCRYPTION_KEY``. That is worth being precise about, because it
+bounds what a signature proves. The signing key sits in the same database as
+the records it signs, so an attacker who owns the platform owns the key too.
+What the signature adds is that evidence which left the platform can be
+checked later by someone who never trusted the platform's copy of it.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import DateTime
+
+from .base import Base
+
+#: The only algorithm this table holds today. Stored rather than assumed so a
+#: future key type does not need a migration to be told apart from this one.
+SIGNING_ALGORITHM_ED25519 = "ed25519"
+
+#: Prefix on every key id. Signatures carry the id, so it shows up in exported
+#: bundles and in support conversations; a prefix makes it obvious what it is.
+KEY_ID_PREFIX = "psk_"
+
+
+class AccountSigningKey(Base):
+    """One signing key: public part in the clear, private part encrypted."""
+
+    __tablename__ = "account_signing_key"
+    __table_args__ = (
+        # One active key per account.
+        Index(
+            "uq_account_signing_key_active",
+            "account_id",
+            unique=True,
+            postgresql_where=text("retired_at IS NULL"),
+        ),
+        Index("ix_account_signing_key_key_id", "key_id", unique=True),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key_id: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Public identifier carried by every signature this key makes",
+    )
+    algorithm: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default=SIGNING_ALGORITHM_ED25519,
+        server_default=SIGNING_ALGORITHM_ED25519,
+    )
+    public_key: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Base64 of the raw 32 byte Ed25519 public key",
+    )
+    private_key_encrypted: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Fernet token over the base64 raw private key",
+    )
+    retired_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Set on rotation. A retired key still verifies what it signed.",
+    )
+    rotated_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    @property
+    def active(self) -> bool:
+        """True while this key is the one new signatures are made with."""
+        return self.retired_at is None
+
+    def __repr__(self) -> str:
+        """Describe the key without exposing any secret material."""
+        state = "active" if self.retired_at is None else "retired"
+        return f"<AccountSigningKey {self.key_id} {self.algorithm} {state}>"

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
 from sqlalchemy import (
+    Boolean,
     String,
     DateTime,
     Text,
@@ -14,6 +15,7 @@ from sqlalchemy import (
     Index,
     inspect,
     text,
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -338,6 +340,19 @@ class ApprovalRequest(Base):
         nullable=True,
         index=True,
         comment="The ApprovalBypass that auto-approved this request",
+    )
+
+    # Derived legal-hold enforcement flag (see models/legal_hold.py). The
+    # account-visible record with actor and reason is a legal_hold row; this
+    # column is what the retention purge tests so a batch DELETE stays a
+    # single table query.
+    legal_hold: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa_false(),
+        index=True,
+        comment="True while a legal hold blocks this approval from purge",
     )
 
     # Relationships

--- a/backend/preloop/models/models/audit_chain.py
+++ b/backend/preloop/models/models/audit_chain.py
@@ -1,0 +1,155 @@
+"""The per-account audit hash chain: its head, and the checkpoints over it.
+
+Three tables' worth of state, only two of them here (the third is the
+``chain_seq`` / ``prev_hash`` / ``row_hash`` columns on ``audit_log`` itself).
+
+``AuditChainState`` is one row per account and it is the sequence allocator.
+Sealing takes the next sequence with a single ``UPDATE ... RETURNING``, so two
+passes racing each other cannot both take seq N, and a pass whose transaction
+rolls back returns the number rather than leaving a hole. It also carries
+``pruned_below_seq``, which is what stops a retention purge from looking like
+tampering: the purge deletes the oldest audit rows on purpose, so it raises
+the floor of the range the chain can speak about, and the verifier reports
+``pruned`` there instead of ``missing``.
+
+``AuditChainCheckpoint`` is a row every N sealed rows carrying the head hash
+at that point and a detached signature over it. This is the part that makes a
+rewrite detectable rather than merely inconvenient. A server that can write
+the database can also recompute a whole self-consistent chain; what it cannot
+do is produce old checkpoints whose signatures still verify under a public key
+the customer already has, if it does not hold the private key. A checkpoint a
+customer wrote down last month is the anchor. Held only by us, it proves
+nothing more than the chain does.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import DateTime
+
+from .base import Base
+
+#: Hash of the empty chain: what ``prev_hash`` is for the first sealed row.
+#: A literal rather than ``NULL`` so the canonical payload of row 1 has the
+#: same shape as every other row and one code path hashes them all.
+GENESIS_HASH = "0" * 64
+
+
+class AuditChainState(Base):
+    """One row per account: the chain head and the floor under it."""
+
+    __tablename__ = "audit_chain_state"
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    last_seq: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+        comment="Highest sequence handed out for this account. 0 means the "
+        "chain is empty.",
+    )
+    last_hash: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default=GENESIS_HASH,
+        server_default=GENESIS_HASH,
+        comment="row_hash of the row at last_seq, or the genesis hash",
+    )
+    last_sealed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When the head last moved",
+    )
+    pruned_below_seq: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+        comment="Sequences at or below this were removed by the retention "
+        "purge under a stated policy. The chain cannot speak about them and "
+        "a verifier must not call the gap a break.",
+    )
+    pruned_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        """Describe the head without a lazy load."""
+        return (
+            f"<AuditChainState account={self.account_id} seq={self.last_seq} "
+            f"pruned_below={self.pruned_below_seq}>"
+        )
+
+
+class AuditChainCheckpoint(Base):
+    """A signed anchor over the chain, written every N sealed rows."""
+
+    __tablename__ = "audit_chain_checkpoint"
+    __table_args__ = (
+        Index(
+            "uq_audit_chain_checkpoint_account_seq",
+            "account_id",
+            "seq",
+            unique=True,
+        ),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seq: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        comment="Sequence of the last row this checkpoint covers",
+    )
+    chain_hash: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="row_hash at seq: the head of the chain when it was taken",
+    )
+    row_count: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+        comment="Rows sealed since the previous checkpoint",
+    )
+    checkpointed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    signing_key_id: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Key that signed this checkpoint. NULL when the account had "
+        "no signing key yet, which is honest about an unsigned anchor rather "
+        "than pretending to one.",
+    )
+    signature: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Base64 Ed25519 signature over the canonical checkpoint",
+    )
+
+    def __repr__(self) -> str:
+        """Describe the checkpoint without a lazy load."""
+        signed = "signed" if self.signature else "unsigned"
+        return (
+            f"<AuditChainCheckpoint account={self.account_id} seq={self.seq} {signed}>"
+        )

--- a/backend/preloop/models/models/audit_log.py
+++ b/backend/preloop/models/models/audit_log.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import ForeignKey, Text, func
+from sqlalchemy import BigInteger, ForeignKey, Index, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import DateTime, String
@@ -41,6 +41,13 @@ class AuditLog(Base):
     """
 
     __tablename__ = "audit_log"
+    __table_args__ = (
+        # The chain walk is "give me this account's rows in sequence order",
+        # and the sealer's own query is "the next unsealed rows for this
+        # account". One composite index serves both; NULLs sort last in
+        # Postgres, so the unsealed tail sits at the end of it.
+        Index("ix_audit_log_account_chain_seq", "account_id", "chain_seq"),
+    )
 
     # Foreign keys
     account_id: Mapped[uuid.UUID] = mapped_column(
@@ -80,6 +87,35 @@ class AuditLog(Base):
     # Timestamp
     timestamp: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False, index=True
+    )
+
+    # Hash chain (issue #558). Nullable on purpose, in both directions: every
+    # row written before this feature existed has no chain position and never
+    # will, and a freshly written row is unsealed until the sealer reaches it.
+    # Chaining inline would mean holding a per-account lock until the caller's
+    # transaction commits, and ``model_gateway_request`` writes one of these
+    # rows per gateway call. See preloop.services.audit_chain.
+    chain_seq: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        nullable=True,
+        comment="Position in this account's hash chain. NULL means unsealed.",
+    )
+    prev_hash: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="row_hash of the row at chain_seq - 1, or the genesis hash",
+    )
+    row_hash: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="sha256 over the canonical serialisation of this row, "
+        "prev_hash included",
+    )
+    sealed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When the sealer chained this row, which is later than "
+        "timestamp by up to one sealer interval",
     )
 
     # Relationships

--- a/backend/preloop/models/models/flow_artifact.py
+++ b/backend/preloop/models/models/flow_artifact.py
@@ -1,6 +1,14 @@
 """Encrypted hosted recovery artifacts, isolated by account, flow and thread."""
 
-from sqlalchemy import Column, DateTime, ForeignKey, LargeBinary, String
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    LargeBinary,
+    String,
+    false as sa_false,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from .base import Base
@@ -36,3 +44,10 @@ class FlowArtifact(Base):
     expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
     lease_until = Column(DateTime(timezone=True), nullable=True)
     availability = Column(String(20), nullable=False, default="available")
+    # Derived legal-hold enforcement flag (see models/legal_hold.py). While
+    # true the janitor leaves the ciphertext alone past expires_at and the
+    # retention purge leaves the row alone: a held pack must still be
+    # downloadable, so the hold blocks payload expiry, not just deletion.
+    legal_hold = Column(
+        Boolean, nullable=False, server_default=sa_false(), default=False, index=True
+    )

--- a/backend/preloop/models/models/flow_execution.py
+++ b/backend/preloop/models/models/flow_execution.py
@@ -3,6 +3,7 @@ from datetime import datetime, UTC
 from typing import Optional
 
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     ForeignKey,
@@ -11,6 +12,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, query_expression, relationship
@@ -141,8 +143,16 @@ class FlowExecution(Base):
     evidence_archive = Column(LargeBinary, nullable=True)
     # Availability/retention receipt for captured evidence. Small JSON so a
     # release consumer can distinguish available / missing / expired / failed
-    # without downloading the pack. Not a legal-hold claim.
+    # without downloading the pack. The legal_hold field it carries is the
+    # artifact's own flag, not a storage-layer object-lock claim.
     evidence_receipt = Column(JSONB, nullable=True)
+    # Derived legal-hold enforcement flag. The account-visible record (actor,
+    # reason, release) is a legal_hold row; this column is what the retention
+    # purge tests, in the same transaction, so a batch DELETE stays a single
+    # table query. A hold here also covers this execution's evidence packs.
+    legal_hold = Column(
+        Boolean, nullable=False, server_default=sa_false(), default=False, index=True
+    )
     # Workspace snapshot (tar.gz of /workspace, .git included) captured by the
     # runner on every terminal path so work that was never pushed survives the
     # container. Size-capped at capture time

--- a/backend/preloop/models/models/legal_hold.py
+++ b/backend/preloop/models/models/legal_hold.py
@@ -1,0 +1,129 @@
+"""Legal hold: the record of who froze what, why, and when it was released.
+
+A hold is two things and they are deliberately kept apart.
+
+The **row** in this table is the account-visible fact: an actor, a reason, a
+timestamp, and a release with its own actor and reason. That is what a
+regulator or a customer's counsel actually asks for, and it is why ``reason``
+is NOT NULL: a hold nobody can explain is indistinguishable from a bug.
+
+The **boolean** on ``flow_execution``, ``approval_request`` and
+``flow_artifact`` is derived enforcement state, written in the same
+transaction as the row. The purge and the evidence janitor are batch UPDATEs
+and DELETEs over single tables; making them join a hold table on every pass
+would be the wrong shape for the hot path and would make "did the purge miss a
+held row?" a question about a join rather than about a column. Release
+recomputes the boolean from whatever active holds remain, so two overlapping
+holds cannot be lifted by releasing one.
+
+A hold on an execution covers that execution's evidence packs too. Freezing a
+run and leaving its evidence to expire in thirty days would be a hold in name
+only.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import DateTime
+
+from .base import Base
+
+#: A flow execution. Cascades to that execution's evidence artifacts.
+HOLD_RESOURCE_EXECUTION = "execution"
+#: One approval request.
+HOLD_RESOURCE_APPROVAL = "approval"
+#: One evidence pack (a ``flow_artifact`` row of kind ``evidence``).
+HOLD_RESOURCE_EVIDENCE_PACK = "evidence_pack"
+
+HOLD_RESOURCE_TYPES: tuple[str, ...] = (
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+)
+
+
+class LegalHold(Base):
+    """One hold placed on one resource, with its actor, reason and release."""
+
+    __tablename__ = "legal_hold"
+    __table_args__ = (
+        # One *active* hold per resource. Two teams asking for the same freeze
+        # is one freeze; the durable control is here rather than in a service
+        # check that concurrent callers can race past.
+        Index(
+            "uq_legal_hold_active_resource",
+            "account_id",
+            "resource_type",
+            "resource_id",
+            unique=True,
+            postgresql_where=text("released_at IS NULL"),
+        ),
+        Index("ix_legal_hold_account_released", "account_id", "released_at"),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    resource_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="execution | approval | evidence_pack",
+    )
+    resource_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Identifier of the held resource within this account",
+    )
+    reason: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Why the records are frozen. Mandatory: an unexplained hold "
+        "is indistinguishable from a bug.",
+    )
+    # ON DELETE SET NULL, like approval attribution: removing a user must not
+    # erase the fact that a hold was placed.
+    placed_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    placed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    released_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    released_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    release_reason: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Why the hold was lifted",
+    )
+
+    @property
+    def active(self) -> bool:
+        """True while the hold still blocks purge and payload expiry."""
+        return self.released_at is None
+
+    def __repr__(self) -> str:
+        """Describe the hold without a lazy load."""
+        state = "active" if self.released_at is None else "released"
+        return (
+            f"<LegalHold {self.resource_type}:{self.resource_id} {state} "
+            f"placed_at={self.placed_at}>"
+        )

--- a/backend/preloop/models/models/record_signature.py
+++ b/backend/preloop/models/models/record_signature.py
@@ -1,0 +1,93 @@
+"""Detached signatures over records that are not files we can append to.
+
+A period export is an archive, so its signature travels inside it as
+``signature.json``. An evidence pack is different: the archive is immutable
+and content addressed the moment it is stored, and appending a member would
+change the digest the receipt already promised. So the signature lives beside
+the record instead, keyed by what it covers.
+
+The payload is stored, not just its digest. A verifier who has the archive
+must be able to rebuild the exact bytes that were signed without asking us
+what they were, and a digest alone would make them take our word for the
+payload behind it.
+
+One signature per (account, payload type, subject). Re-signing an immutable
+record would either produce the same document again or quietly replace
+evidence a customer already holds; the unique index makes the second one
+impossible.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import DateTime
+
+from .base import Base
+
+#: Subject kinds this table holds. Stored as plain strings: a new signed
+#: record type should not need a migration.
+SUBJECT_EVIDENCE_PACK = "evidence_pack"
+
+
+class RecordSignature(Base):
+    """One detached signature and the payload it was taken over."""
+
+    __tablename__ = "record_signature"
+    __table_args__ = (
+        Index(
+            "uq_record_signature_subject",
+            "account_id",
+            "payload_type",
+            "subject_id",
+            unique=True,
+        ),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    payload_type: Mapped[str] = mapped_column(
+        String(120),
+        nullable=False,
+        comment="Signed payload type, inside the signed bytes as domain separation",
+    )
+    subject_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    subject_id: Mapped[str] = mapped_column(
+        String(120),
+        nullable=False,
+        comment="Identifier of the record this signature covers",
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="The exact payload the digest was taken over",
+    )
+    digest: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="sha256 of the canonical JSON of payload",
+    )
+    algorithm: Mapped[str] = mapped_column(String(32), nullable=False)
+    signing_key_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    signature: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Base64 detached signature"
+    )
+    signed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Covered by the signature, so it is dated rather than claimed",
+    )
+
+    def __repr__(self) -> str:
+        """Describe the signature by what it covers, not by its bytes."""
+        return (
+            f"<RecordSignature {self.payload_type} {self.subject_type}="
+            f"{self.subject_id} key={self.signing_key_id}>"
+        )

--- a/backend/preloop/schemas/audit_chain.py
+++ b/backend/preloop/schemas/audit_chain.py
@@ -1,0 +1,140 @@
+"""Schemas for the audit hash chain and account signing keys (#558)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChainCheckpointRead(BaseModel):
+    """One signed checkpoint over the chain head at a sequence."""
+
+    seq: int
+    chain_hash: str = Field(..., description="row_hash of the row at this sequence")
+    row_count: int
+    checkpointed_at: str
+    signing_key_id: Optional[str] = None
+    signature: Optional[str] = Field(
+        None, description="Base64 Ed25519 signature, null when signing failed"
+    )
+    signed_payload: Dict[str, Any] = Field(
+        ..., description="Canonical payload the digest was taken over"
+    )
+    digest: str
+    signature_document: Optional[Dict[str, Any]] = Field(
+        None, description="Detached signature document, ready to verify"
+    )
+
+
+class ChainStatusRead(BaseModel):
+    """Where this account's chain is, and how far behind sealing runs."""
+
+    enabled: bool
+    head_seq: int
+    head_hash: str
+    last_sealed_at: Optional[str] = None
+    pruned_below_seq: int = Field(
+        ...,
+        description=(
+            "Rows below this sequence were removed by the retention purge. "
+            "Their absence is policy, not tampering."
+        ),
+    )
+    sealed_rows: int
+    unsealed_rows: int = Field(
+        ..., description="Written but not yet chained; sealing is a background pass"
+    )
+    seal_lag_seconds: int
+    checkpoint_interval: int
+    latest_checkpoint: Optional[ChainCheckpointRead] = None
+    active_key_id: Optional[str] = None
+
+
+class ChainBreakRead(BaseModel):
+    """The first place the walk stopped agreeing with the chain."""
+
+    kind: str
+    seq: int
+    row_id: Optional[str] = None
+    detail: str
+
+
+class ChainVerifyRead(BaseModel):
+    """Verdict of a server side walk over a range of the chain."""
+
+    account_id: str
+    status: str = Field(..., description="ok, broken or empty")
+    checked_rows: int
+    start_seq: int
+    end_seq: int
+    head_seq: int
+    pruned_below_seq: int
+    unsealed_rows: int
+    truncated: bool = Field(
+        ..., description="True when the range was cut to the row limit"
+    )
+    out_of_order_rows: int = Field(
+        ...,
+        description=(
+            "Rows whose timestamp precedes the row before them. Concurrency, "
+            "not evidence of tampering on its own."
+        ),
+    )
+    first_break: Optional[ChainBreakRead] = None
+    checkpoints_verified: int
+    checkpoint_failures: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class ChainSegmentEntry(BaseModel):
+    """One row's chain material, enough to recompute its hash."""
+
+    seq: int
+    row_id: str
+    prev_hash: Optional[str] = None
+    row_hash: Optional[str] = None
+    payload: Dict[str, Any]
+
+
+class ChainSegmentRead(BaseModel):
+    """Material for a client side walk. The client decides, not the server."""
+
+    account_id: str
+    row_domain: str
+    after_seq: int
+    head_seq: int
+    pruned_below_seq: int
+    genesis_hash: str
+    entries: List[ChainSegmentEntry]
+    has_more: bool
+    note: str
+
+
+class SigningKeyRead(BaseModel):
+    """The public half of one signing key. Never the private half."""
+
+    key_id: str
+    algorithm: str
+    public_key: str = Field(..., description="Base64 raw Ed25519 public key")
+    active: bool
+    created_at: Optional[str] = None
+    retired_at: Optional[str] = None
+
+
+class SigningKeyListRead(BaseModel):
+    """Every key this account has held, plus which one signs today."""
+
+    active_key_id: Optional[str] = None
+    signature_schema: str
+    signed_bytes_format: str = Field(
+        ...,
+        description="Exact layout of the bytes a signature covers",
+    )
+    keys: List[SigningKeyRead]
+
+
+class SigningKeyRotateRead(BaseModel):
+    """Result of a rotation: what was retired and what signs now."""
+
+    retired: Optional[SigningKeyRead] = None
+    active: SigningKeyRead

--- a/backend/preloop/schemas/retention.py
+++ b/backend/preloop/schemas/retention.py
@@ -1,0 +1,147 @@
+"""Schemas for retention settings, legal holds and period exports."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from preloop.models.models.legal_hold import HOLD_RESOURCE_TYPES
+from preloop.services.legal_hold import MAX_REASON_CHARS, MIN_REASON_CHARS
+from preloop.services.retention_policy import RECORD_CLASSES
+
+
+class RetentionClassRead(BaseModel):
+    """Resolved retention for one record class."""
+
+    record_class: str
+    label: str
+    days: int
+    source: str = Field(
+        ..., description="'account' when this account set it, 'default' otherwise"
+    )
+    floored: bool = Field(
+        False, description="True when the stored value was raised to meet the floor"
+    )
+
+
+class RetentionSettingsRead(BaseModel):
+    """Everything the console needs to render the retention panel."""
+
+    floor_days: int = Field(
+        ..., description="No record class can be set below this many days"
+    )
+    default_days: int = Field(
+        ..., description="Applied to any class this account has not set"
+    )
+    max_days: int
+    classes: List[RetentionClassRead]
+    purge_enabled: bool = Field(
+        ...,
+        description=(
+            "False when this deployment never deletes. Retention is then a "
+            "stated policy that nothing enforces."
+        ),
+    )
+    purge_dry_run: bool
+    purge_window_utc: Optional[str] = Field(
+        None, description="Off-peak UTC hour window the purge runs in, e.g. '1-5'"
+    )
+    evidence_payload_hours: int = Field(
+        ...,
+        description=(
+            "How long encrypted evidence payloads are kept. Separate from the "
+            "'evidence' record class, which governs the record row."
+        ),
+    )
+
+
+class RetentionSettingsUpdate(BaseModel):
+    """Full desired state. An omitted class falls back to the default."""
+
+    classes: Dict[str, Optional[int]] = Field(
+        default_factory=dict,
+        description=(
+            "Record class to days. null clears the account's setting for that "
+            f"class. Known classes: {', '.join(RECORD_CLASSES)}"
+        ),
+    )
+
+    @field_validator("classes")
+    @classmethod
+    def _known_classes(
+        cls, value: Dict[str, Optional[int]]
+    ) -> Dict[str, Optional[int]]:
+        """Refuse an unknown class instead of dropping it silently."""
+        unknown = sorted(set(value) - set(RECORD_CLASSES))
+        if unknown:
+            raise ValueError(
+                f"unknown record classes: {', '.join(unknown)}. "
+                f"Known: {', '.join(RECORD_CLASSES)}"
+            )
+        return value
+
+
+class LegalHoldCreate(BaseModel):
+    """Place a hold on one execution, approval or evidence pack."""
+
+    resource_type: str = Field(
+        ..., description=f"One of {', '.join(HOLD_RESOURCE_TYPES)}"
+    )
+    resource_id: str = Field(..., max_length=255)
+    reason: str = Field(
+        ...,
+        min_length=MIN_REASON_CHARS,
+        max_length=MAX_REASON_CHARS,
+        description="Why this record is frozen. Written to the audit log.",
+    )
+
+    @field_validator("resource_type")
+    @classmethod
+    def _known_type(cls, value: str) -> str:
+        if value not in HOLD_RESOURCE_TYPES:
+            raise ValueError(
+                f"resource_type must be one of {', '.join(HOLD_RESOURCE_TYPES)}"
+            )
+        return value
+
+
+class LegalHoldRelease(BaseModel):
+    """Lift a hold. The release reason is recorded too."""
+
+    reason: str = Field(
+        ...,
+        min_length=MIN_REASON_CHARS,
+        max_length=MAX_REASON_CHARS,
+        description="Why the hold is being lifted. Written to the audit log.",
+    )
+
+
+class LegalHoldRead(BaseModel):
+    """One hold, active or released."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    resource_type: str
+    resource_id: str
+    reason: str
+    placed_by_user_id: Optional[UUID] = None
+    placed_at: Optional[datetime] = None
+    released_by_user_id: Optional[UUID] = None
+    released_at: Optional[datetime] = None
+    release_reason: Optional[str] = None
+    active: bool
+    #: Rows whose enforcement flag the place or release call moved, per table.
+    flagged: Optional[Dict[str, int]] = None
+
+
+class RetentionPurgePreview(BaseModel):
+    """What a purge would remove right now, without removing it."""
+
+    account_id: UUID
+    purge_enabled: bool
+    classes: List[Dict[str, Any]]
+    total: int

--- a/backend/preloop/services/audit_chain.py
+++ b/backend/preloop/services/audit_chain.py
@@ -1,0 +1,957 @@
+"""The per-account hash chain over audit rows, and the sealer that builds it.
+
+## What the chain is
+
+Every audit row gets a position in its account's chain: a ``chain_seq``, the
+``prev_hash`` of the row before it, and a ``row_hash`` over a canonical
+serialisation of the row *including* that ``prev_hash``. Changing any field of
+a sealed row, deleting one, or inserting one between two others changes a hash
+that the next row committed to, and the walk stops at the first link that does
+not hold.
+
+The canonical serialisation is
+:func:`preloop.cra.evidence_pack.canonical_manifest_json`, the same sorted-key
+compact JSON the evidence pack manifest (#511) and the period export manifest
+(#559) already hash. One canonical form in the product, not three.
+
+## Why sealing is a background job
+
+The obvious implementation chains inside ``crud_audit_log.log_action``. It is
+the wrong one here. It needs the account's chain head under a lock held until
+the caller's transaction commits, and ``model_gateway_request`` writes an audit
+row per gateway call: that would serialise the highest throughput path in the
+product on one row per account, and would let a chain failure fail the action
+being audited. Recording the event has to be more reliable than sequencing it.
+
+So a bounded sweeper seals rows off the request path, in ``(timestamp, id)``
+order, in batches, the same shape as #559's ``RetentionPurgeSweeper``. The
+cost is stated rather than hidden: sealing lags writes by up to one pass, and
+a row deleted before it was sealed leaves no gap to find. That is in the docs
+next to everything else this does not prove.
+
+## Sequence allocation
+
+``audit_chain_state`` is one row per account, taken ``FOR UPDATE`` for the
+duration of a batch. Two sealer passes (two API replicas, say) cannot both
+take seq N, and a pass whose transaction rolls back gives the numbers back
+instead of leaving a hole that looks like a deletion.
+
+## Checkpoints
+
+Every ``AUDIT_CHAIN_CHECKPOINT_INTERVAL`` sealed rows the sealer writes a
+checkpoint: the head hash at that sequence, signed with the account's Ed25519
+key. This is the part that makes a rewrite detectable instead of merely
+laborious. A server that can write the database can recompute an entire
+self-consistent chain; it cannot produce a checkpoint from last month whose
+signature still verifies, unless it also holds the key. Which, on a
+compromised platform, it does. The anchor is only worth what the copy the
+customer keeps off the platform is worth.
+
+## The purge
+
+Retention deletes the oldest audit rows on purpose (#559). That is not
+tampering and must not look like it, so the purge raises
+``pruned_below_seq`` on the chain state and the verifier reports ``pruned``
+under that floor instead of a break.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.audit_chain import (
+    GENESIS_HASH,
+    AuditChainCheckpoint,
+    AuditChainState,
+)
+from preloop.models.models.audit_log import AuditLog
+from preloop.services import record_signing
+
+logger = logging.getLogger(__name__)
+
+ROW_SCHEMA = "preloop.audit.chain_row/v1"
+CHECKPOINT_SCHEMA = record_signing.PAYLOAD_AUDIT_CHECKPOINT
+ROW_DOMAIN = b"preloop.audit.chain/v1\n"
+
+#: Verification outcomes.
+STATUS_OK = "ok"
+STATUS_BROKEN = "broken"
+STATUS_EMPTY = "empty"
+
+#: Break kinds, in the order the walk can meet them.
+BREAK_MISSING_ROW = "missing_row"
+BREAK_PREV_HASH = "prev_hash_mismatch"
+BREAK_ROW_HASH = "row_hash_mismatch"
+BREAK_DUPLICATE_SEQ = "duplicate_seq"
+
+
+def _iso(value: Any) -> Optional[str]:
+    """ISO 8601 for a datetime, passthrough for a string, None for None."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _canonical_timestamp(value: Any) -> Optional[str]:
+    """The one timestamp spelling a row hash is allowed to see.
+
+    ``audit_log.timestamp`` is a naive UTC column, but callers hand
+    ``log_action`` an aware ``datetime``, so the same instant is
+    ``...+00:00`` in the session that wrote it and naive once it comes back
+    from Postgres. Hashing whichever one was in memory would make a row's
+    hash depend on who read it. Aware values are converted to UTC and the
+    offset dropped, which is also exactly what
+    ``preloop.services.retention_export._iso`` produces for a row read from
+    the database, so an offline verifier rehashing an exported bundle gets
+    the same bytes.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        # Drop the offset without shifting the clock. ``audit_log.timestamp``
+        # is a naive column and the driver writes an aware value as the local
+        # wall clock, so the number Postgres keeps is the number here; a
+        # conversion to UTC would hash something the database does not hold.
+        return value.replace(tzinfo=None).isoformat()
+    return _iso(value)
+
+
+def canonical_row(
+    row: Any, *, seq: int, prev_hash: str, account_id: Optional[Any] = None
+) -> dict[str, Any]:
+    """The exact fields a row hash commits to.
+
+    Every audited field is in here. A column that a future change adds and
+    forgets to include would be a field an attacker could edit without
+    breaking the chain, which is why this is one explicit dict and not
+    ``row.to_dict()``: a silent addition is safer than a silent omission.
+    """
+    account = account_id if account_id is not None else getattr(row, "account_id", None)
+    return {
+        "schema": ROW_SCHEMA,
+        "account_id": str(account) if account is not None else None,
+        "id": str(getattr(row, "id", "")),
+        "seq": int(seq),
+        "prev_hash": prev_hash,
+        "timestamp": _canonical_timestamp(getattr(row, "timestamp", None)),
+        "user_id": (
+            str(row.user_id) if getattr(row, "user_id", None) is not None else None
+        ),
+        "action": getattr(row, "action", None),
+        "resource_type": getattr(row, "resource_type", None),
+        "resource_id": getattr(row, "resource_id", None),
+        "status": getattr(row, "status", None),
+        "ip_address": getattr(row, "ip_address", None),
+        "user_agent": getattr(row, "user_agent", None),
+        "details": getattr(row, "details", None),
+    }
+
+
+def hash_row(payload: dict[str, Any]) -> str:
+    """Domain separated sha256 over the canonical row payload."""
+    return hashlib.sha256(ROW_DOMAIN + canonical_manifest_json(payload)).hexdigest()
+
+
+def checkpoint_payload(
+    *, account_id: Any, seq: int, chain_hash: str, row_count: int, taken_at: Any
+) -> dict[str, Any]:
+    """The canonical form of a checkpoint, which is what gets signed.
+
+    ``checkpointed_at`` goes through ``format_signed_at``: UTC, second
+    resolution, one spelling. The column is timezone aware and the driver may
+    hand it back in the server's zone, and a digest that changed depending on
+    which zone the reader was in would invalidate its own signature.
+    """
+    return {
+        "schema": CHECKPOINT_SCHEMA,
+        "account_id": str(account_id),
+        "seq": int(seq),
+        "chain_hash": chain_hash,
+        "row_count": int(row_count),
+        "checkpointed_at": record_signing.format_signed_at(taken_at),
+    }
+
+
+def checkpoint_interval() -> int:
+    """Rows between checkpoints, at least one."""
+    return max(1, int(settings.audit_chain_checkpoint_interval))
+
+
+def seal_lag() -> timedelta:
+    """How far behind now the sealer stays.
+
+    A transaction that started before the last pass can still commit an audit
+    row with an earlier timestamp than rows already sealed. Waiting a lag
+    keeps that rare rather than routine; when it happens anyway the row is
+    still sealed, at the end of the chain, and the walk reports it as
+    out of order rather than as a break.
+    """
+    return timedelta(seconds=max(0, int(settings.audit_chain_seal_lag_seconds)))
+
+
+@dataclass
+class SealResult:
+    """What one sealing pass did to one account."""
+
+    account_id: str
+    sealed: int = 0
+    checkpoints: int = 0
+    batches: int = 0
+    #: True when rows were still waiting when the pass stopped.
+    more_remaining: bool = False
+    out_of_order: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        """Log shape."""
+        return {
+            "account_id": self.account_id,
+            "sealed": self.sealed,
+            "checkpoints": self.checkpoints,
+            "batches": self.batches,
+            "more_remaining": self.more_remaining,
+            "out_of_order": self.out_of_order,
+        }
+
+
+@dataclass
+class SweepResult:
+    """Totals for one pass across every account it reached."""
+
+    accounts: int = 0
+    sealed: int = 0
+    checkpoints: int = 0
+    budget_exhausted: bool = False
+    skipped_reason: Optional[str] = None
+    results: list[SealResult] = field(default_factory=list)
+
+    def record(self, result: SealResult) -> None:
+        """Fold one account's result into the totals."""
+        self.results.append(result)
+        self.sealed += result.sealed
+        self.checkpoints += result.checkpoints
+        if result.more_remaining:
+            self.budget_exhausted = True
+
+    def as_dict(self) -> dict[str, Any]:
+        """Log shape."""
+        return {
+            "accounts": self.accounts,
+            "sealed": self.sealed,
+            "checkpoints": self.checkpoints,
+            "budget_exhausted": self.budget_exhausted,
+            "skipped_reason": self.skipped_reason,
+        }
+
+
+def get_state(
+    db: Session, *, account_id: Any, for_update: bool = False, create: bool = True
+) -> Optional[AuditChainState]:
+    """Return (and optionally create) the chain head row for an account."""
+    stmt = select(AuditChainState).where(AuditChainState.account_id == account_id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    state = db.execute(stmt).scalar_one_or_none()
+    if state is None and create:
+        state = AuditChainState(
+            account_id=account_id,
+            last_seq=0,
+            last_hash=GENESIS_HASH,
+            pruned_below_seq=0,
+        )
+        db.add(state)
+        db.flush()
+    return state
+
+
+def note_pruned(db: Session, *, account_id: Any, up_to_seq: int, now: Any) -> None:
+    """Raise the floor after a retention purge removed audit rows.
+
+    Deleting the oldest rows under a stated retention is the purge doing its
+    job. Without this the next verification would call it a break, and a
+    tamper-evidence feature that cries wolf every night teaches people to
+    ignore it.
+    """
+    if up_to_seq <= 0:
+        return
+    state = get_state(db, account_id=account_id, for_update=True)
+    if state is None:
+        return
+    if up_to_seq > int(state.pruned_below_seq or 0):
+        state.pruned_below_seq = int(up_to_seq)
+        state.pruned_at = now
+        db.add(state)
+
+
+def _write_checkpoint(
+    db: Session,
+    *,
+    account_id: Any,
+    seq: int,
+    chain_hash: str,
+    row_count: int,
+    taken_at: datetime,
+) -> AuditChainCheckpoint:
+    """Write one checkpoint, signed when the account has a usable key."""
+    payload = checkpoint_payload(
+        account_id=account_id,
+        seq=seq,
+        chain_hash=chain_hash,
+        row_count=row_count,
+        taken_at=taken_at,
+    )
+    key_id: Optional[str] = None
+    signature: Optional[str] = None
+    document = record_signing.sign_manifest(
+        db,
+        account_id=account_id,
+        payload_type=CHECKPOINT_SCHEMA,
+        manifest=payload,
+        signed_at=taken_at,
+        commit=False,
+    )
+    if document is not None:
+        key_id = str(document.get("key_id"))
+        signature = str(document.get("signature"))
+    checkpoint = AuditChainCheckpoint(
+        account_id=account_id,
+        seq=seq,
+        chain_hash=chain_hash,
+        row_count=row_count,
+        checkpointed_at=taken_at,
+        signing_key_id=key_id,
+        signature=signature,
+    )
+    db.add(checkpoint)
+    db.flush()
+    return checkpoint
+
+
+def seal_account(
+    db: Session,
+    *,
+    account_id: Any,
+    batch_size: Optional[int] = None,
+    max_batches: Optional[int] = None,
+    now: Optional[datetime] = None,
+    lag: Optional[timedelta] = None,
+    deadline: Optional[float] = None,
+) -> SealResult:
+    """Seal this account's unsealed audit rows, in batches.
+
+    One transaction per batch, so a backlog never holds a long lock on the
+    table the request path writes to. The chain head is taken ``FOR UPDATE``
+    inside each batch, which is what makes two sealers safe.
+    """
+    stamp = now or datetime.now(UTC)
+    window = stamp - (seal_lag() if lag is None else lag)
+    size = max(1, int(batch_size or settings.audit_chain_seal_batch_size))
+    ceiling = max(1, int(max_batches or settings.audit_chain_seal_max_batches))
+    interval = checkpoint_interval()
+    result = SealResult(account_id=str(account_id))
+
+    for _ in range(ceiling):
+        if deadline is not None and time.monotonic() >= deadline:
+            result.more_remaining = True
+            break
+        state = get_state(db, account_id=account_id, for_update=True)
+        assert state is not None  # create=True
+        # Naive comparison: audit_log.timestamp is a naive UTC column.
+        cutoff = window.replace(tzinfo=None)
+        rows = list(
+            db.execute(
+                select(AuditLog)
+                .where(
+                    AuditLog.account_id == account_id,
+                    AuditLog.chain_seq.is_(None),
+                    AuditLog.timestamp <= cutoff,
+                )
+                .order_by(AuditLog.timestamp, AuditLog.id)
+                .limit(size)
+                # Hash what the database holds, never a copy of the row that
+                # happens to be in this session's identity map. The two can
+                # differ: a caller hands ``log_action`` an aware datetime and
+                # the naive column gives back the local wall clock. A hash
+                # over the in-memory value would verify in the session that
+                # wrote it and nowhere else.
+                .execution_options(populate_existing=True)
+            )
+            .scalars()
+            .all()
+        )
+        if not rows:
+            db.commit()
+            break
+        seq = int(state.last_seq or 0)
+        prev = str(state.last_hash or GENESIS_HASH)
+        last_timestamp = state.last_sealed_at
+        pending_checkpoints: list[tuple[int, str, int]] = []
+        since_checkpoint = seq % interval
+        for row in rows:
+            seq += 1
+            payload = canonical_row(row, seq=seq, prev_hash=prev)
+            digest = hash_row(payload)
+            row.chain_seq = seq
+            row.prev_hash = prev
+            row.row_hash = digest
+            row.sealed_at = stamp
+            db.add(row)
+            prev = digest
+            since_checkpoint += 1
+            if since_checkpoint >= interval:
+                pending_checkpoints.append((seq, digest, since_checkpoint))
+                since_checkpoint = 0
+        state.last_seq = seq
+        state.last_hash = prev
+        state.last_sealed_at = stamp
+        db.add(state)
+        db.flush()
+        for cp_seq, cp_hash, cp_count in pending_checkpoints:
+            _write_checkpoint(
+                db,
+                account_id=account_id,
+                seq=cp_seq,
+                chain_hash=cp_hash,
+                row_count=cp_count,
+                taken_at=stamp,
+            )
+            result.checkpoints += 1
+        db.commit()
+        result.sealed += len(rows)
+        result.batches += 1
+        if last_timestamp is not None:
+            first = rows[0].timestamp
+            if first is not None and _canonical_timestamp(first) < _canonical_timestamp(
+                last_timestamp
+            ):
+                result.out_of_order += 1
+        if len(rows) == size:
+            result.more_remaining = True
+        else:
+            result.more_remaining = False
+            break
+    return result
+
+
+def run_seal_pass(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    account_ids: Optional[Sequence[Any]] = None,
+    ignore_enabled: bool = False,
+    lag: Optional[timedelta] = None,
+) -> SweepResult:
+    """One bounded pass over every active account.
+
+    Returns totals rather than raising: the caller is a background loop, and
+    an exception per pass would be noise on top of per account logging.
+    """
+    summary = SweepResult()
+    if not (ignore_enabled or settings.audit_chain_enabled):
+        summary.skipped_reason = "disabled"
+        return summary
+    stamp = now or datetime.now(UTC)
+    deadline = time.monotonic() + max(1, int(settings.audit_chain_seal_max_seconds))
+    stmt = select(Account).where(Account.is_active.is_(True)).order_by(Account.id)
+    if account_ids:
+        stmt = stmt.where(Account.id.in_(list(account_ids)))
+    for account in db.execute(stmt).scalars().all():
+        if time.monotonic() >= deadline:
+            summary.budget_exhausted = True
+            break
+        summary.accounts += 1
+        try:
+            summary.record(
+                seal_account(
+                    db, account_id=account.id, now=stamp, lag=lag, deadline=deadline
+                )
+            )
+        except Exception:
+            db.rollback()
+            logger.error(
+                "Audit chain sealing failed for account %s", account.id, exc_info=True
+            )
+    if summary.sealed:
+        logger.info("Audit chain seal pass: %s", summary.as_dict())
+    return summary
+
+
+def chain_status(db: Session, *, account_id: Any) -> dict[str, Any]:
+    """Head, floor, pending count and the newest checkpoint."""
+    state = get_state(db, account_id=account_id, create=False)
+    pending = int(
+        db.execute(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.account_id == account_id, AuditLog.chain_seq.is_(None))
+        ).scalar_one()
+        or 0
+    )
+    sealed = int(
+        db.execute(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.account_id == account_id, AuditLog.chain_seq.is_not(None))
+        ).scalar_one()
+        or 0
+    )
+    latest = db.execute(
+        select(AuditChainCheckpoint)
+        .where(AuditChainCheckpoint.account_id == account_id)
+        .order_by(AuditChainCheckpoint.seq.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    active_key = record_signing.get_active_key(db, account_id=account_id)
+    return {
+        "enabled": bool(settings.audit_chain_enabled),
+        "head_seq": int(state.last_seq) if state else 0,
+        "head_hash": str(state.last_hash) if state else GENESIS_HASH,
+        "last_sealed_at": _iso(state.last_sealed_at) if state else None,
+        "pruned_below_seq": int(state.pruned_below_seq) if state else 0,
+        "sealed_rows": sealed,
+        "unsealed_rows": pending,
+        "seal_lag_seconds": int(settings.audit_chain_seal_lag_seconds),
+        "checkpoint_interval": checkpoint_interval(),
+        "latest_checkpoint": checkpoint_summary(latest) if latest else None,
+        "active_key_id": active_key.key_id if active_key else None,
+    }
+
+
+def checkpoint_summary(checkpoint: AuditChainCheckpoint) -> dict[str, Any]:
+    """One checkpoint as an API payload, signature included."""
+    payload = checkpoint_payload(
+        account_id=checkpoint.account_id,
+        seq=checkpoint.seq,
+        chain_hash=checkpoint.chain_hash,
+        row_count=checkpoint.row_count,
+        taken_at=checkpoint.checkpointed_at,
+    )
+    digest = record_signing.digest_of(payload)
+    signed_at = record_signing.format_signed_at(checkpoint.checkpointed_at)
+    return {
+        "seq": int(checkpoint.seq),
+        "chain_hash": checkpoint.chain_hash,
+        "row_count": int(checkpoint.row_count),
+        "checkpointed_at": signed_at,
+        "signing_key_id": checkpoint.signing_key_id,
+        "signature": checkpoint.signature,
+        "signed_payload": payload,
+        "digest": digest,
+        # The detached document a client verifies, assembled here so nobody
+        # has to guess how the signed bytes were spelled.
+        "signature_document": (
+            {
+                "schema": record_signing.SIGNATURE_SCHEMA,
+                "algorithm": "ed25519",
+                "key_id": checkpoint.signing_key_id,
+                "payload_type": CHECKPOINT_SCHEMA,
+                "digest": digest,
+                "signed_at": signed_at,
+                "signature": checkpoint.signature,
+            }
+            if checkpoint.signature
+            else None
+        ),
+    }
+
+
+def list_checkpoints(
+    db: Session, *, account_id: Any, limit: int = 50, after_seq: int = 0
+) -> list[dict[str, Any]]:
+    """Checkpoints in sequence order, so a client can keep its own copies."""
+    rows = (
+        db.execute(
+            select(AuditChainCheckpoint)
+            .where(
+                AuditChainCheckpoint.account_id == account_id,
+                AuditChainCheckpoint.seq > after_seq,
+            )
+            .order_by(AuditChainCheckpoint.seq)
+            .limit(max(1, min(int(limit), 1000)))
+        )
+        .scalars()
+        .all()
+    )
+    return [checkpoint_summary(row) for row in rows]
+
+
+def chain_segment(
+    db: Session, *, account_id: Any, after_seq: int = 0, limit: int = 500
+) -> dict[str, Any]:
+    """Canonical payloads plus stored hashes, for a client side walk.
+
+    A verification endpoint that only reports its own verdict is worth
+    exactly the trust the caller already places in the server. This returns
+    the material so the CLI can recompute every hash itself and disagree.
+    """
+    count = max(1, min(int(limit), 1000))
+    rows = (
+        db.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.account_id == account_id,
+                AuditLog.chain_seq.is_not(None),
+                AuditLog.chain_seq > after_seq,
+            )
+            .order_by(AuditLog.chain_seq)
+            .limit(count)
+            .execution_options(populate_existing=True)
+        )
+        .scalars()
+        .all()
+    )
+    state = get_state(db, account_id=account_id, create=False)
+    entries = [
+        {
+            "seq": int(row.chain_seq),
+            "row_id": str(row.id),
+            "prev_hash": row.prev_hash,
+            "row_hash": row.row_hash,
+            "payload": canonical_row(
+                row, seq=int(row.chain_seq), prev_hash=str(row.prev_hash or "")
+            ),
+        }
+        for row in rows
+    ]
+    return {
+        "account_id": str(account_id),
+        "row_domain": ROW_DOMAIN.decode("utf-8"),
+        "after_seq": int(after_seq),
+        "head_seq": int(state.last_seq) if state else 0,
+        "pruned_below_seq": int(state.pruned_below_seq) if state else 0,
+        "genesis_hash": GENESIS_HASH,
+        "entries": entries,
+        "has_more": len(entries) == count,
+        "note": (
+            "Recompute row_hash as sha256(row_domain + canonical JSON of "
+            "payload) with sorted keys and no insignificant whitespace, and "
+            "check that each prev_hash equals the previous row_hash. A "
+            "verdict from this server is not a verification."
+        ),
+    }
+
+
+def verify_chain(
+    db: Session,
+    *,
+    account_id: Any,
+    start_seq: Optional[int] = None,
+    end_seq: Optional[int] = None,
+    max_rows: Optional[int] = None,
+) -> dict[str, Any]:
+    """Walk the chain and report the first break, if any.
+
+    The walk is over a range because that is the only claim the chain can
+    honestly support: rows below ``pruned_below_seq`` were removed by the
+    retention purge under a stated policy and cannot be recovered or verified,
+    and rows written since the last seal are not in the chain yet.
+    """
+    state = get_state(db, account_id=account_id, create=False)
+    head = int(state.last_seq) if state else 0
+    floor = int(state.pruned_below_seq) if state else 0
+    begin = max(int(start_seq) if start_seq else 1, floor + 1)
+    finish = min(int(end_seq) if end_seq else head, head)
+    limit = max(1, int(max_rows or settings.audit_chain_verify_max_rows))
+
+    report: dict[str, Any] = {
+        "account_id": str(account_id),
+        "status": STATUS_EMPTY,
+        "checked_rows": 0,
+        "start_seq": begin,
+        "end_seq": finish,
+        "head_seq": head,
+        "pruned_below_seq": floor,
+        "unsealed_rows": int(
+            db.execute(
+                select(func.count())
+                .select_from(AuditLog)
+                .where(AuditLog.account_id == account_id, AuditLog.chain_seq.is_(None))
+            ).scalar_one()
+            or 0
+        ),
+        "truncated": False,
+        "out_of_order_rows": 0,
+        "first_break": None,
+        "checkpoints_verified": 0,
+        "checkpoint_failures": [],
+    }
+    if head == 0 or finish < begin:
+        return report
+
+    if finish - begin + 1 > limit:
+        finish = begin + limit - 1
+        report["truncated"] = True
+        report["end_seq"] = finish
+
+    rows = (
+        db.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.account_id == account_id,
+                AuditLog.chain_seq >= begin,
+                AuditLog.chain_seq <= finish,
+            )
+            .order_by(AuditLog.chain_seq)
+            # Verify against persisted values, for the same reason the sealer
+            # hashes them: a stale in-memory row would report a break that is
+            # not in the database, or hide one that is.
+            .execution_options(populate_existing=True)
+        )
+        .scalars()
+        .all()
+    )
+
+    # The expected prev_hash for the first row in the range: the row before
+    # it when there is one, the genesis hash when the range starts at 1.
+    if begin <= 1:
+        expected_prev = GENESIS_HASH
+    else:
+        anchor = db.execute(
+            select(AuditLog.row_hash).where(
+                AuditLog.account_id == account_id, AuditLog.chain_seq == begin - 1
+            )
+        ).scalar_one_or_none()
+        expected_prev = str(anchor) if anchor else None
+
+    checked = 0
+    previous_timestamp: Optional[str] = None
+    expected_seq = begin
+    for row in rows:
+        seq = int(row.chain_seq)
+        if seq < expected_seq:
+            report["status"] = STATUS_BROKEN
+            report["first_break"] = {
+                "kind": BREAK_DUPLICATE_SEQ,
+                "seq": seq,
+                "row_id": str(row.id),
+                "detail": "two rows share one chain sequence",
+            }
+            break
+        if seq > expected_seq:
+            report["status"] = STATUS_BROKEN
+            report["first_break"] = {
+                "kind": BREAK_MISSING_ROW,
+                "seq": expected_seq,
+                "row_id": None,
+                "detail": (
+                    f"sequence {expected_seq} is not in the log; the chain "
+                    f"jumps to {seq}. A row was deleted after it was sealed, "
+                    "or it is outside this account."
+                ),
+            }
+            break
+        stored_prev = str(row.prev_hash or "")
+        if expected_prev is not None and stored_prev != expected_prev:
+            report["status"] = STATUS_BROKEN
+            report["first_break"] = {
+                "kind": BREAK_PREV_HASH,
+                "seq": seq,
+                "row_id": str(row.id),
+                "detail": (
+                    "prev_hash does not match the row_hash of the row before "
+                    "it: the previous row was altered or replaced"
+                ),
+                "expected": expected_prev,
+                "found": stored_prev,
+            }
+            break
+        recomputed = hash_row(canonical_row(row, seq=seq, prev_hash=stored_prev))
+        if recomputed != str(row.row_hash or ""):
+            report["status"] = STATUS_BROKEN
+            report["first_break"] = {
+                "kind": BREAK_ROW_HASH,
+                "seq": seq,
+                "row_id": str(row.id),
+                "detail": (
+                    "the row no longer hashes to its stored row_hash: a "
+                    "field of this row was changed after it was sealed"
+                ),
+                "expected": str(row.row_hash or ""),
+                "found": recomputed,
+            }
+            break
+        stamp = _canonical_timestamp(row.timestamp)
+        if previous_timestamp is not None and stamp is not None:
+            if stamp < previous_timestamp:
+                report["out_of_order_rows"] = int(report["out_of_order_rows"]) + 1
+        previous_timestamp = stamp
+        expected_prev = str(row.row_hash or "")
+        expected_seq = seq + 1
+        checked += 1
+
+    report["checked_rows"] = checked
+    if report["first_break"] is None:
+        if checked < finish - begin + 1:
+            report["status"] = STATUS_BROKEN
+            report["first_break"] = {
+                "kind": BREAK_MISSING_ROW,
+                "seq": expected_seq,
+                "row_id": None,
+                "detail": (
+                    f"the log ends at sequence {expected_seq - 1} but the "
+                    f"chain head is {head}: rows were deleted from the tail"
+                ),
+            }
+        elif checked:
+            report["status"] = STATUS_OK
+
+    _verify_checkpoints(
+        db, account_id=account_id, report=report, begin=begin, end=finish
+    )
+    return report
+
+
+def _verify_checkpoints(
+    db: Session, *, account_id: Any, report: dict[str, Any], begin: int, end: int
+) -> None:
+    """Check every checkpoint in range against the chain and its signature."""
+    checkpoints = (
+        db.execute(
+            select(AuditChainCheckpoint)
+            .where(
+                AuditChainCheckpoint.account_id == account_id,
+                AuditChainCheckpoint.seq >= begin,
+                AuditChainCheckpoint.seq <= end,
+            )
+            .order_by(AuditChainCheckpoint.seq)
+        )
+        .scalars()
+        .all()
+    )
+    failures: list[dict[str, Any]] = []
+    verified = 0
+    for checkpoint in checkpoints:
+        stored = db.execute(
+            select(AuditLog.row_hash).where(
+                AuditLog.account_id == account_id,
+                AuditLog.chain_seq == checkpoint.seq,
+            )
+        ).scalar_one_or_none()
+        if stored != checkpoint.chain_hash:
+            failures.append(
+                {
+                    "seq": int(checkpoint.seq),
+                    "kind": "checkpoint_hash_mismatch",
+                    "detail": (
+                        "the chain no longer hashes to the value this "
+                        "checkpoint anchored"
+                    ),
+                }
+            )
+            continue
+        if checkpoint.signature and checkpoint.signing_key_id:
+            key = record_signing.get_key_by_id(
+                db, account_id=account_id, key_id=checkpoint.signing_key_id
+            )
+            document = checkpoint_summary(checkpoint)["signature_document"]
+            if key is None or not record_signing.verify_signature_document(
+                document, public_key=key.public_key
+            ):
+                failures.append(
+                    {
+                        "seq": int(checkpoint.seq),
+                        "kind": "checkpoint_signature_invalid",
+                        "detail": "the checkpoint signature does not verify",
+                    }
+                )
+                continue
+        verified += 1
+    report["checkpoints_verified"] = verified
+    report["checkpoint_failures"] = failures
+    if failures and report["status"] != STATUS_BROKEN:
+        report["status"] = STATUS_BROKEN
+        report["first_break"] = {
+            "kind": failures[0]["kind"],
+            "seq": failures[0]["seq"],
+            "row_id": None,
+            "detail": failures[0]["detail"],
+        }
+
+
+class AuditChainSealer:
+    """Periodic asyncio sealing pass, modeled on the retention purge sweeper.
+
+    Started from the app lifespan on the API role only. The DB work is
+    synchronous, so each pass runs in a thread and the event loop stays free.
+    """
+
+    def __init__(self, check_interval_seconds: Optional[int] = None) -> None:
+        self.check_interval = int(
+            check_interval_seconds
+            if check_interval_seconds is not None
+            else settings.audit_chain_seal_interval_seconds
+        )
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start the sealing background task."""
+        if self._running:
+            logger.warning("Audit chain sealer is already running")
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._seal_loop())
+        logger.info(
+            "Audit chain sealer started (check_interval=%ss, checkpoint=%s rows)",
+            self.check_interval,
+            checkpoint_interval(),
+        )
+
+    async def stop(self) -> None:
+        """Stop the sealing background task."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected when stop() cancels the loop task.
+                pass
+
+    async def _seal_loop(self) -> None:
+        """Seal on every tick, after waiting one interval first."""
+        while self._running:
+            try:
+                await asyncio.sleep(self.check_interval)
+            except asyncio.CancelledError:
+                break
+            try:
+                await asyncio.to_thread(self._seal_once)
+            except Exception:
+                logger.error("Error in audit chain seal pass", exc_info=True)
+
+    @staticmethod
+    def _seal_once() -> None:
+        """One synchronous pass with its own session."""
+        db = next(get_db_session())
+        try:
+            run_seal_pass(db)
+        finally:
+            db.close()
+
+
+_sealer_instance: Optional[AuditChainSealer] = None
+
+
+def get_audit_chain_sealer() -> AuditChainSealer:
+    """Get or create the global audit chain sealer."""
+    global _sealer_instance
+    if _sealer_instance is None:
+        _sealer_instance = AuditChainSealer()
+    return _sealer_instance

--- a/backend/preloop/services/flow_artifacts.py
+++ b/backend/preloop/services/flow_artifacts.py
@@ -699,7 +699,70 @@ def put_artifact(
         quota_bytes=settings.flow_artifact_account_quota_bytes,
         require_execution_open=require_execution_open,
     )
+    if kind == "evidence":
+        # Imported here, not at module scope: signing canonicalises through
+        # preloop.cra.evidence_pack, which imports this module.
+        from preloop.services import record_signing
+
+        # Sign at mint, not at download. A signature made when the pack is
+        # served would only ever say "this is what we hold now"; made here it
+        # is dated to the capture, and re-serving cannot change it (#558).
+        record_signing.sign_evidence_pack(
+            db,
+            account_id=account_id,
+            artifact_id=artifact.id,
+            execution_id=execution_id,
+            archive_sha256=manifest["sha256"],
+            size_bytes=manifest.get("size_bytes"),
+            created_at=now,
+        )
     return artifact_reference(artifact)
+
+
+def evidence_signature(
+    db: Session, *, account_id: UUID, artifact_id: Any
+) -> dict[str, Any] | None:
+    """The detached signature over one evidence pack, or None.
+
+    None is a normal answer: packs captured before #558, and packs from an
+    account whose key could not be minted, have no signature and the receipt
+    says so rather than pretending.
+    """
+    if not artifact_id:
+        return None
+    from preloop.services import record_signing
+
+    try:
+        record = record_signing.get_record_signature(
+            db,
+            account_id=account_id,
+            payload_type=record_signing.PAYLOAD_EVIDENCE_PACK,
+            subject_id=artifact_id,
+        )
+    except Exception:
+        logger.warning("Could not read the evidence signature", exc_info=True)
+        return None
+    if record is None:
+        return None
+    return record_signing.record_signature_document(record)
+
+
+def attach_evidence_signature(
+    db: Session, *, account_id: UUID, receipt: dict[str, Any]
+) -> dict[str, Any]:
+    """Return the receipt with its signature, when the pack has one.
+
+    Kept out of :func:`evidence_receipt` on purpose: that function is called
+    on paths that hold no session, and a receipt builder that needs a database
+    round trip would put one on every status poll.
+    """
+    document = evidence_signature(
+        db, account_id=account_id, artifact_id=receipt.get("artifact_id")
+    )
+    out = dict(receipt)
+    out["signature"] = document
+    out["signing_key_id"] = (document or {}).get("key_id")
+    return out
 
 
 def get_artifact(

--- a/backend/preloop/services/flow_artifacts.py
+++ b/backend/preloop/services/flow_artifacts.py
@@ -715,6 +715,9 @@ def put_artifact(
             archive_sha256=manifest["sha256"],
             size_bytes=manifest.get("size_bytes"),
             created_at=now,
+            # store() already committed the artifact; this is the boundary
+            # that persists the signature (and a first-use key) beside it.
+            commit=True,
         )
     return artifact_reference(artifact)
 

--- a/backend/preloop/services/flow_artifacts.py
+++ b/backend/preloop/services/flow_artifacts.py
@@ -190,8 +190,15 @@ def evidence_receipt(
         "created_at": created,
         "expires_at": expires,
         "retention_hours": artifact_retention_hours("evidence"),
+        # object_lock stays false because Preloop does not assert it. It is a
+        # storage-layer property the operator configures (S3 Object Lock, a
+        # WORM volume) and the control plane has no way to verify it.
         "object_lock": False,
-        "legal_hold": False,
+        # legal_hold is now a real fact about this row rather than a constant:
+        # true means a legal_hold record freezes the pack, so the janitor
+        # leaves the ciphertext alone past expires_at and the retention purge
+        # leaves the row alone.
+        "legal_hold": bool(getattr(artifact, "legal_hold", False)),
         "integrity_verified": integrity_verified,
         "error": error,
     }
@@ -376,6 +383,11 @@ def _mark_status_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     """Availability metadata for polls; never a verified-download claim."""
     status = str(receipt.get("status") or "missing")
     expires = receipt.get("expires_at")
+    # A held pack does not expire on the poll path either. The hold service
+    # stamps this key on the persisted receipt when it freezes a pack, so the
+    # cheap status poll and the live inspect agree.
+    if receipt.get("legal_hold"):
+        expires = None
     if status == "available" and expires:
         try:
             exp = datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
@@ -428,7 +440,14 @@ def public_evidence_status(execution: Any) -> dict[str, Any]:
 def _receipt_for_artifact(execution: Any, artifact: Any) -> dict[str, Any]:
     """Build a receipt from a scoped evidence row's current availability."""
     now = datetime.now(UTC)
-    expired = artifact.expires_at <= now or artifact.ciphertext is None
+    # A held pack whose bytes are still there is available, whatever the
+    # operational expiry says: the hold is what stopped the janitor from
+    # taking them, so reporting "expired" would contradict the download.
+    held = bool(getattr(artifact, "legal_hold", False))
+    if held and artifact.ciphertext is not None:
+        expired = False
+    else:
+        expired = artifact.expires_at <= now or artifact.ciphertext is None
     status = "expired" if expired else str(artifact.availability or "available")
     if status not in {"available", "expired", "failed"}:
         status = "expired" if expired else "available"

--- a/backend/preloop/services/legal_hold.py
+++ b/backend/preloop/services/legal_hold.py
@@ -1,0 +1,391 @@
+"""Place and release legal holds, and answer "is this held?".
+
+A legal hold is the answer to "counsel says nothing about this incident may be
+deleted while the matter is open". Before this, the honest answer in the
+evidence storage guide was that ``legal_hold`` is always false, and the
+30 day operational evidence window applied to a run under investigation
+exactly as it applied to a run nobody would ever look at again.
+
+Two things happen when a hold is placed, in one transaction:
+
+1. a ``legal_hold`` record with the actor and the mandatory reason, and
+2. the derived boolean on the held rows, which is what the purge and the
+   evidence janitor actually test.
+
+Both the placement and the release are written to the audit log, because a
+hold that can be lifted without a trace is a hold whose absence proves
+nothing.
+
+Release does not blindly clear the boolean. An evidence pack can be covered by
+its own pack-level hold and by a hold on its execution at the same time;
+lifting one must leave the other in force, so the flag is recomputed from the
+holds that remain active.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_audit_log
+from preloop.models.crud import legal_hold as crud
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import (
+    HOLD_RESOURCE_APPROVAL,
+    HOLD_RESOURCE_EVIDENCE_PACK,
+    HOLD_RESOURCE_EXECUTION,
+    HOLD_RESOURCE_TYPES,
+    LegalHold,
+)
+
+logger = logging.getLogger(__name__)
+
+AUDIT_ACTION_PLACED = "legal_hold_placed"
+AUDIT_ACTION_RELEASED = "legal_hold_released"
+
+#: A reason is the whole point of the record. One word is not a reason, and a
+#: novel pasted into an audit row is a different problem.
+MIN_REASON_CHARS = 8
+MAX_REASON_CHARS = 2000
+
+
+class LegalHoldError(ValueError):
+    """A hold could not be placed or released as asked."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class HoldOutcome:
+    """What a place or release call actually changed."""
+
+    hold: LegalHold
+    #: Rows whose derived flag this call moved, per table.
+    flagged: dict[str, int]
+
+
+def _clean_reason(reason: Any) -> str:
+    text = str(reason or "").strip()
+    if len(text) < MIN_REASON_CHARS:
+        raise LegalHoldError(
+            "reason_required",
+            f"a legal hold reason of at least {MIN_REASON_CHARS} characters is "
+            "required; the record exists to explain why the data is frozen",
+        )
+    return text[:MAX_REASON_CHARS]
+
+
+def _coerce_uuid(resource_id: Any) -> UUID:
+    try:
+        return UUID(str(resource_id))
+    except (TypeError, ValueError) as exc:
+        raise LegalHoldError(
+            "resource_not_found", "the resource id is not a valid identifier"
+        ) from exc
+
+
+def _require_resource(
+    db: Session, *, account_id: Any, resource_type: str, resource_id: str
+) -> UUID:
+    """Refuse a hold on something this account does not own.
+
+    A hold on a nonexistent id would look active in a listing and freeze
+    nothing, which is the failure mode a hold exists to prevent.
+    """
+    if resource_type not in HOLD_RESOURCE_TYPES:
+        raise LegalHoldError(
+            "unknown_resource_type",
+            f"resource_type must be one of {', '.join(HOLD_RESOURCE_TYPES)}",
+        )
+    identifier = _coerce_uuid(resource_id)
+    model = {
+        HOLD_RESOURCE_EXECUTION: FlowExecution,
+        HOLD_RESOURCE_APPROVAL: ApprovalRequest,
+        HOLD_RESOURCE_EVIDENCE_PACK: FlowArtifact,
+    }[resource_type]
+    stmt = select(model.id).where(
+        model.id == identifier, model.account_id == account_id
+    )
+    if resource_type == HOLD_RESOURCE_EVIDENCE_PACK:
+        stmt = stmt.where(FlowArtifact.kind == "evidence")
+    if db.execute(stmt).scalar_one_or_none() is None:
+        raise LegalHoldError(
+            "resource_not_found",
+            f"no {resource_type} {resource_id} in this account",
+        )
+    return identifier
+
+
+def _stamp_evidence_receipts(
+    db: Session, *, account_id: Any, execution_ids: Sequence[Any], held: bool
+) -> int:
+    """Mirror the hold onto the persisted evidence receipt of each execution.
+
+    ``GET .../evidence-status`` answers from ``flow_execution.evidence_receipt``
+    without touching ciphertext, and it downgrades an ``available`` receipt to
+    ``expired`` once ``expires_at`` has passed. A held pack whose bytes the
+    janitor was told to leave alone would otherwise poll as expired and
+    download fine, which is exactly the contradiction the receipt exists to
+    avoid.
+    """
+    if not execution_ids:
+        return 0
+    rows = (
+        db.execute(
+            select(FlowExecution).where(
+                FlowExecution.account_id == account_id,
+                FlowExecution.id.in_(list(execution_ids)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stamped = 0
+    for execution in rows:
+        receipt = execution.evidence_receipt
+        if not isinstance(receipt, dict):
+            continue
+        if bool(receipt.get("legal_hold")) == held:
+            continue
+        updated = dict(receipt)
+        updated["legal_hold"] = held
+        execution.evidence_receipt = updated
+        db.add(execution)
+        stamped += 1
+    return stamped
+
+
+def _apply_flags(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: UUID,
+    held: bool,
+) -> dict[str, int]:
+    """Set (or recompute) the derived flags for one hold's resource."""
+    flagged: dict[str, int] = {}
+    if resource_type == HOLD_RESOURCE_EXECUTION:
+        flagged["flow_execution"] = crud.set_execution_flag(
+            db, account_id=account_id, execution_id=resource_id, held=held
+        )
+        flagged["evidence_receipt"] = _stamp_evidence_receipts(
+            db, account_id=account_id, execution_ids=[resource_id], held=held
+        )
+        if held:
+            flagged["flow_artifact"] = crud.set_execution_evidence_flags(
+                db, account_id=account_id, execution_id=resource_id, held=True
+            )
+        else:
+            # Clearing: a pack that carries its own active pack-level hold
+            # keeps its flag. Two overlapping holds, one released, still one
+            # frozen pack.
+            still_held = crud.active_resource_ids(
+                db, account_id=account_id, resource_type=HOLD_RESOURCE_EVIDENCE_PACK
+            )
+            cleared = 0
+            for artifact_id in crud.execution_artifact_ids(
+                db, account_id=account_id, execution_id=resource_id
+            ):
+                if str(artifact_id) in still_held:
+                    continue
+                cleared += crud.set_artifact_flag(
+                    db, account_id=account_id, artifact_id=artifact_id, held=False
+                )
+            flagged["flow_artifact"] = cleared
+    elif resource_type == HOLD_RESOURCE_APPROVAL:
+        flagged["approval_request"] = crud.set_approval_flag(
+            db, account_id=account_id, approval_id=resource_id, held=held
+        )
+    else:
+        execution_id = db.execute(
+            select(FlowArtifact.execution_id).where(
+                FlowArtifact.id == resource_id,
+                FlowArtifact.account_id == account_id,
+            )
+        ).scalar_one_or_none()
+        if not held:
+            # The pack may still sit under an execution-level hold.
+            covering = crud.active_resource_ids(
+                db, account_id=account_id, resource_type=HOLD_RESOURCE_EXECUTION
+            )
+            if execution_id is not None and str(execution_id) in covering:
+                return {"flow_artifact": 0}
+        flagged["flow_artifact"] = crud.set_artifact_flag(
+            db, account_id=account_id, artifact_id=resource_id, held=held
+        )
+        flagged["evidence_receipt"] = _stamp_evidence_receipts(
+            db,
+            account_id=account_id,
+            execution_ids=[execution_id] if execution_id is not None else [],
+            held=held,
+        )
+    return flagged
+
+
+def place_hold(
+    db: Session,
+    *,
+    account_id: Any,
+    resource_type: str,
+    resource_id: str,
+    reason: str,
+    user_id: Optional[UUID] = None,
+    now: Optional[datetime] = None,
+    commit: bool = True,
+) -> HoldOutcome:
+    """Freeze one resource. Record, flags and audit row in one transaction."""
+    cleaned_reason = _clean_reason(reason)
+    identifier = _require_resource(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+    existing = crud.get_active(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+    )
+    if existing is not None:
+        raise LegalHoldError(
+            "already_held",
+            f"{resource_type} {identifier} is already under an active legal hold",
+        )
+    stamp = now or datetime.now(UTC)
+    hold = crud.create(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+        reason=cleaned_reason,
+        placed_by_user_id=user_id,
+        placed_at=stamp,
+    )
+    flagged = _apply_flags(
+        db,
+        account_id=account_id,
+        resource_type=resource_type,
+        resource_id=identifier,
+        held=True,
+    )
+    crud_audit_log.log_action(
+        db,
+        account_id=account_id,
+        user_id=user_id,
+        action=AUDIT_ACTION_PLACED,
+        resource_type=resource_type,
+        resource_id=str(identifier),
+        status="success",
+        details={
+            "hold_id": str(hold.id),
+            "reason": cleaned_reason,
+            "flagged": flagged,
+        },
+        commit=False,
+    )
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    logger.info(
+        "Legal hold placed on %s %s (%s rows flagged)",
+        resource_type,
+        identifier,
+        sum(flagged.values()),
+    )
+    return HoldOutcome(hold=hold, flagged=flagged)
+
+
+def release_hold(
+    db: Session,
+    *,
+    account_id: Any,
+    hold_id: UUID,
+    reason: str,
+    user_id: Optional[UUID] = None,
+    now: Optional[datetime] = None,
+    commit: bool = True,
+) -> HoldOutcome:
+    """Lift one hold, recording who lifted it and why."""
+    cleaned_reason = _clean_reason(reason)
+    hold = crud.get(db, account_id=account_id, hold_id=hold_id)
+    if hold is None:
+        raise LegalHoldError("hold_not_found", f"no legal hold {hold_id}")
+    if hold.released_at is not None:
+        raise LegalHoldError(
+            "already_released", f"legal hold {hold_id} was already released"
+        )
+    stamp = now or datetime.now(UTC)
+    crud.release(
+        db,
+        hold=hold,
+        released_by_user_id=user_id,
+        released_at=stamp,
+        release_reason=cleaned_reason,
+    )
+    # The record is released first so the recompute below sees the remaining
+    # active holds, not this one.
+    flagged = _apply_flags(
+        db,
+        account_id=account_id,
+        resource_type=hold.resource_type,
+        resource_id=_coerce_uuid(hold.resource_id),
+        held=False,
+    )
+    crud_audit_log.log_action(
+        db,
+        account_id=account_id,
+        user_id=user_id,
+        action=AUDIT_ACTION_RELEASED,
+        resource_type=hold.resource_type,
+        resource_id=str(hold.resource_id),
+        status="success",
+        details={
+            "hold_id": str(hold.id),
+            "reason": cleaned_reason,
+            "placed_reason": hold.reason,
+            "flagged": flagged,
+        },
+        commit=False,
+    )
+    if commit:
+        db.commit()
+        db.refresh(hold)
+    logger.info(
+        "Legal hold %s released on %s %s",
+        hold_id,
+        hold.resource_type,
+        hold.resource_id,
+    )
+    return HoldOutcome(hold=hold, flagged=flagged)
+
+
+def hold_summary(hold: LegalHold) -> dict[str, Any]:
+    """Serializable view of one hold for API responses and exports."""
+    return {
+        "id": str(hold.id),
+        "resource_type": hold.resource_type,
+        "resource_id": hold.resource_id,
+        "reason": hold.reason,
+        "placed_by_user_id": (
+            str(hold.placed_by_user_id) if hold.placed_by_user_id else None
+        ),
+        "placed_at": hold.placed_at.isoformat() if hold.placed_at else None,
+        "released_by_user_id": (
+            str(hold.released_by_user_id) if hold.released_by_user_id else None
+        ),
+        "released_at": hold.released_at.isoformat() if hold.released_at else None,
+        "release_reason": hold.release_reason,
+        "active": hold.released_at is None,
+    }

--- a/backend/preloop/services/legal_hold.py
+++ b/backend/preloop/services/legal_hold.py
@@ -113,9 +113,15 @@ def _require_resource(
         HOLD_RESOURCE_APPROVAL: ApprovalRequest,
         HOLD_RESOURCE_EVIDENCE_PACK: FlowArtifact,
     }[resource_type]
-    stmt = select(model.id).where(
-        model.id == identifier, model.account_id == account_id
-    )
+    if resource_type == HOLD_RESOURCE_EXECUTION:
+        # An execution is owned through its flow, not by a column of its own.
+        stmt = select(FlowExecution.id).where(
+            FlowExecution.id == identifier, crud.execution_in_account(account_id)
+        )
+    else:
+        stmt = select(model.id).where(
+            model.id == identifier, model.account_id == account_id
+        )
     if resource_type == HOLD_RESOURCE_EVIDENCE_PACK:
         stmt = stmt.where(FlowArtifact.kind == "evidence")
     if db.execute(stmt).scalar_one_or_none() is None:
@@ -143,7 +149,7 @@ def _stamp_evidence_receipts(
     rows = (
         db.execute(
             select(FlowExecution).where(
-                FlowExecution.account_id == account_id,
+                crud.execution_in_account(account_id),
                 FlowExecution.id.in_(list(execution_ids)),
             )
         )

--- a/backend/preloop/services/record_signing.py
+++ b/backend/preloop/services/record_signing.py
@@ -1,0 +1,398 @@
+"""Ed25519 signing for records that leave the platform.
+
+Two ideas, kept separate on purpose.
+
+**The key.** One active Ed25519 key per account. The private half is stored
+Fernet-encrypted through :mod:`preloop.utils.encryption`, the same at-rest
+treatment as model credentials and webhook secrets (#504). The public half is
+served in the clear from an endpoint, because a signature nobody can check is
+decoration. Rotation retires the old key and mints a new one; retired keys
+keep their public half so signatures already issued stay verifiable. Every
+signature carries its ``key_id``, so a verifier never has to guess.
+
+**The signature.** Always detached, always over a digest, never over a blob.
+The signed bytes are domain separated:
+
+    preloop.signature/v1\\n<payload_type>\\n<digest>\\n<signed_at>
+
+so a signature over an evidence pack manifest can never be replayed as a
+signature over a period export manifest or an audit checkpoint, and the time
+of signing is covered rather than merely claimed.
+
+What this proves is narrow and the docs say so at length: it proves the bytes
+in front of you are the bytes the holder of that key signed. It does not prove
+the records were true when they were written. The key lives in the same
+database as the records, so a platform administrator who can forge a record
+can also sign the forgery. The value is for evidence that has already left:
+a bundle a customer downloaded last year can be checked today by someone who
+does not trust the platform's copy of it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models.models.account_signing_key import (
+    KEY_ID_PREFIX,
+    SIGNING_ALGORITHM_ED25519,
+    AccountSigningKey,
+)
+from preloop.utils.encryption import decrypt_value, encrypt_value
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_SCHEMA = "preloop.signature/v1"
+SIGNATURE_DOMAIN = b"preloop.signature/v1\n"
+
+#: Payload types. The type is inside the signed bytes, so one of these
+#: signatures can never be presented as another.
+PAYLOAD_PERIOD_EXPORT = "preloop.retention.period_export_manifest/v1"
+PAYLOAD_EVIDENCE_PACK = "preloop.cra.evidence_manifest/v1"
+PAYLOAD_AUDIT_CHECKPOINT = "preloop.audit.chain_checkpoint/v1"
+
+#: Name of the signature member inside a period export archive. It is not in
+#: the manifest's ``members`` list, and cannot be: it covers the manifest.
+SIGNATURE_MEMBER_NAME = "signature.json"
+
+
+class SigningError(RuntimeError):
+    """Signing was asked for and could not be done."""
+
+
+@dataclass(frozen=True)
+class KeyMaterial:
+    """A usable key pair, decrypted, with the row it came from."""
+
+    key_id: str
+    algorithm: str
+    public_key: str
+    private_key: Ed25519PrivateKey
+    record: AccountSigningKey
+
+
+def new_key_id() -> str:
+    """Return a fresh public key identifier."""
+    return f"{KEY_ID_PREFIX}{secrets.token_hex(8)}"
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _unb64(value: str) -> bytes:
+    return base64.b64decode(value.encode("ascii"), validate=True)
+
+
+def public_key_from_b64(value: str) -> Ed25519PublicKey:
+    """Load a public key from its base64 raw form."""
+    return Ed25519PublicKey.from_public_bytes(_unb64(value))
+
+
+def digest_of(payload: Any) -> str:
+    """Digest a manifest (or any JSON value) the way this product does.
+
+    ``canonical_manifest_json`` is the evidence pack serialisation from #511,
+    reused so the product has one canonical form rather than a second one
+    invented for signing.
+    """
+    return hashlib.sha256(canonical_manifest_json(payload)).hexdigest()
+
+
+def signed_bytes(*, payload_type: str, digest: str, signed_at: str) -> bytes:
+    """Return the exact bytes signed. Shipped so verifiers can copy it."""
+    return (
+        SIGNATURE_DOMAIN
+        + payload_type.encode("utf-8")
+        + b"\n"
+        + digest.encode("ascii")
+        + b"\n"
+        + signed_at.encode("ascii")
+    )
+
+
+def format_signed_at(value: Optional[datetime] = None) -> str:
+    """The one spelling of a signing time, second resolution, always UTC.
+
+    Public because it is part of the wire format: a verifier rebuilding the
+    signed bytes has to produce this string exactly, and a naive datetime
+    read back from a column has to land on the same value as the aware one
+    that was signed.
+    """
+    stamp = value or datetime.now(UTC)
+    if getattr(stamp, "tzinfo", None) is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return stamp.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_active_key(db: Session, *, account_id: Any) -> Optional[AccountSigningKey]:
+    """Return the account's active signing key, or None when it has none."""
+    return db.execute(
+        select(AccountSigningKey).where(
+            AccountSigningKey.account_id == account_id,
+            AccountSigningKey.retired_at.is_(None),
+        )
+    ).scalar_one_or_none()
+
+
+def list_keys(db: Session, *, account_id: Any) -> list[AccountSigningKey]:
+    """Every key this account has held, newest first. Public parts only."""
+    return list(
+        db.execute(
+            select(AccountSigningKey)
+            .where(AccountSigningKey.account_id == account_id)
+            .order_by(AccountSigningKey.created_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+
+
+def get_key_by_id(
+    db: Session, *, account_id: Any, key_id: str
+) -> Optional[AccountSigningKey]:
+    """Look one key up by its public identifier, inside the account."""
+    return db.execute(
+        select(AccountSigningKey).where(
+            AccountSigningKey.account_id == account_id,
+            AccountSigningKey.key_id == key_id,
+        )
+    ).scalar_one_or_none()
+
+
+def create_key(
+    db: Session,
+    *,
+    account_id: Any,
+    user_id: Optional[Any] = None,
+    commit: bool = True,
+) -> AccountSigningKey:
+    """Mint a signing key for an account that has none.
+
+    The caller is responsible for having retired any previous active key; the
+    partial unique index refuses a second active key rather than trusting that.
+    """
+    private = Ed25519PrivateKey.generate()
+    raw_private = private.private_bytes_raw()
+    raw_public = private.public_key().public_bytes_raw()
+    record = AccountSigningKey(
+        account_id=account_id,
+        key_id=new_key_id(),
+        algorithm=SIGNING_ALGORITHM_ED25519,
+        public_key=_b64(raw_public),
+        private_key_encrypted=encrypt_value(_b64(raw_private)),
+        rotated_by_user_id=user_id,
+    )
+    db.add(record)
+    if commit:
+        db.commit()
+        db.refresh(record)
+    else:
+        db.flush()
+    return record
+
+
+def ensure_key(
+    db: Session, *, account_id: Any, commit: bool = True
+) -> Optional[AccountSigningKey]:
+    """Return the active key, minting one on first use.
+
+    Returns None rather than raising when minting fails. Signing is an
+    addition to an export, never a precondition for it: a customer asking for
+    their compliance period must still get it if key generation broke.
+    """
+    existing = get_active_key(db, account_id=account_id)
+    if existing is not None:
+        return existing
+    try:
+        return create_key(db, account_id=account_id, commit=commit)
+    except Exception:
+        db.rollback()
+        logger.error("Failed to mint an account signing key", exc_info=True)
+        return get_active_key(db, account_id=account_id)
+
+
+def rotate_key(
+    db: Session,
+    *,
+    account_id: Any,
+    user_id: Optional[Any] = None,
+    now: Optional[datetime] = None,
+    commit: bool = True,
+) -> tuple[Optional[AccountSigningKey], AccountSigningKey]:
+    """Retire the active key, if any, and mint its replacement.
+
+    Returns ``(retired, active)``. The retired key keeps its public half, so
+    every signature it ever made still verifies. Rotation that invalidated
+    past signatures would be revocation of the customer's own evidence.
+    """
+    retired = get_active_key(db, account_id=account_id)
+    if retired is not None:
+        retired.retired_at = now or datetime.now(UTC)
+        retired.rotated_by_user_id = user_id or retired.rotated_by_user_id
+        db.add(retired)
+        db.flush()
+    created = create_key(db, account_id=account_id, user_id=user_id, commit=False)
+    if commit:
+        db.commit()
+        db.refresh(created)
+        if retired is not None:
+            db.refresh(retired)
+    return retired, created
+
+
+def load_material(record: AccountSigningKey) -> KeyMaterial:
+    """Decrypt one key row into usable material."""
+    try:
+        raw = _unb64(decrypt_value(record.private_key_encrypted))
+    except Exception as exc:
+        raise SigningError(
+            f"signing key {record.key_id} cannot be decrypted with the "
+            "configured encryption key"
+        ) from exc
+    return KeyMaterial(
+        key_id=record.key_id,
+        algorithm=record.algorithm,
+        public_key=record.public_key,
+        private_key=Ed25519PrivateKey.from_private_bytes(raw),
+        record=record,
+    )
+
+
+def sign_digest(
+    material: KeyMaterial,
+    *,
+    payload_type: str,
+    digest: str,
+    signed_at: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Return a detached signature document over one digest."""
+    stamp = format_signed_at(signed_at)
+    signature = material.private_key.sign(
+        signed_bytes(payload_type=payload_type, digest=digest, signed_at=stamp)
+    )
+    return {
+        "schema": SIGNATURE_SCHEMA,
+        "algorithm": material.algorithm,
+        "key_id": material.key_id,
+        "payload_type": payload_type,
+        "digest": digest,
+        "signed_at": stamp,
+        "signature": _b64(signature),
+        "note": (
+            "Detached Ed25519 signature over the digest above, which is the "
+            "sha256 of the canonical JSON of the named payload. It proves "
+            "these bytes are the bytes this key signed. It does not prove "
+            "the records were true when they were written."
+        ),
+    }
+
+
+def sign_manifest(
+    db: Session,
+    *,
+    account_id: Any,
+    payload_type: str,
+    manifest: Any,
+    signed_at: Optional[datetime] = None,
+    commit: bool = True,
+) -> Optional[dict[str, Any]]:
+    """Sign a manifest for an account, minting a key on first use.
+
+    Returns None when the account has no usable key and one could not be
+    made. Callers degrade to an unsigned export rather than failing it.
+    """
+    record = ensure_key(db, account_id=account_id, commit=commit)
+    if record is None:
+        return None
+    try:
+        material = load_material(record)
+    except SigningError:
+        logger.error("Signing key is unusable; serving unsigned", exc_info=True)
+        return None
+    return sign_digest(
+        material,
+        payload_type=payload_type,
+        digest=digest_of(manifest),
+        signed_at=signed_at,
+    )
+
+
+def verify_signature_document(
+    document: Any,
+    *,
+    public_key: str,
+    payload_type: Optional[str] = None,
+    digest: Optional[str] = None,
+) -> bool:
+    """Verify a detached signature document against a public key.
+
+    Shipped in the product so the documented verification steps are the code
+    the tests exercise, the same reason #504 shipped its webhook verifier.
+
+    Args:
+        document: The parsed signature document.
+        public_key: Base64 raw Ed25519 public key to check against.
+        payload_type: Required payload type, when the caller knows it.
+        digest: Digest the caller computed itself, when it has the payload.
+
+    Returns:
+        True only when the signature verifies and every stated expectation
+        holds.
+    """
+    if not isinstance(document, dict):
+        return False
+    if document.get("algorithm") != SIGNING_ALGORITHM_ED25519:
+        return False
+    claimed_type = document.get("payload_type")
+    claimed_digest = document.get("digest")
+    stamp = document.get("signed_at")
+    raw_signature = document.get("signature")
+    if not (
+        isinstance(claimed_type, str)
+        and isinstance(claimed_digest, str)
+        and isinstance(stamp, str)
+        and isinstance(raw_signature, str)
+    ):
+        return False
+    if payload_type is not None and claimed_type != payload_type:
+        return False
+    if digest is not None and claimed_digest != digest:
+        return False
+    try:
+        key = public_key_from_b64(public_key)
+        key.verify(
+            _unb64(raw_signature),
+            signed_bytes(
+                payload_type=claimed_type, digest=claimed_digest, signed_at=stamp
+            ),
+        )
+    except (InvalidSignature, ValueError, TypeError, base64.binascii.Error):
+        return False
+    return True
+
+
+def public_key_summary(record: AccountSigningKey) -> dict[str, Any]:
+    """The public view of one key. Never includes private material."""
+    return {
+        "key_id": record.key_id,
+        "algorithm": record.algorithm,
+        "public_key": record.public_key,
+        "active": record.retired_at is None,
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+        "retired_at": record.retired_at.isoformat() if record.retired_at else None,
+    }

--- a/backend/preloop/services/record_signing.py
+++ b/backend/preloop/services/record_signing.py
@@ -217,15 +217,23 @@ def ensure_key(
 
     Returns None rather than raising when minting fails. Signing is an
     addition to an export, never a precondition for it: a customer asking for
-    their compliance period must still get it if key generation broke.
+    their compliance period must still get it if key generation broke. A mint
+    failure is contained in a savepoint so the caller's in-flight work stays.
     """
     existing = get_active_key(db, account_id=account_id)
     if existing is not None:
         return existing
     try:
-        return create_key(db, account_id=account_id, commit=commit)
+        # Savepoint, not session.rollback(): this function does not own the
+        # caller's transaction. A mint failure must not undo sealed rows or
+        # a chain-head update already flushed in this session.
+        with db.begin_nested():
+            record = create_key(db, account_id=account_id, commit=False)
+        if commit:
+            db.commit()
+            db.refresh(record)
+        return record
     except Exception:
-        db.rollback()
         logger.error("Failed to mint an account signing key", exc_info=True)
         return get_active_key(db, account_id=account_id)
 
@@ -313,12 +321,16 @@ def sign_manifest(
     payload_type: str,
     manifest: Any,
     signed_at: Optional[datetime] = None,
-    commit: bool = True,
+    commit: bool = False,
 ) -> Optional[dict[str, Any]]:
     """Sign a manifest for an account, minting a key on first use.
 
     Returns None when the account has no usable key and one could not be
     made. Callers degrade to an unsigned export rather than failing it.
+
+    ``commit`` defaults to False: this helper does not own the caller's
+    transaction. Commit at the request or operation boundary. Pass
+    ``commit=True`` only when this call *is* that boundary.
     """
     record = ensure_key(db, account_id=account_id, commit=commit)
     if record is None:
@@ -530,9 +542,14 @@ def sign_evidence_pack(
     archive_sha256: str,
     size_bytes: Optional[int] = None,
     created_at: Optional[datetime] = None,
-    commit: bool = True,
+    commit: bool = False,
 ) -> Optional[dict[str, Any]]:
-    """Sign one evidence pack at mint time. Never raises at the caller."""
+    """Sign one evidence pack at mint time. Never raises at the caller.
+
+    ``commit`` defaults to False so a mint-time signature stays in the
+    caller's transaction. Pass ``commit=True`` when this call is the
+    operation boundary (for example after another helper already committed).
+    """
     payload = evidence_pack_payload(
         account_id=account_id,
         artifact_id=artifact_id,

--- a/backend/preloop/services/record_signing.py
+++ b/backend/preloop/services/record_signing.py
@@ -52,6 +52,10 @@ from preloop.models.models.account_signing_key import (
     SIGNING_ALGORITHM_ED25519,
     AccountSigningKey,
 )
+from preloop.models.models.record_signature import (
+    SUBJECT_EVIDENCE_PACK,
+    RecordSignature,
+)
 from preloop.utils.encryption import decrypt_value, encrypt_value
 
 logger = logging.getLogger(__name__)
@@ -396,3 +400,166 @@ def public_key_summary(record: AccountSigningKey) -> dict[str, Any]:
         "created_at": record.created_at.isoformat() if record.created_at else None,
         "retired_at": record.retired_at.isoformat() if record.retired_at else None,
     }
+
+
+def evidence_pack_payload(
+    *,
+    account_id: Any,
+    artifact_id: Any,
+    execution_id: Any,
+    archive_sha256: str,
+    size_bytes: Optional[int],
+    created_at: Optional[datetime],
+) -> dict[str, Any]:
+    """The payload signed for one evidence pack.
+
+    Small and self-contained on purpose. A verifier holding the downloaded
+    archive can rebuild every field here: sha256 the bytes, compare, then
+    check the signature over the canonical JSON of this object. Signing the
+    stored artifact manifest instead would have made verification depend on
+    fields the downloader never receives.
+    """
+    return {
+        "schema": PAYLOAD_EVIDENCE_PACK,
+        "account_id": str(account_id),
+        "artifact_id": str(artifact_id),
+        "execution_id": str(execution_id) if execution_id is not None else None,
+        "archive_sha256": archive_sha256,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+        "created_at": format_signed_at(created_at) if created_at else None,
+    }
+
+
+def get_record_signature(
+    db: Session, *, account_id: Any, payload_type: str, subject_id: Any
+) -> Optional[RecordSignature]:
+    """Look up the stored signature for one record, or None."""
+    return db.execute(
+        select(RecordSignature).where(
+            RecordSignature.account_id == account_id,
+            RecordSignature.payload_type == payload_type,
+            RecordSignature.subject_id == str(subject_id),
+        )
+    ).scalar_one_or_none()
+
+
+def record_signature_document(record: RecordSignature) -> dict[str, Any]:
+    """Render a stored signature as the same document a bundle carries."""
+    return {
+        "schema": SIGNATURE_SCHEMA,
+        "algorithm": record.algorithm,
+        "key_id": record.signing_key_id,
+        "payload_type": record.payload_type,
+        "digest": record.digest,
+        "signed_at": format_signed_at(record.signed_at),
+        "signature": record.signature,
+        "payload": record.payload,
+    }
+
+
+def sign_record(
+    db: Session,
+    *,
+    account_id: Any,
+    payload_type: str,
+    subject_type: str,
+    subject_id: Any,
+    payload: Any,
+    signed_at: Optional[datetime] = None,
+    commit: bool = True,
+) -> Optional[dict[str, Any]]:
+    """Sign a payload and store the signature beside the record it covers.
+
+    Idempotent by subject: an existing signature is returned unchanged rather
+    than replaced, because the records this is used for are immutable and a
+    second signature over the same bytes would only invite the question of
+    which one is real. Returns None when the account has no usable key, since
+    signing is an addition to a record and never a precondition for storing
+    it.
+    """
+    existing = get_record_signature(
+        db, account_id=account_id, payload_type=payload_type, subject_id=subject_id
+    )
+    if existing is not None:
+        return record_signature_document(existing)
+    key = ensure_key(db, account_id=account_id, commit=commit)
+    if key is None:
+        return None
+    try:
+        material = load_material(key)
+    except SigningError:
+        logger.error("Signing key is unusable; storing no signature", exc_info=True)
+        return None
+    document = sign_digest(
+        material,
+        payload_type=payload_type,
+        digest=digest_of(payload),
+        signed_at=signed_at,
+    )
+    stamp = datetime.strptime(document["signed_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=UTC
+    )
+    record = RecordSignature(
+        account_id=account_id,
+        payload_type=payload_type,
+        subject_type=subject_type,
+        subject_id=str(subject_id),
+        payload=payload,
+        digest=document["digest"],
+        algorithm=document["algorithm"],
+        signing_key_id=document["key_id"],
+        signature=document["signature"],
+        signed_at=stamp,
+    )
+    db.add(record)
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+    out = dict(document)
+    out["payload"] = payload
+    return out
+
+
+def sign_evidence_pack(
+    db: Session,
+    *,
+    account_id: Any,
+    artifact_id: Any,
+    execution_id: Any,
+    archive_sha256: str,
+    size_bytes: Optional[int] = None,
+    created_at: Optional[datetime] = None,
+    commit: bool = True,
+) -> Optional[dict[str, Any]]:
+    """Sign one evidence pack at mint time. Never raises at the caller."""
+    payload = evidence_pack_payload(
+        account_id=account_id,
+        artifact_id=artifact_id,
+        execution_id=execution_id,
+        archive_sha256=archive_sha256,
+        size_bytes=size_bytes,
+        created_at=created_at,
+    )
+    try:
+        # Inside a savepoint, so a signing failure rolls back the signature
+        # and nothing else. A plain rollback here would undo the caller's
+        # work, and an evidence pack that stored but did not sign is worth
+        # far more than an upload that failed: the bytes cannot be captured
+        # again after the run has finished.
+        with db.begin_nested():
+            document = sign_record(
+                db,
+                account_id=account_id,
+                payload_type=PAYLOAD_EVIDENCE_PACK,
+                subject_type=SUBJECT_EVIDENCE_PACK,
+                subject_id=artifact_id,
+                payload=payload,
+                commit=False,
+            )
+        if commit:
+            db.commit()
+        return document
+    except Exception:
+        logger.error("Failed to sign evidence pack %s", artifact_id, exc_info=True)
+        return None

--- a/backend/preloop/services/retention_export.py
+++ b/backend/preloop/services/retention_export.py
@@ -1,0 +1,406 @@
+"""Period export: audit rows, approvals and evidence receipts as one archive.
+
+The purpose is narrow and worth stating. Retention plus a purge means records
+eventually go. A customer whose obligation outlives our retention, or who
+simply wants their compliance evidence somewhere we cannot reach, needs to be
+able to take the period away with them and prove later that what they kept is
+what they were given. That is the whole feature: a tar with the rows, a
+manifest that names and digests every member, and a digest over the manifest's
+member list.
+
+The manifest deliberately reuses the shape #511 gave evidence packs
+(:func:`preloop.cra.evidence_pack.build_pack_manifest`): same ``members``
+entries, same ``members_digest`` computed over the same canonical JSON. Two
+manifest formats for the same idea would be one format too many, and #558
+(signed exports and the audit hash chain) then has one thing to sign.
+
+What this is not: it is not signed, and the digests prove that the archive was
+not altered after we built it, not that the rows were true when they were
+written. #558 is the issue for provenance. Saying so here is cheaper than
+having someone infer it.
+
+Bounded on purpose: ``RETENTION_EXPORT_MAX_ROWS`` per record class, and going
+over is an error telling the caller to narrow the period. A compliance export
+that silently drops the rows past a limit is worse than no export.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import tarfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Iterable, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models.crud import crud_audit_log
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.legal_hold import LegalHold
+from preloop.services.legal_hold import hold_summary
+from preloop.services.retention_policy import RECORD_CLASSES, resolve_retention
+
+logger = logging.getLogger(__name__)
+
+EXPORT_MANIFEST_SCHEMA = "preloop.retention.period_export_manifest/v1"
+EXPORT_MANIFEST_NAME = "manifest.json"
+
+MEMBER_AUDIT = "audit/audit_log.jsonl"
+MEMBER_APPROVALS = "approvals/approval_request.jsonl"
+MEMBER_EVIDENCE = "evidence/receipts.jsonl"
+MEMBER_HOLDS = "holds/legal_hold.jsonl"
+
+AUDIT_ACTION_EXPORT = "retention_period_export"
+
+
+class PeriodExportError(ValueError):
+    """The requested period cannot be exported as asked."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class PeriodExport:
+    """One built archive and the manifest that describes it."""
+
+    archive: bytes
+    manifest: dict[str, Any]
+    counts: dict[str, int]
+
+    @property
+    def sha256(self) -> str:
+        """Digest of the archive bytes as served."""
+        return hashlib.sha256(self.archive).hexdigest()
+
+    @property
+    def filename(self) -> str:
+        """Stable, sortable download name."""
+        period = self.manifest.get("period") or {}
+        start = str(period.get("start") or "")[:10]
+        end = str(period.get("end") or "")[:10]
+        return f"preloop-period-export-{start}-to-{end}.tar.gz"
+
+
+def _iso(value: Any) -> Optional[str]:
+    """ISO 8601 for a datetime, passthrough for anything already a string."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _max_rows() -> int:
+    return max(1, int(settings.retention_export_max_rows))
+
+
+def _fetch(db: Session, stmt) -> list[Any]:
+    """Read one class, refusing to truncate.
+
+    One extra row is asked for so "exactly at the limit" and "over the limit"
+    are distinguishable without a second COUNT.
+    """
+    limit = _max_rows()
+    rows = list(db.execute(stmt.limit(limit + 1)).scalars().all())
+    if len(rows) > limit:
+        raise PeriodExportError(
+            "period_too_large",
+            f"the period holds more than {limit} rows for one record class; "
+            "narrow the date range and export it in parts",
+        )
+    return rows
+
+
+def _audit_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(AuditLog)
+        .where(
+            AuditLog.account_id == account_id,
+            AuditLog.timestamp >= start,
+            AuditLog.timestamp < end,
+        )
+        .order_by(AuditLog.timestamp, AuditLog.id)
+    )
+    return [
+        {
+            "id": str(row.id),
+            "timestamp": _iso(row.timestamp),
+            "user_id": str(row.user_id) if row.user_id else None,
+            "action": row.action,
+            "resource_type": row.resource_type,
+            "resource_id": row.resource_id,
+            "status": row.status,
+            "ip_address": row.ip_address,
+            "user_agent": row.user_agent,
+            "details": row.details,
+        }
+        for row in _fetch(db, stmt)
+    ]
+
+
+def _approval_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(ApprovalRequest)
+        .where(
+            ApprovalRequest.account_id == account_id,
+            ApprovalRequest.requested_at >= start,
+            ApprovalRequest.requested_at < end,
+        )
+        .order_by(ApprovalRequest.requested_at, ApprovalRequest.id)
+    )
+    rows = []
+    for row in _fetch(db, stmt):
+        rows.append(
+            {
+                "id": str(row.id),
+                "tool_name": row.tool_name,
+                "status": row.status,
+                "summary": row.summary,
+                "requested_at": _iso(row.requested_at),
+                "resolved_at": _iso(row.resolved_at),
+                "expires_at": _iso(row.expires_at),
+                "execution_id": row.execution_id,
+                "managed_agent_id": (
+                    str(row.managed_agent_id) if row.managed_agent_id else None
+                ),
+                "managed_agent_name": row.managed_agent_name,
+                "runtime_session_id": (
+                    str(row.runtime_session_id) if row.runtime_session_id else None
+                ),
+                "api_key_id": str(row.api_key_id) if row.api_key_id else None,
+                "approver_comment": row.approver_comment,
+                "structured_answer": row.structured_answer,
+                "responses": row.responses,
+                "decided_by_ai": bool(row.decided_by_ai),
+                "ai_model": row.ai_model,
+                "ai_reasoning": row.ai_reasoning,
+                "auto_approved_reason": row.auto_approved_reason,
+                "rule_context": row.rule_context,
+                "legal_hold": bool(row.legal_hold),
+                # tool_args and tool_result are deliberately excluded: they
+                # carry the payload of whatever the agent was about to do,
+                # which is the least predictable content in the record and not
+                # what a retention export is for. The decision, the reason it
+                # was asked for, and who decided are.
+            }
+        )
+    return rows
+
+
+def _evidence_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Evidence *receipts*, never the packs.
+
+    A period bundle that inlined evidence payloads would be unbounded and
+    would duplicate bytes the evidence download already serves under its own
+    digest check. The receipt is the durable claim: which pack, what digest,
+    when it expires, whether it is held.
+    """
+    stmt = (
+        select(FlowArtifact)
+        .where(
+            FlowArtifact.account_id == account_id,
+            FlowArtifact.kind == "evidence",
+            FlowArtifact.created_at >= start,
+            FlowArtifact.created_at < end,
+        )
+        .order_by(FlowArtifact.created_at, FlowArtifact.id)
+    )
+    rows = []
+    for row in _fetch(db, stmt):
+        manifest = row.manifest if isinstance(row.manifest, dict) else {}
+        rows.append(
+            {
+                "artifact_id": str(row.id),
+                "execution_id": str(row.execution_id),
+                "flow_id": str(row.flow_id),
+                "thread_id": row.thread_id,
+                "kind": row.kind,
+                "sha256": manifest.get("sha256"),
+                "manifest_sha256": row.manifest_sha256,
+                "size_bytes": manifest.get("size_bytes"),
+                "expanded_bytes": manifest.get("expanded_bytes"),
+                "created_at": _iso(row.created_at),
+                "expires_at": _iso(row.expires_at),
+                "availability": row.availability,
+                "payload_present": row.ciphertext is not None,
+                "legal_hold": bool(row.legal_hold),
+                # object_lock is not in here at all. Preloop does not assert
+                # it, and an absent field is more honest than a false one.
+            }
+        )
+    return rows
+
+
+def _hold_rows(
+    db: Session, *, account_id: Any, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Holds placed in the period, so a frozen record is explained in place."""
+    stmt = (
+        select(LegalHold)
+        .where(
+            LegalHold.account_id == account_id,
+            LegalHold.placed_at >= start,
+            LegalHold.placed_at < end,
+        )
+        .order_by(LegalHold.placed_at, LegalHold.id)
+    )
+    return [hold_summary(row) for row in _fetch(db, stmt)]
+
+
+def _jsonl(rows: Iterable[dict[str, Any]]) -> bytes:
+    """One JSON object per line, sorted keys, so a diff is readable."""
+    buffer = io.BytesIO()
+    for row in rows:
+        buffer.write(
+            json.dumps(row, sort_keys=True, default=str, ensure_ascii=False).encode(
+                "utf-8"
+            )
+        )
+        buffer.write(b"\n")
+    return buffer.getvalue()
+
+
+def _member_entry(name: str, body: bytes) -> dict[str, Any]:
+    return {
+        "name": name,
+        "size_bytes": len(body),
+        "sha256": hashlib.sha256(body).hexdigest(),
+    }
+
+
+def _add(tar: tarfile.TarFile, name: str, body: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(body)
+    info.mode = 0o600
+    # Fixed mtime so the same rows produce the same archive bytes twice.
+    info.mtime = 0
+    tar.addfile(info, io.BytesIO(body))
+
+
+def build_period_export(
+    db: Session,
+    *,
+    account: Any,
+    start: datetime,
+    end: datetime,
+    generated_at: Optional[datetime] = None,
+    record_classes: Sequence[str] = RECORD_CLASSES,
+) -> PeriodExport:
+    """Build the archive for one account and one half-open period.
+
+    ``start`` is inclusive and ``end`` exclusive, so consecutive periods tile
+    without a row landing in both bundles or in neither.
+    """
+    if end <= start:
+        raise PeriodExportError("invalid_period", "end must be after start")
+    account_id = account.id
+    bodies: dict[str, bytes] = {}
+    counts: dict[str, int] = {}
+
+    audit = _audit_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_AUDIT] = _jsonl(audit)
+    counts["audit"] = len(audit)
+
+    approvals = _approval_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_APPROVALS] = _jsonl(approvals)
+    counts["approvals"] = len(approvals)
+
+    evidence = _evidence_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_EVIDENCE] = _jsonl(evidence)
+    counts["evidence"] = len(evidence)
+
+    holds = _hold_rows(db, account_id=account_id, start=start, end=end)
+    bodies[MEMBER_HOLDS] = _jsonl(holds)
+    counts["legal_holds"] = len(holds)
+
+    members = [_member_entry(name, body) for name, body in sorted(bodies.items())]
+    stamp = generated_at or datetime.now(UTC)
+    manifest = {
+        "schema": EXPORT_MANIFEST_SCHEMA,
+        "account_id": str(account_id),
+        "generated_at": stamp.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "period": {
+            "start": start.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "end": end.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "boundary": "start inclusive, end exclusive",
+        },
+        "members": members,
+        # Same computation as the evidence pack manifest, so one verifier
+        # covers both and #558 has one thing to sign.
+        "members_digest": hashlib.sha256(canonical_manifest_json(members)).hexdigest(),
+        "counts": counts,
+        "retention": {
+            record_class: resolve_retention(
+                account.meta_data, record_class=record_class
+            ).days
+            for record_class in record_classes
+        },
+        "note": (
+            "sha256 values cover the members of this archive as packed. This "
+            "bundle is not signed: the digests show the archive was not "
+            "altered after Preloop built it, not that the records were true "
+            "when they were written. Evidence packs are referenced by receipt "
+            "(artifact id and digest), not inlined."
+        ),
+    }
+    manifest_body = canonical_manifest_json(manifest)
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        _add(tar, EXPORT_MANIFEST_NAME, manifest_body)
+        for name, body in sorted(bodies.items()):
+            _add(tar, name, body)
+    return PeriodExport(archive=buffer.getvalue(), manifest=manifest, counts=counts)
+
+
+def audit_period_export(
+    db: Session,
+    *,
+    account_id: Any,
+    user_id: Any,
+    export: PeriodExport,
+) -> None:
+    """Record that the period left the platform, and with what digest.
+
+    An export is a bulk read of an account's compliance record. Who took it,
+    when, for which period, and the digest of what they got are exactly the
+    questions asked afterwards.
+    """
+    period = export.manifest.get("period") or {}
+    try:
+        crud_audit_log.log_action(
+            db,
+            account_id=account_id,
+            user_id=user_id,
+            action=AUDIT_ACTION_EXPORT,
+            resource_type="retention",
+            resource_id="period_export",
+            status="success",
+            details={
+                "period_start": period.get("start"),
+                "period_end": period.get("end"),
+                "counts": export.counts,
+                "archive_sha256": export.sha256,
+                "members_digest": export.manifest.get("members_digest"),
+                "size_bytes": len(export.archive),
+            },
+        )
+    except Exception:
+        db.rollback()
+        logger.error("Failed to audit period export", exc_info=True)

--- a/backend/preloop/services/retention_export.py
+++ b/backend/preloop/services/retention_export.py
@@ -12,12 +12,19 @@ The manifest deliberately reuses the shape #511 gave evidence packs
 (:func:`preloop.cra.evidence_pack.build_pack_manifest`): same ``members``
 entries, same ``members_digest`` computed over the same canonical JSON. Two
 manifest formats for the same idea would be one format too many, and #558
-(signed exports and the audit hash chain) then has one thing to sign.
+signs exactly one thing because of it.
 
-What this is not: it is not signed, and the digests prove that the archive was
-not altered after we built it, not that the rows were true when they were
-written. #558 is the issue for provenance. Saying so here is cheaper than
-having someone infer it.
+Since #558 the archive also carries ``signature.json``, a detached Ed25519
+signature over the sha256 of ``manifest.json`` as packed, made with the
+account's signing key. Verification is: recompute each member's digest,
+recompute ``members_digest`` from the manifest, then check the signature over
+the manifest bytes with the account's published public key.
+
+What this is not: it is not proof that the rows were true when they were
+written. The digests show the archive was not altered after we built it and
+the signature shows we built it, both of which are claims about bytes, not
+about the world. The signing key lives on the same platform that wrote the
+records. Saying so here is cheaper than having someone infer it.
 
 Bounded on purpose: ``RETENTION_EXPORT_MAX_ROWS`` per record class, and going
 over is an error telling the caller to narrow the period. A compliance export
@@ -46,6 +53,11 @@ from preloop.models.models.audit_log import AuditLog
 from preloop.models.models.flow_artifact import FlowArtifact
 from preloop.models.models.legal_hold import LegalHold
 from preloop.services.legal_hold import hold_summary
+from preloop.services.record_signing import (
+    PAYLOAD_PERIOD_EXPORT,
+    SIGNATURE_MEMBER_NAME,
+    sign_manifest,
+)
 from preloop.services.retention_policy import RECORD_CLASSES, resolve_retention
 
 logger = logging.getLogger(__name__)
@@ -76,11 +88,24 @@ class PeriodExport:
     archive: bytes
     manifest: dict[str, Any]
     counts: dict[str, int]
+    #: Detached signature over the manifest digest, or None when the account
+    #: has no usable signing key. An unsigned export is still an export.
+    signature: Optional[dict[str, Any]] = None
 
     @property
     def sha256(self) -> str:
         """Digest of the archive bytes as served."""
         return hashlib.sha256(self.archive).hexdigest()
+
+    @property
+    def manifest_sha256(self) -> str:
+        """Digest of the manifest as packed, which is what gets signed."""
+        return hashlib.sha256(canonical_manifest_json(self.manifest)).hexdigest()
+
+    @property
+    def key_id(self) -> Optional[str]:
+        """Identifier of the key that signed this export, if any."""
+        return (self.signature or {}).get("key_id")
 
     @property
     def filename(self) -> str:
@@ -145,6 +170,12 @@ def _audit_rows(
             "ip_address": row.ip_address,
             "user_agent": row.user_agent,
             "details": row.details,
+            # Chain position travels with the row (#558), so a bundle taken
+            # today can be checked against a checkpoint years later without
+            # asking the platform for anything.
+            "chain_seq": row.chain_seq,
+            "prev_hash": row.prev_hash,
+            "row_hash": row.row_hash,
         }
         for row in _fetch(db, stmt)
     ]
@@ -301,6 +332,7 @@ def build_period_export(
     end: datetime,
     generated_at: Optional[datetime] = None,
     record_classes: Sequence[str] = RECORD_CLASSES,
+    sign: bool = True,
 ) -> PeriodExport:
     """Build the archive for one account and one half-open period.
 
@@ -351,22 +383,51 @@ def build_period_export(
             ).days
             for record_class in record_classes
         },
+        # Named before it exists, and deliberately without the key id: the
+        # signature covers this manifest, so nothing the signature says can
+        # also be asserted here without the two being able to disagree.
+        "signature": {
+            "member": SIGNATURE_MEMBER_NAME,
+            "payload_type": PAYLOAD_PERIOD_EXPORT,
+            "covers": (
+                "sha256 of this file as packed, byte for byte, including this "
+                "declaration"
+            ),
+        },
         "note": (
-            "sha256 values cover the members of this archive as packed. This "
-            "bundle is not signed: the digests show the archive was not "
-            "altered after Preloop built it, not that the records were true "
-            "when they were written. Evidence packs are referenced by receipt "
-            "(artifact id and digest), not inlined."
+            "sha256 values cover the members of this archive as packed. The "
+            "detached signature shows the bundle is the one Preloop built and "
+            "has not been altered since. It does not show the records were "
+            "true when they were written: the signing key lives on the same "
+            "platform that wrote them. Evidence packs are referenced by "
+            "receipt (artifact id and digest), not inlined."
         ),
     }
     manifest_body = canonical_manifest_json(manifest)
+
+    signature: Optional[dict[str, Any]] = None
+    if sign:
+        signature = sign_manifest(
+            db,
+            account_id=account_id,
+            payload_type=PAYLOAD_PERIOD_EXPORT,
+            manifest=manifest,
+            signed_at=stamp,
+        )
 
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
         _add(tar, EXPORT_MANIFEST_NAME, manifest_body)
         for name, body in sorted(bodies.items()):
             _add(tar, name, body)
-    return PeriodExport(archive=buffer.getvalue(), manifest=manifest, counts=counts)
+        if signature is not None:
+            _add(tar, SIGNATURE_MEMBER_NAME, canonical_manifest_json(signature))
+    return PeriodExport(
+        archive=buffer.getvalue(),
+        manifest=manifest,
+        counts=counts,
+        signature=signature,
+    )
 
 
 def audit_period_export(
@@ -398,6 +459,8 @@ def audit_period_export(
                 "counts": export.counts,
                 "archive_sha256": export.sha256,
                 "members_digest": export.manifest.get("members_digest"),
+                "manifest_sha256": export.manifest_sha256,
+                "signing_key_id": export.key_id,
                 "size_bytes": len(export.archive),
             },
         )

--- a/backend/preloop/services/retention_policy.py
+++ b/backend/preloop/services/retention_policy.py
@@ -1,0 +1,256 @@
+"""Per-record-class retention settings for one account.
+
+The reason this module exists is a floor, not a default. AI Act Art. 26(6)
+asks a deployer to keep automatically generated logs for at least six months,
+and DORA asks for record keeping over a comparable horizon. Before this,
+audit rows, approvals, runtime sessions and usage rows had no retention job at
+all (they lived until the account was purged) and evidence packs had a 30 day
+operational window. "Forever" is not a retention policy any more than "30
+days" is: the first is a liability nobody chose and the second is shorter than
+the obligation.
+
+So an account states, per record class, how long it keeps records, and the
+platform refuses to be told anything under six months.
+
+Precedence, most specific first:
+
+1. ``account.meta_data["retention"][<class>]`` when the account sets one
+2. ``settings.retention_default_days`` (365, twelve months)
+
+and the result is clamped up to the effective floor, which is
+``max(ABSOLUTE_FLOOR_DAYS, settings.retention_floor_days)``. The absolute floor
+is a constant here rather than a setting because the regulation is the reason
+it exists; the setting can only make a deployment stricter. This is the
+mirror image of the account cap in
+:mod:`preloop.services.approval_window`, where an account may only tighten a
+ceiling.
+
+What this module does NOT govern: how long the encrypted evidence payload is
+kept. That stays ``FLOW_EVIDENCE_RETENTION_HOURS`` (30 days by default), an
+operational window sized for review, not for archive. The ``evidence`` record
+class here governs the ``flow_artifact`` row, its manifest and its digest.
+Raising the payload window is a separate, deliberate storage decision, and a
+legal hold pins the payload regardless. Said plainly in
+``docs/guide/flows/evidence-storage.md`` rather than left to be discovered.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from preloop.config import settings
+
+logger = logging.getLogger(__name__)
+
+#: Account metadata bucket holding per-class retention, in whole days.
+RETENTION_KEY = "retention"
+
+#: Six months. Not a setting: this is the obligation the floor exists for.
+#: 183 days is the longest six calendar months, so it cannot round short.
+ABSOLUTE_FLOOR_DAYS = 183
+
+#: Twelve months, used when neither the account nor the deployment says more.
+FALLBACK_DEFAULT_DAYS = 365
+
+#: An account that wants to keep records for longer than this should be
+#: exporting them (see the period export), not asking the platform to hold a
+#: growing table forever. Twenty years is past any retention obligation we
+#: have been shown and still finite.
+MAX_RETENTION_DAYS = 7300
+
+#: Audit rows: permission checks, decisions, retention decisions themselves.
+CLASS_AUDIT = "audit"
+#: Approval requests and their events.
+CLASS_APPROVALS = "approvals"
+#: Evidence pack rows (manifest, digest, receipt metadata), not the payload.
+CLASS_EVIDENCE = "evidence"
+#: Runtime sessions and their activity.
+CLASS_RUNTIME_SESSIONS = "runtime_sessions"
+#: API and gateway usage rows.
+CLASS_USAGE = "usage"
+
+RECORD_CLASSES: tuple[str, ...] = (
+    CLASS_AUDIT,
+    CLASS_APPROVALS,
+    CLASS_EVIDENCE,
+    CLASS_RUNTIME_SESSIONS,
+    CLASS_USAGE,
+)
+
+RECORD_CLASS_LABELS: dict[str, str] = {
+    CLASS_AUDIT: "Audit log rows",
+    CLASS_APPROVALS: "Approval requests and their events",
+    CLASS_EVIDENCE: "Evidence pack records (manifest and digest)",
+    CLASS_RUNTIME_SESSIONS: "Runtime sessions and session activity",
+    CLASS_USAGE: "API and gateway usage rows",
+}
+
+
+class RetentionFloorError(ValueError):
+    """Raised when a requested retention is below the effective floor."""
+
+    def __init__(self, record_class: str, requested_days: int, floor_days: int) -> None:
+        super().__init__(
+            f"retention for {record_class!r} must be at least {floor_days} days "
+            f"(six months); {requested_days} was requested"
+        )
+        self.record_class = record_class
+        self.requested_days = requested_days
+        self.floor_days = floor_days
+
+
+@dataclass(frozen=True)
+class RetentionSetting:
+    """The resolved retention for one record class of one account."""
+
+    record_class: str
+    days: int
+    #: ``account`` when the account set it, ``default`` otherwise.
+    source: str
+    #: True when the stored/requested value was raised to meet the floor.
+    floored: bool = False
+
+    def describe(self) -> str:
+        """Operator-facing sentence naming the setting that produced it."""
+        names = {
+            "account": "this account's retention setting",
+            "default": "the deployment default retention",
+        }
+        text = f"{self.days}d ({names.get(self.source, self.source)})"
+        return f"{text}, raised to the floor" if self.floored else text
+
+
+def floor_days() -> int:
+    """Effective floor: the constant, or a stricter deployment setting."""
+    try:
+        configured = int(settings.retention_floor_days)
+    except (TypeError, ValueError):
+        configured = ABSOLUTE_FLOOR_DAYS
+    return max(ABSOLUTE_FLOOR_DAYS, configured)
+
+
+def default_days() -> int:
+    """Deployment default, never below the floor."""
+    try:
+        configured = int(settings.retention_default_days)
+    except (TypeError, ValueError):
+        configured = FALLBACK_DEFAULT_DAYS
+    if configured <= 0:
+        configured = FALLBACK_DEFAULT_DAYS
+    return max(floor_days(), min(MAX_RETENTION_DAYS, configured))
+
+
+def _coerce_days(value: Any) -> Optional[int]:
+    """Positive int or None. A garbage setting must not decide retention."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return None
+    return days if days > 0 else None
+
+
+def normalize_retention_store(meta_data: Optional[Mapping[str, Any]]) -> dict[str, int]:
+    """Read the account bucket, keeping only known classes and sane values.
+
+    Values are returned as stored. Clamping happens in
+    :func:`resolve_retention`, so a caller can still see that a stored value
+    is under the floor (and the API can refuse to write one).
+    """
+    raw = (meta_data or {}).get(RETENTION_KEY)
+    if not isinstance(raw, Mapping):
+        return {}
+    store: dict[str, int] = {}
+    for record_class in RECORD_CLASSES:
+        days = _coerce_days(raw.get(record_class))
+        if days is not None:
+            store[record_class] = min(MAX_RETENTION_DAYS, days)
+    return store
+
+
+def resolve_retention(
+    meta_data: Optional[Mapping[str, Any]], *, record_class: str
+) -> RetentionSetting:
+    """Retention for one class: the account's value, floored, else the default."""
+    if record_class not in RECORD_CLASSES:
+        raise ValueError(f"unknown record class {record_class!r}")
+    minimum = floor_days()
+    stored = normalize_retention_store(meta_data).get(record_class)
+    if stored is None:
+        return RetentionSetting(
+            record_class=record_class, days=default_days(), source="default"
+        )
+    days = max(minimum, stored)
+    if days != stored:
+        # Reachable when the deployment raised its floor after the account
+        # chose, or when a row was written by hand. The floor wins; it is the
+        # only reason this module exists.
+        logger.info(
+            "Retention %sd for %s raised to the %sd floor",
+            stored,
+            record_class,
+            days,
+        )
+    return RetentionSetting(
+        record_class=record_class,
+        days=days,
+        source="account",
+        floored=days != stored,
+    )
+
+
+def resolve_all(meta_data: Optional[Mapping[str, Any]]) -> dict[str, RetentionSetting]:
+    """Resolved retention for every record class."""
+    return {
+        record_class: resolve_retention(meta_data, record_class=record_class)
+        for record_class in RECORD_CLASSES
+    }
+
+
+def validate_retention_request(values: Mapping[str, Any]) -> dict[str, int]:
+    """Sanitize an API payload, refusing anything under the floor.
+
+    A value of ``None`` clears the account's setting for that class (it falls
+    back to the deployment default, which is itself at or above the floor).
+    Unknown classes are refused rather than ignored: silently dropping a key
+    the caller named would let an operator believe they had set something.
+    """
+    minimum = floor_days()
+    cleaned: dict[str, int] = {}
+    for key, value in values.items():
+        if key not in RECORD_CLASSES:
+            raise ValueError(f"unknown record class {key!r}")
+        if value is None:
+            continue
+        days = _coerce_days(value)
+        if days is None:
+            raise ValueError(f"retention for {key!r} must be a positive number of days")
+        if days < minimum:
+            raise RetentionFloorError(key, days, minimum)
+        cleaned[key] = min(MAX_RETENTION_DAYS, days)
+    return cleaned
+
+
+def set_retention(
+    meta_data: Optional[Mapping[str, Any]],
+    *,
+    values: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return account metadata with the retention bucket replaced.
+
+    ``values`` is the full desired state: a class the caller omits or sets to
+    ``None`` goes back to the deployment default. Every other metadata key is
+    left untouched, because this bucket shares ``meta_data`` with subject
+    governance and the approval window cap.
+    """
+    cleaned = validate_retention_request(values)
+    updated = deepcopy(dict(meta_data or {}))
+    if cleaned:
+        updated[RETENTION_KEY] = cleaned
+    else:
+        updated.pop(RETENTION_KEY, None)
+    return updated

--- a/backend/preloop/services/retention_purge.py
+++ b/backend/preloop/services/retention_purge.py
@@ -341,6 +341,7 @@ def purge_class(
             db, account_id=account.id, record_class=record_class, cutoff=cutoff
         )
         return result
+    pruned_seq = 0
     for _ in range(max_batches):
         if deadline is not None and time.monotonic() >= deadline:
             result.more_remaining = True
@@ -361,6 +362,12 @@ def purge_class(
             break
         if record_class == CLASS_EVIDENCE:
             _expire_receipts_for_artifacts(db, account_id=account.id, artifact_ids=ids)
+        if record_class == CLASS_AUDIT:
+            # Read the chain positions before the rows go. Deleting the oldest
+            # sealed rows is this job doing its job, and the chain verifier has
+            # to be told so, or the next verification reports the purge as
+            # tampering (issue #558).
+            pruned_seq = max(pruned_seq, _max_chain_seq(db, ids))
         deleted = db.execute(
             delete(model)
             .where(model.id.in_(ids))
@@ -382,7 +389,41 @@ def purge_class(
         if cleared:
             db.commit()
             result.deleted += cleared
+    if pruned_seq:
+        _raise_chain_floor(db, account_id=account.id, up_to_seq=pruned_seq, now=now)
     return result
+
+
+def _max_chain_seq(db: Session, ids: Sequence[Any]) -> int:
+    """Highest chain position among the audit rows about to be deleted."""
+    value = db.execute(
+        select(func.max(AuditLog.chain_seq)).where(AuditLog.id.in_(ids))
+    ).scalar()
+    return int(value or 0)
+
+
+def _raise_chain_floor(
+    db: Session, *, account_id: Any, up_to_seq: int, now: datetime
+) -> None:
+    """Record the purged prefix on the account's chain state.
+
+    Failure here is logged, not raised: the rows are already gone and the
+    purge succeeded. The cost of the failure is a verification that reports a
+    gap at the bottom of the range until the next purge pass raises the floor.
+    """
+    try:
+        from preloop.services.audit_chain import note_pruned
+
+        note_pruned(db, account_id=account_id, up_to_seq=up_to_seq, now=now)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.error(
+            "Could not raise the audit chain floor for account %s to seq %s",
+            account_id,
+            up_to_seq,
+            exc_info=True,
+        )
 
 
 def purge_account(

--- a/backend/preloop/services/retention_purge.py
+++ b/backend/preloop/services/retention_purge.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session
 
 from preloop.config import settings
 from preloop.models.crud import crud_audit_log
+from preloop.models.crud.legal_hold import execution_in_account
 from preloop.models.db.session import get_db_session
 from preloop.models.models.account import Account
 from preloop.models.models.api_usage import ApiUsage
@@ -267,7 +268,7 @@ def _expire_receipts_for_artifacts(
     rows = (
         db.execute(
             select(FlowExecution).where(
-                FlowExecution.account_id == account_id,
+                execution_in_account(account_id),
                 FlowExecution.id.in_(execution_ids),
             )
         )
@@ -304,7 +305,7 @@ def _drop_legacy_evidence_columns(
     result = db.execute(
         update(FlowExecution)
         .where(
-            FlowExecution.account_id == account_id,
+            execution_in_account(account_id),
             FlowExecution.created_at < cutoff,
             FlowExecution.legal_hold.is_(False),
             FlowExecution.evidence_archive.isnot(None),

--- a/backend/preloop/services/retention_purge.py
+++ b/backend/preloop/services/retention_purge.py
@@ -1,0 +1,584 @@
+"""The scheduled purge that makes a retention setting mean something.
+
+A retention policy nobody enforces is a paragraph in a trust centre. This is
+the job that enforces it, and it is written defensively because it is the only
+code in the product whose purpose is to delete a customer's records.
+
+Four properties it has to have, in order of how much they matter:
+
+**It never touches a held record.** Every statement carries the legal hold
+predicate. A hold that a purge could race past is not a hold.
+
+**It is off by default.** ``RETENTION_PURGE_ENABLED`` is false. An operator
+upgrading to this release does not discover afterwards that a background job
+started deleting audit history. ``RETENTION_PURGE_DRY_RUN`` counts and audits
+what would go without deleting it.
+
+**It is bounded.** Batches of ``RETENTION_PURGE_BATCH_SIZE`` rows, each its
+own transaction, at most ``RETENTION_PURGE_MAX_BATCHES`` per class per
+account per pass, the whole pass under a wall-clock budget, and only inside
+the off-peak UTC window. A backlog is drained across passes. It runs off the
+request path in a background task, the same shape as
+:class:`preloop.services.session_optimization_jobs.OptimizationJobSweeper`.
+
+**It audits itself.** Retention decisions are themselves records: one
+``audit_log`` row per account and record class that actually deleted
+something, with the cutoff, the counts and the setting that produced them.
+
+The record classes and the floor live in
+:mod:`preloop.services.retention_policy`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.models.crud import crud_audit_log
+from preloop.models.db.session import get_db_session
+from preloop.models.models.account import Account
+from preloop.models.models.api_usage import ApiUsage
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.runtime_session import RuntimeSession
+from preloop.services.retention_policy import (
+    CLASS_APPROVALS,
+    CLASS_AUDIT,
+    CLASS_EVIDENCE,
+    CLASS_RUNTIME_SESSIONS,
+    CLASS_USAGE,
+    RECORD_CLASSES,
+    resolve_retention,
+)
+
+logger = logging.getLogger(__name__)
+
+AUDIT_ACTION_PURGE = "retention_purge"
+AUDIT_ACTION_PREVIEW = "retention_purge_preview"
+
+#: Approval requests still waiting on a human are never purged, whatever the
+#: retention says. A parked execution is waiting on that row; deleting it
+#: would strand the run, and a six month old pending approval is a bug to fix
+#: rather than a record to shred.
+_UNRESOLVED_APPROVAL_STATUS = "pending"
+
+
+@dataclass
+class ClassResult:
+    """What the purge did to one record class of one account."""
+
+    record_class: str
+    retention_days: int
+    cutoff: datetime
+    deleted: int = 0
+    batches: int = 0
+    #: True when the class still had matching rows when the pass stopped.
+    more_remaining: bool = False
+
+    def as_details(self) -> dict[str, Any]:
+        """Audit-row shape."""
+        return {
+            "record_class": self.record_class,
+            "retention_days": self.retention_days,
+            "cutoff": self.cutoff.isoformat(),
+            "deleted": self.deleted,
+            "batches": self.batches,
+            "more_remaining": self.more_remaining,
+        }
+
+
+@dataclass
+class PurgeResult:
+    """Totals for one pass across every account it reached."""
+
+    accounts: int = 0
+    deleted: int = 0
+    classes: dict[str, int] = field(default_factory=dict)
+    #: True when the pass ended on its time or batch budget, not on empty.
+    budget_exhausted: bool = False
+    skipped_reason: Optional[str] = None
+
+    def record(self, result: ClassResult) -> None:
+        """Fold one class result into the totals."""
+        self.deleted += result.deleted
+        self.classes[result.record_class] = (
+            self.classes.get(result.record_class, 0) + result.deleted
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Log/telemetry shape."""
+        return {
+            "accounts": self.accounts,
+            "deleted": self.deleted,
+            "classes": dict(self.classes),
+            "budget_exhausted": self.budget_exhausted,
+            "skipped_reason": self.skipped_reason,
+        }
+
+
+def parse_window(raw: Any) -> Optional[tuple[int, int]]:
+    """Parse ``"start-end"`` UTC hours. ``None`` means any hour.
+
+    A malformed window is treated as "any hour" and logged rather than
+    silently pinning the job to a window nobody meant, because the failure
+    mode of the alternative is a purge that never runs and a retention
+    promise that is quietly untrue.
+    """
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        start_text, end_text = text.split("-", 1)
+        start, end = int(start_text), int(end_text)
+    except (ValueError, AttributeError):
+        logger.warning("Ignoring unparseable RETENTION_PURGE_WINDOW_UTC %r", raw)
+        return None
+    if not (0 <= start <= 23 and 0 <= end <= 24) or start == end:
+        logger.warning("Ignoring out-of-range RETENTION_PURGE_WINDOW_UTC %r", raw)
+        return None
+    return start, end
+
+
+def in_window(now: datetime, window: Optional[tuple[int, int]]) -> bool:
+    """True when ``now`` is inside the half-open off-peak window."""
+    if window is None:
+        return True
+    start, end = window
+    hour = now.astimezone(UTC).hour
+    if start < end:
+        return start <= hour < end
+    # Wraps midnight, for example 22-4.
+    return hour >= start or hour < end
+
+
+def _audit_cutoff_filters(cutoff: datetime):
+    return (AuditLog.timestamp < cutoff,)
+
+
+def _approval_cutoff_filters(cutoff: datetime):
+    return (
+        ApprovalRequest.requested_at < cutoff,
+        ApprovalRequest.status != _UNRESOLVED_APPROVAL_STATUS,
+        ApprovalRequest.legal_hold.is_(False),
+    )
+
+
+def _evidence_cutoff_filters(cutoff: datetime):
+    return (
+        FlowArtifact.created_at < cutoff,
+        FlowArtifact.kind == "evidence",
+        FlowArtifact.legal_hold.is_(False),
+    )
+
+
+def _runtime_session_cutoff_filters(cutoff: datetime):
+    # A session that never ended is dated by when it started. Using ended_at
+    # alone would make an abandoned session immortal.
+    return (func.coalesce(RuntimeSession.ended_at, RuntimeSession.started_at) < cutoff,)
+
+
+def _usage_cutoff_filters(cutoff: datetime):
+    return (ApiUsage.timestamp < cutoff,)
+
+
+_CLASS_MODELS: dict[str, Any] = {
+    CLASS_AUDIT: AuditLog,
+    CLASS_APPROVALS: ApprovalRequest,
+    CLASS_EVIDENCE: FlowArtifact,
+    CLASS_RUNTIME_SESSIONS: RuntimeSession,
+    CLASS_USAGE: ApiUsage,
+}
+
+_CLASS_FILTERS = {
+    CLASS_AUDIT: _audit_cutoff_filters,
+    CLASS_APPROVALS: _approval_cutoff_filters,
+    CLASS_EVIDENCE: _evidence_cutoff_filters,
+    CLASS_RUNTIME_SESSIONS: _runtime_session_cutoff_filters,
+    CLASS_USAGE: _usage_cutoff_filters,
+}
+
+
+def _candidate_ids_stmt(
+    record_class: str, *, account_id: Any, cutoff: datetime, limit: int
+):
+    """Ids of the next batch to remove for one class, account scoped."""
+    model = _CLASS_MODELS[record_class]
+    return (
+        select(model.id)
+        .where(model.account_id == account_id, *_CLASS_FILTERS[record_class](cutoff))
+        .order_by(model.id)
+        .limit(limit)
+    )
+
+
+def count_purgeable(
+    db: Session, *, account_id: Any, record_class: str, cutoff: datetime
+) -> int:
+    """How many rows the purge would remove. Used by dry runs and tests."""
+    model = _CLASS_MODELS[record_class]
+    return int(
+        db.execute(
+            select(func.count())
+            .select_from(model)
+            .where(
+                model.account_id == account_id,
+                *_CLASS_FILTERS[record_class](cutoff),
+            )
+        ).scalar_one()
+    )
+
+
+def _expire_receipts_for_artifacts(
+    db: Session, *, account_id: Any, artifact_ids: Sequence[Any]
+) -> int:
+    """Retire the execution receipts that name packs this batch removes.
+
+    ``inspect_evidence`` resolves a terminal receipt through its stored
+    ``artifact_id``. Deleting the row underneath and leaving the receipt as it
+    was would answer ``failed`` / ``artifact_scope_mismatch``, which reads like
+    corruption. It was retention, so the receipt says ``expired`` and carries
+    the reason.
+    """
+    if not artifact_ids:
+        return 0
+    execution_ids = list(
+        db.execute(
+            select(FlowArtifact.execution_id).where(
+                FlowArtifact.id.in_(list(artifact_ids)),
+                FlowArtifact.account_id == account_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not execution_ids:
+        return 0
+    wanted = {str(value) for value in artifact_ids}
+    rows = (
+        db.execute(
+            select(FlowExecution).where(
+                FlowExecution.account_id == account_id,
+                FlowExecution.id.in_(execution_ids),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stamped = 0
+    for execution in rows:
+        receipt = execution.evidence_receipt
+        if not isinstance(receipt, dict):
+            continue
+        if str(receipt.get("artifact_id") or "") not in wanted:
+            continue
+        updated = dict(receipt)
+        updated["status"] = "expired"
+        updated["error"] = "retention_purged"
+        updated["legal_hold"] = False
+        execution.evidence_receipt = updated
+        db.add(execution)
+        stamped += 1
+    return stamped
+
+
+def _drop_legacy_evidence_columns(
+    db: Session, *, account_id: Any, cutoff: datetime
+) -> int:
+    """Clear pre-artifact evidence blobs on executions past the cutoff.
+
+    Legacy captures live in ``flow_execution.evidence_archive`` rather than in
+    a ``flow_artifact`` row, so the evidence class would otherwise purge the
+    modern packs and leave the old bytes forever. Held executions are skipped.
+    The execution row itself stays: it is a run record, not an evidence record.
+    """
+    result = db.execute(
+        update(FlowExecution)
+        .where(
+            FlowExecution.account_id == account_id,
+            FlowExecution.created_at < cutoff,
+            FlowExecution.legal_hold.is_(False),
+            FlowExecution.evidence_archive.isnot(None),
+        )
+        .values(evidence_archive=None)
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def purge_class(
+    db: Session,
+    *,
+    account: Account,
+    record_class: str,
+    now: datetime,
+    batch_size: int,
+    max_batches: int,
+    dry_run: bool,
+    deadline: Optional[float] = None,
+) -> ClassResult:
+    """Delete one record class for one account, in bounded batches."""
+    setting = resolve_retention(account.meta_data, record_class=record_class)
+    cutoff = now - timedelta(days=setting.days)
+    result = ClassResult(
+        record_class=record_class,
+        retention_days=setting.days,
+        cutoff=cutoff,
+    )
+    model = _CLASS_MODELS[record_class]
+    if dry_run:
+        result.deleted = count_purgeable(
+            db, account_id=account.id, record_class=record_class, cutoff=cutoff
+        )
+        return result
+    for _ in range(max_batches):
+        if deadline is not None and time.monotonic() >= deadline:
+            result.more_remaining = True
+            break
+        ids = list(
+            db.execute(
+                _candidate_ids_stmt(
+                    record_class,
+                    account_id=account.id,
+                    cutoff=cutoff,
+                    limit=batch_size,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not ids:
+            break
+        if record_class == CLASS_EVIDENCE:
+            _expire_receipts_for_artifacts(db, account_id=account.id, artifact_ids=ids)
+        deleted = db.execute(
+            delete(model)
+            .where(model.id.in_(ids))
+            .execution_options(synchronize_session=False)
+        )
+        # One transaction per batch. A long-running DELETE over a retention
+        # backlog would hold locks on tables the request path writes to.
+        db.commit()
+        result.deleted += int(deleted.rowcount or 0)
+        result.batches += 1
+        if len(ids) < batch_size:
+            break
+    else:
+        result.more_remaining = True
+    if record_class == CLASS_EVIDENCE:
+        cleared = _drop_legacy_evidence_columns(
+            db, account_id=account.id, cutoff=cutoff
+        )
+        if cleared:
+            db.commit()
+            result.deleted += cleared
+    return result
+
+
+def purge_account(
+    db: Session,
+    *,
+    account: Account,
+    now: datetime,
+    batch_size: int,
+    max_batches: int,
+    dry_run: bool,
+    deadline: Optional[float] = None,
+    record_classes: Sequence[str] = RECORD_CLASSES,
+) -> list[ClassResult]:
+    """Run every record class for one account and audit what was removed."""
+    results: list[ClassResult] = []
+    for record_class in record_classes:
+        try:
+            result = purge_class(
+                db,
+                account=account,
+                record_class=record_class,
+                now=now,
+                batch_size=batch_size,
+                max_batches=max_batches,
+                dry_run=dry_run,
+                deadline=deadline,
+            )
+        except Exception:
+            # One bad class must not stop the others, and must not take the
+            # sweeper down. The failure is loud in the log and the class is
+            # retried on the next pass.
+            db.rollback()
+            logger.error(
+                "Retention purge failed for account %s class %s",
+                account.id,
+                record_class,
+                exc_info=True,
+            )
+            continue
+        results.append(result)
+        if result.deleted:
+            try:
+                crud_audit_log.log_action(
+                    db,
+                    account_id=account.id,
+                    user_id=None,
+                    action=AUDIT_ACTION_PREVIEW if dry_run else AUDIT_ACTION_PURGE,
+                    resource_type="retention",
+                    resource_id=record_class,
+                    status="success",
+                    details=result.as_details(),
+                )
+            except Exception:
+                db.rollback()
+                logger.error(
+                    "Retention purge audit row failed for account %s class %s",
+                    account.id,
+                    record_class,
+                    exc_info=True,
+                )
+    return results
+
+
+def run_retention_purge(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    account_ids: Optional[Sequence[Any]] = None,
+    ignore_window: bool = False,
+    ignore_enabled: bool = False,
+) -> PurgeResult:
+    """One bounded pass over every active account.
+
+    Returns totals rather than raising: the caller is a background loop, and
+    an exception per pass would be noise on top of the per class logging that
+    already happened.
+    """
+    stamp = now or datetime.now(UTC)
+    summary = PurgeResult()
+    if not (ignore_enabled or settings.retention_purge_enabled):
+        summary.skipped_reason = "disabled"
+        return summary
+    window = parse_window(settings.retention_purge_window_utc)
+    if not ignore_window and not in_window(stamp, window):
+        summary.skipped_reason = "outside_window"
+        return summary
+    dry_run = bool(settings.retention_purge_dry_run)
+    batch_size = max(1, int(settings.retention_purge_batch_size))
+    max_batches = max(1, int(settings.retention_purge_max_batches))
+    deadline = time.monotonic() + max(1, int(settings.retention_purge_max_seconds))
+
+    stmt = select(Account).where(Account.is_active.is_(True)).order_by(Account.id)
+    if account_ids:
+        stmt = stmt.where(Account.id.in_(list(account_ids)))
+    accounts = list(db.execute(stmt).scalars().all())
+    for account in accounts:
+        if time.monotonic() >= deadline:
+            summary.budget_exhausted = True
+            break
+        summary.accounts += 1
+        for result in purge_account(
+            db,
+            account=account,
+            now=stamp,
+            batch_size=batch_size,
+            max_batches=max_batches,
+            dry_run=dry_run,
+            deadline=deadline,
+        ):
+            summary.record(result)
+            if result.more_remaining:
+                summary.budget_exhausted = True
+    if summary.deleted:
+        logger.info(
+            "Retention purge pass: %s",
+            summary.as_dict(),
+        )
+    return summary
+
+
+class RetentionPurgeSweeper:
+    """Periodic asyncio purge pass, modeled on the optimization job sweeper.
+
+    Started from the app lifespan on the API role only. The DB work is
+    synchronous CRUD, so each pass runs in a thread and the event loop stays
+    responsive. The pass itself decides whether it is inside the off-peak
+    window, so the interval can stay short without the purge running at noon.
+    """
+
+    def __init__(self, check_interval_seconds: Optional[int] = None) -> None:
+        self.check_interval = int(
+            check_interval_seconds
+            if check_interval_seconds is not None
+            else settings.retention_purge_interval_seconds
+        )
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start the purge background task."""
+        if self._running:
+            logger.warning("Retention purge sweeper is already running")
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._sweep_loop())
+        logger.info(
+            "Retention purge sweeper started (check_interval=%ss, window=%s)",
+            self.check_interval,
+            settings.retention_purge_window_utc or "any",
+        )
+
+    async def stop(self) -> None:
+        """Stop the purge background task."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected when stop() cancels the sweep loop task.
+                pass
+
+    async def _sweep_loop(self) -> None:
+        """Wait one interval first, then purge on every tick.
+
+        Unlike the optimization sweeper this does not run immediately on
+        startup: nothing is being recovered, and a delete pass firing during
+        every deploy would tie data loss to restart timing.
+        """
+        while self._running:
+            try:
+                await asyncio.sleep(self.check_interval)
+            except asyncio.CancelledError:
+                break
+            try:
+                await asyncio.to_thread(self._sweep_once)
+            except Exception:
+                logger.error("Error in retention purge pass", exc_info=True)
+
+    @staticmethod
+    def _sweep_once() -> None:
+        """One synchronous pass with its own session."""
+        db = next(get_db_session())
+        try:
+            run_retention_purge(db)
+        finally:
+            db.close()
+
+
+_sweeper_instance: Optional[RetentionPurgeSweeper] = None
+
+
+def get_retention_purge_sweeper() -> RetentionPurgeSweeper:
+    """Get or create the global retention purge sweeper."""
+    global _sweeper_instance
+    if _sweeper_instance is None:
+        _sweeper_instance = RetentionPurgeSweeper()
+    return _sweeper_instance

--- a/backend/tests/api/test_audit_chain_api.py
+++ b/backend/tests/api/test_audit_chain_api.py
@@ -1,0 +1,312 @@
+"""API surface for the audit chain and the account's signing keys."""
+
+import base64
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+from preloop.services import audit_chain, record_signing
+
+BASE = "/api/v1/audit/chain"
+KEYS = "/api/v1/signing/keys"
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _rows(db_session, account_id, count, *, action="permission_check"):
+    when = datetime(2026, 4, 1, tzinfo=UTC)
+    for index in range(count):
+        db_session.add(
+            AuditLog(
+                account_id=account_id,
+                action=action,
+                resource_type="tool",
+                resource_id=f"r{index}",
+                status="success",
+                timestamp=when + timedelta(seconds=index),
+                details={"index": index},
+            )
+        )
+    db_session.flush()
+
+
+def _seal(db_session, account_id):
+    return audit_chain.seal_account(
+        db_session,
+        account_id=account_id,
+        batch_size=100,
+        max_batches=10,
+        now=datetime.now(UTC) + timedelta(hours=1),
+        lag=timedelta(0),
+    )
+
+
+# --- status ----------------------------------------------------------------
+
+
+def test_status_reports_an_empty_chain_without_inventing_one(client):
+    response = client.get(f"{BASE}/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["head_seq"] == 0
+    assert body["head_hash"] == "0" * 64
+    assert body["latest_checkpoint"] is None
+
+
+def test_status_reports_the_head_after_sealing(client, db_session, account):
+    _rows(db_session, account.id, 3)
+    _seal(db_session, account.id)
+
+    body = client.get(f"{BASE}/status").json()
+
+    assert body["head_seq"] >= 3
+    assert body["head_hash"] != "0" * 64
+    assert body["sealed_rows"] >= 3
+
+
+def test_status_counts_rows_that_are_written_but_not_yet_chained(
+    client, db_session, account
+):
+    _rows(db_session, account.id, 2)
+
+    body = client.get(f"{BASE}/status").json()
+
+    # Honest about the lag rather than implying every row is protected.
+    assert body["unsealed_rows"] >= 2
+    assert body["head_seq"] == 0
+
+
+# --- verification ----------------------------------------------------------
+
+
+def test_verify_walks_the_chain_and_calls_it_ok(client, db_session, account):
+    _rows(db_session, account.id, 5)
+    _seal(db_session, account.id)
+
+    body = client.get(f"{BASE}/verify").json()
+
+    assert body["status"] == "ok"
+    assert body["checked_rows"] >= 5
+    assert body["first_break"] is None
+
+
+def test_verify_finds_an_edited_row_and_names_it(client, db_session, account):
+    _rows(db_session, account.id, 5)
+    _seal(db_session, account.id)
+    victim = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.account_id == account.id, AuditLog.chain_seq == 3)
+        .one()
+    )
+    victim.status = "denied"
+    db_session.add(victim)
+    db_session.flush()
+
+    body = client.get(f"{BASE}/verify").json()
+
+    assert body["status"] == "broken"
+    assert body["first_break"]["kind"] == "row_hash_mismatch"
+    assert body["first_break"]["seq"] == 3
+    assert body["first_break"]["row_id"] == str(victim.id)
+
+
+def test_verify_finds_a_deleted_row(client, db_session, account):
+    _rows(db_session, account.id, 5)
+    _seal(db_session, account.id)
+    db_session.query(AuditLog).filter(
+        AuditLog.account_id == account.id, AuditLog.chain_seq == 2
+    ).delete()
+    db_session.flush()
+
+    body = client.get(f"{BASE}/verify").json()
+
+    assert body["status"] == "broken"
+    assert body["first_break"]["kind"] == "missing_row"
+    assert body["first_break"]["seq"] == 2
+
+
+def test_a_verification_is_itself_audited(client, db_session, account):
+    _rows(db_session, account.id, 2)
+    _seal(db_session, account.id)
+
+    client.get(f"{BASE}/verify")
+
+    row = (
+        db_session.query(AuditLog)
+        .filter(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "audit_chain_verified",
+        )
+        .one()
+    )
+    assert row.details["chain_status"] == "ok"
+
+
+# --- segment ---------------------------------------------------------------
+
+
+def test_the_segment_endpoint_hands_back_material_a_client_can_check(
+    client, db_session, account
+):
+    _rows(db_session, account.id, 4)
+    _seal(db_session, account.id)
+
+    body = client.get(f"{BASE}/segment", params={"limit": 10}).json()
+
+    assert body["genesis_hash"] == "0" * 64
+    assert body["entries"]
+    previous = body["genesis_hash"]
+    for entry in body["entries"]:
+        payload = json.dumps(
+            entry["payload"], sort_keys=True, separators=(",", ":"), default=str
+        ).encode()
+        recomputed = hashlib.sha256(
+            body["row_domain"].encode("utf-8") + payload
+        ).hexdigest()
+        assert entry["prev_hash"] == previous
+        assert recomputed == entry["row_hash"]
+        previous = entry["row_hash"]
+
+
+def test_the_segment_endpoint_pages(client, db_session, account):
+    _rows(db_session, account.id, 6)
+    _seal(db_session, account.id)
+
+    first = client.get(f"{BASE}/segment", params={"limit": 2}).json()
+    assert first["has_more"] is True
+    last_seq = first["entries"][-1]["seq"]
+
+    second = client.get(
+        f"{BASE}/segment", params={"limit": 2, "after_seq": last_seq}
+    ).json()
+
+    assert second["entries"][0]["seq"] == last_seq + 1
+
+
+# --- checkpoints -----------------------------------------------------------
+
+
+def test_checkpoints_are_listed_with_a_verifiable_signature(
+    client, db_session, account, monkeypatch
+):
+    monkeypatch.setattr(
+        "preloop.services.audit_chain.settings.audit_chain_checkpoint_interval", 2
+    )
+    _rows(db_session, account.id, 4)
+    _seal(db_session, account.id)
+
+    body = client.get(f"{BASE}/checkpoints").json()
+
+    assert body
+    checkpoint = body[0]
+    key = record_signing.get_key_by_id(
+        db_session, account_id=account.id, key_id=checkpoint["signing_key_id"]
+    )
+    assert record_signing.verify_signature_document(
+        checkpoint["signature_document"], public_key=key.public_key
+    )
+
+
+# --- keys ------------------------------------------------------------------
+
+
+def test_the_public_key_is_served_and_the_private_one_is_not(
+    client, db_session, account
+):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+    db_session.flush()
+
+    body = client.get(KEYS).json()
+
+    assert body["active_key_id"].startswith("psk_")
+    assert body["signature_schema"] == "preloop.signature/v1"
+    assert body["signed_bytes_format"]
+    key = body["keys"][0]
+    assert len(base64.b64decode(key["public_key"])) == 32
+    assert "private" not in json.dumps(body)
+
+
+def test_rotation_retires_the_old_key_and_keeps_it_listed(client, db_session, account):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+    db_session.flush()
+    before = client.get(KEYS).json()["active_key_id"]
+
+    response = client.post(f"{KEYS}/rotate")
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["retired"]["key_id"] == before
+    assert body["active"]["key_id"] != before
+    listed = client.get(KEYS).json()
+    assert {key["key_id"] for key in listed["keys"]} == {
+        before,
+        body["active"]["key_id"],
+    }
+    assert listed["active_key_id"] == body["active"]["key_id"]
+
+
+def test_the_rotated_key_signs_and_the_published_public_key_verifies(
+    client, db_session, account
+):
+    client.post(f"{KEYS}/rotate")
+    published = client.get(KEYS).json()
+    active = next(key for key in published["keys"] if key["active"])
+
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+
+    Ed25519PublicKey.from_public_bytes(base64.b64decode(active["public_key"])).verify(
+        base64.b64decode(document["signature"]),
+        record_signing.signed_bytes(
+            payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+            digest=document["digest"],
+            signed_at=document["signed_at"],
+        ),
+    )
+
+
+def test_a_rotation_is_audited_with_both_key_ids(client, db_session, account):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+    db_session.flush()
+    before = client.get(KEYS).json()["active_key_id"]
+
+    body = client.post(f"{KEYS}/rotate").json()
+
+    row = (
+        db_session.query(AuditLog)
+        .filter(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "signing_key_rotated",
+        )
+        .one()
+    )
+    assert row.details["retired_key_id"] == before
+    assert row.details["new_key_id"] == body["active"]["key_id"]
+
+
+def test_another_accounts_chain_is_not_visible(client, db_session, account):
+    other = models.Account(organization_name=f"other-{uuid.uuid4().hex[:6]}")
+    db_session.add(other)
+    db_session.flush()
+    _rows(db_session, other.id, 3)
+    _seal(db_session, other.id)
+
+    body = client.get(f"{BASE}/status").json()
+
+    assert body["head_seq"] == 0
+    assert client.get(f"{BASE}/segment").json()["entries"] == []

--- a/backend/tests/api/test_retention_api.py
+++ b/backend/tests/api/test_retention_api.py
@@ -1,0 +1,408 @@
+"""API surface for retention settings, legal holds and the period export."""
+
+import io
+import json
+import tarfile
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+
+BASE = "/api/v1/retention"
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+@pytest.fixture
+def pack(db_session, test_user):
+    """An execution with one evidence pack, so holds have something to hold."""
+    flow = models.Flow(
+        name=f"api-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "e" * 64, "size_bytes": 32},
+        manifest_sha256="f" * 64,
+        ciphertext=b"cipher",
+        expires_at=datetime.now(UTC) + timedelta(days=1),
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- settings --------------------------------------------------------------
+
+
+def test_settings_report_the_floor_and_the_defaults(client):
+    response = client.get(f"{BASE}/settings")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["floor_days"] == 183
+    assert body["default_days"] == 365
+    classes = {item["record_class"]: item for item in body["classes"]}
+    assert set(classes) == {
+        "audit",
+        "approvals",
+        "evidence",
+        "runtime_sessions",
+        "usage",
+    }
+    assert classes["audit"]["days"] == 365
+    assert classes["audit"]["source"] == "default"
+    assert all(item["label"] for item in body["classes"])
+
+
+def test_settings_say_whether_anything_actually_deletes(client, monkeypatch):
+    """Retention nobody enforces is a sentence, and the API admits it."""
+    monkeypatch.setattr(settings, "retention_purge_enabled", False, raising=False)
+
+    body = client.get(f"{BASE}/settings").json()
+
+    assert body["purge_enabled"] is False
+    assert body["evidence_payload_hours"] == settings.flow_evidence_retention_hours
+
+
+def test_a_retention_above_the_floor_is_stored(client, db_session, account):
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    assert response.status_code == 200
+    classes = {item["record_class"]: item for item in response.json()["classes"]}
+    assert classes["audit"]["days"] == 400
+    assert classes["audit"]["source"] == "account"
+    db_session.refresh(account)
+    assert account.meta_data["retention"] == {"audit": 400}
+
+
+def test_a_retention_below_the_floor_is_refused_with_the_floor_named(client):
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": 30}})
+
+    assert response.status_code == 422
+    assert "183" in response.json()["detail"]
+
+
+def test_an_unknown_record_class_is_refused(client):
+    response = client.put(f"{BASE}/settings", json={"classes": {"logs": 400}})
+
+    assert response.status_code == 422
+
+
+def test_updating_retention_leaves_other_account_metadata_alone(
+    client, db_session, account
+):
+    account.meta_data = {"approval_window_max_seconds": 900}
+    db_session.add(account)
+    db_session.flush()
+
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    db_session.refresh(account)
+    assert account.meta_data["approval_window_max_seconds"] == 900
+    assert account.meta_data["retention"] == {"audit": 400}
+
+
+def test_a_retention_change_is_audited_with_the_before_and_after(
+    client, db_session, account, test_user
+):
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_settings_updated",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["changed"]["audit"] == {"from": 365, "to": 400}
+
+
+def test_clearing_a_class_returns_it_to_the_default(client, db_session, account):
+    client.put(f"{BASE}/settings", json={"classes": {"audit": 400}})
+
+    response = client.put(f"{BASE}/settings", json={"classes": {"audit": None}})
+
+    classes = {item["record_class"]: item for item in response.json()["classes"]}
+    assert classes["audit"]["days"] == 365
+    assert classes["audit"]["source"] == "default"
+
+
+# --- purge preview ---------------------------------------------------------
+
+
+def test_purge_preview_counts_without_deleting(client, db_session, account):
+    old = AuditLog(
+        account_id=account.id,
+        action="permission_check",
+        status="success",
+        timestamp=datetime.now(UTC) - timedelta(days=400),
+    )
+    db_session.add(old)
+    db_session.flush()
+
+    body = client.get(f"{BASE}/purge-preview").json()
+
+    audit = next(row for row in body["classes"] if row["record_class"] == "audit")
+    assert audit["purgeable"] >= 1
+    assert audit["retention_days"] == 365
+    assert db_session.get(AuditLog, old.id) is not None
+
+
+# --- holds -----------------------------------------------------------------
+
+
+def test_placing_a_hold_returns_the_record_and_what_it_froze(client, pack):
+    execution, _ = pack
+
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["active"] is True
+    assert body["reason"] == "incident review INC-114"
+    assert body["flagged"]["flow_execution"] == 1
+    assert body["flagged"]["flow_artifact"] == 1
+
+
+def test_a_hold_without_a_real_reason_is_refused(client, pack):
+    execution, _ = pack
+
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "x",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_a_hold_on_an_unknown_record_is_a_404(client):
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(uuid.uuid4()),
+            "reason": "matter 2026-04 discovery",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_a_second_hold_on_the_same_record_is_a_conflict(client, pack):
+    execution, _ = pack
+    payload = {
+        "resource_type": "execution",
+        "resource_id": str(execution.id),
+        "reason": "incident review INC-114",
+    }
+    client.post(f"{BASE}/holds", json=payload)
+
+    response = client.post(f"{BASE}/holds", json=payload)
+
+    assert response.status_code == 409
+
+
+def test_an_unknown_resource_type_is_refused(client, pack):
+    response = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "invoice",
+            "resource_id": str(pack[0].id),
+            "reason": "matter 2026-04 discovery",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_holds_are_listed_and_released(client, pack):
+    execution, _ = pack
+    created = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    ).json()
+
+    listed = client.get(f"{BASE}/holds").json()
+    assert [row["id"] for row in listed] == [created["id"]]
+
+    released = client.post(
+        f"{BASE}/holds/{created['id']}/release",
+        json={"reason": "review closed, nothing found"},
+    )
+    assert released.status_code == 200
+    assert released.json()["active"] is False
+
+    assert client.get(f"{BASE}/holds").json() == []
+    history = client.get(f"{BASE}/holds", params={"active_only": False}).json()
+    assert len(history) == 1
+    assert history[0]["release_reason"] == "review closed, nothing found"
+
+
+def test_releasing_an_unknown_hold_is_a_404(client):
+    response = client.post(
+        f"{BASE}/holds/{uuid.uuid4()}/release",
+        json={"reason": "review closed, nothing found"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_releasing_twice_is_a_conflict(client, pack):
+    execution, _ = pack
+    created = client.post(
+        f"{BASE}/holds",
+        json={
+            "resource_type": "execution",
+            "resource_id": str(execution.id),
+            "reason": "incident review INC-114",
+        },
+    ).json()
+    body = {"reason": "review closed, nothing found"}
+    client.post(f"{BASE}/holds/{created['id']}/release", json=body)
+
+    response = client.post(f"{BASE}/holds/{created['id']}/release", json=body)
+
+    assert response.status_code == 409
+
+
+# --- period export ---------------------------------------------------------
+
+
+def test_the_export_streams_a_tar_with_a_manifest(client, db_session, account):
+    db_session.add(
+        AuditLog(
+            account_id=account.id,
+            action="permission_check",
+            status="success",
+            timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+        )
+    )
+    db_session.flush()
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/gzip"
+    assert (
+        "preloop-period-export-2026-04-01-to-2026-05-01.tar.gz"
+        in (response.headers["content-disposition"])
+    )
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
+        manifest = json.loads(tar.extractfile("manifest.json").read())
+    assert manifest["schema"] == "preloop.retention.period_export_manifest/v1"
+    assert manifest["counts"]["audit"] == 1
+    assert manifest["members_digest"] == response.headers["x-preloop-members-digest"]
+
+
+def test_the_response_carries_the_digest_of_the_bytes_served(client):
+    import hashlib
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.headers["x-preloop-archive-sha256"] == (
+        hashlib.sha256(response.content).hexdigest()
+    )
+
+
+def test_an_export_is_audited(client, db_session, account, test_user):
+    client.post(f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"})
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_period_export",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["period_start"] == "2026-04-01T00:00:00Z"
+    assert row.details["archive_sha256"]
+
+
+def test_an_inverted_period_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-05-01", "end": "2026-04-01"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_a_period_over_a_year_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2024-01-01", "end": "2026-01-01"}
+    )
+
+    assert response.status_code == 400
+    assert "366" in response.json()["detail"]
+
+
+def test_an_unparseable_date_is_refused(client):
+    response = client.post(
+        f"{BASE}/exports", params={"start": "last april", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_a_period_over_the_row_cap_is_refused(client, db_session, account, monkeypatch):
+    monkeypatch.setattr(settings, "retention_export_max_rows", 1, raising=False)
+    for _ in range(2):
+        db_session.add(
+            AuditLog(
+                account_id=account.id,
+                action="permission_check",
+                status="success",
+                timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+            )
+        )
+    db_session.flush()
+
+    response = client.post(
+        f"{BASE}/exports", params={"start": "2026-04-01", "end": "2026-05-01"}
+    )
+
+    assert response.status_code == 413

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -174,4 +174,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert delivery_key.down_revision == "20260908_event_webhooks"
     retention = script.get_revision("20260910_retention_hold")
     assert retention.down_revision == "20260908_webhook_delivery_key"
-    assert script.get_heads() == ["20260910_retention_hold"]
+    audit_chain = script.get_revision("20260910_audit_chain")
+    assert audit_chain.down_revision == "20260910_retention_hold"
+    assert script.get_heads() == ["20260910_audit_chain"]

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -172,4 +172,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert event_webhooks.down_revision == "20260908_approval_park"
     delivery_key = script.get_revision("20260908_webhook_delivery_key")
     assert delivery_key.down_revision == "20260908_event_webhooks"
-    assert script.get_heads() == ["20260908_webhook_delivery_key"]
+    retention = script.get_revision("20260910_retention_hold")
+    assert retention.down_revision == "20260908_webhook_delivery_key"
+    assert script.get_heads() == ["20260910_retention_hold"]

--- a/backend/tests/models/test_audit_chain_migration.py
+++ b/backend/tests/models/test_audit_chain_migration.py
@@ -1,0 +1,179 @@
+"""Run the audit chain migration down and up again on real Postgres.
+
+`test_alembic_single_head.py` only walks the revision graph and the test
+database is built from ORM metadata, so neither one ever executes this DDL.
+This does, inside the test transaction, and then diffs what came back against
+the ORM definitions.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import inspect
+
+from preloop.models.models.account_signing_key import AccountSigningKey
+from preloop.models.models.audit_chain import AuditChainCheckpoint, AuditChainState
+from preloop.models.models.record_signature import RecordSignature
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "preloop"
+    / "models"
+    / "alembic"
+    / "versions"
+    / "20260910_audit_chain_signing.py"
+)
+
+NEW_TABLES = {
+    "audit_chain_state": AuditChainState,
+    "audit_chain_checkpoint": AuditChainCheckpoint,
+    "account_signing_key": AccountSigningKey,
+    "record_signature": RecordSignature,
+}
+
+CHAIN_COLUMNS = {"chain_seq", "prev_hash", "row_hash", "sealed_at"}
+
+
+def _load_migration():
+    """Import the migration module by path (its name starts with digits)."""
+    spec = importlib.util.spec_from_file_location(
+        "audit_chain_signing_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(db_session):
+    """An Alembic operations context bound to the test transaction."""
+    context = MigrationContext.configure(db_session.connection())
+    return Operations.context(context)
+
+
+def _column_names(db_session, table: str) -> set[str]:
+    return {
+        column["name"] for column in inspect(db_session.connection()).get_columns(table)
+    }
+
+
+def test_downgrade_removes_every_table_and_column_it_added(db_session):
+    migration = _load_migration()
+    inspector = inspect(db_session.connection())
+    for table in NEW_TABLES:
+        assert inspector.has_table(table)
+
+    with _operations(db_session):
+        migration.downgrade()
+
+    inspector = inspect(db_session.connection())
+    for table in NEW_TABLES:
+        assert not inspector.has_table(table)
+    assert not CHAIN_COLUMNS & _column_names(db_session, "audit_log")
+
+
+def test_downgrade_leaves_the_audit_rows_themselves_alone(db_session, test_user):
+    """Reversing tamper evidence must not delete the records it covered."""
+    from preloop.models.models.audit_log import AuditLog
+
+    row = AuditLog(
+        account_id=test_user.account_id,
+        action="permission_check",
+        resource_type="tool",
+        resource_id="send_payment",
+        status="success",
+    )
+    db_session.add(row)
+    db_session.flush()
+    row_id = row.id
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+
+    surviving = db_session.connection().exec_driver_sql(
+        "SELECT count(*) FROM audit_log WHERE id = %(id)s", {"id": str(row_id)}
+    )
+    assert surviving.scalar() == 1
+
+
+def test_a_full_cycle_rebuilds_exactly_the_orm_shape(db_session):
+    migration = _load_migration()
+    expected = {
+        table: {column.name for column in model.__table__.columns}
+        for table, model in NEW_TABLES.items()
+    }
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    for table, columns in expected.items():
+        assert _column_names(db_session, table) == columns
+    assert CHAIN_COLUMNS <= _column_names(db_session, "audit_log")
+
+
+def test_the_chain_columns_come_back_nullable(db_session):
+    """Every row written before the chain existed has no position in it."""
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    columns = {
+        column["name"]: column
+        for column in inspect(db_session.connection()).get_columns("audit_log")
+    }
+    for name in CHAIN_COLUMNS:
+        assert columns[name]["nullable"] is True
+
+
+def test_the_upgrade_recreates_the_one_active_key_index(db_session):
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(db_session.connection()).get_indexes("account_signing_key")
+    }
+    active = indexes["uq_account_signing_key_active"]
+    assert active["unique"] is True
+    assert active["column_names"] == ["account_id"]
+    # Partial: rotation must not be blocked by the keys it retired.
+    assert "retired_at IS NULL" in str(active.get("dialect_options", {}))
+
+
+def test_the_upgrade_recreates_the_chain_walk_index(db_session):
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(db_session.connection()).get_indexes("audit_log")
+    }
+    walk = indexes["ix_audit_log_account_chain_seq"]
+    assert walk["column_names"] == ["account_id", "chain_seq"]
+
+
+def test_one_signature_per_record_survives_the_cycle(db_session):
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(db_session.connection()).get_indexes("record_signature")
+    }
+    subject = indexes["uq_record_signature_subject"]
+    assert subject["unique"] is True
+    assert subject["column_names"] == ["account_id", "payload_type", "subject_id"]

--- a/backend/tests/models/test_retention_legal_hold_migration.py
+++ b/backend/tests/models/test_retention_legal_hold_migration.py
@@ -1,0 +1,146 @@
+"""Run the retention migration's downgrade/upgrade cycle on real Postgres.
+
+`test_alembic_single_head.py` only walks the revision graph, and the test
+database is built from ORM metadata, so neither one ever executes this
+migration's DDL. This one does, in the test transaction: down then up, then
+diff the rebuilt table and the added columns against the ORM definition.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import inspect
+
+from preloop.models.models.approval_request import ApprovalRequest
+from preloop.models.models.flow_artifact import FlowArtifact
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.legal_hold import LegalHold
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "preloop"
+    / "models"
+    / "alembic"
+    / "versions"
+    / "20260910_retention_legal_hold.py"
+)
+
+FLAGGED = {
+    "flow_execution": FlowExecution,
+    "approval_request": ApprovalRequest,
+    "flow_artifact": FlowArtifact,
+}
+
+
+def _load_migration():
+    """Import the migration module by path (its name starts with digits)."""
+    spec = importlib.util.spec_from_file_location(
+        "retention_legal_hold_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(db_session):
+    """An Alembic operations context bound to the test transaction."""
+    context = MigrationContext.configure(db_session.connection())
+    return Operations.context(context)
+
+
+def _column_names(db_session, table: str) -> set[str]:
+    return {
+        column["name"] for column in inspect(db_session.connection()).get_columns(table)
+    }
+
+
+def test_downgrade_removes_the_table_and_every_flag(db_session):
+    migration = _load_migration()
+    assert inspect(db_session.connection()).has_table("legal_hold")
+
+    with _operations(db_session):
+        migration.downgrade()
+
+    assert not inspect(db_session.connection()).has_table("legal_hold")
+    for table in FLAGGED:
+        assert "legal_hold" not in _column_names(db_session, table)
+
+
+def test_upgrade_after_downgrade_rebuilds_the_orm_shape(db_session):
+    """A full down/up cycle leaves exactly the columns the ORM expects."""
+    migration = _load_migration()
+    expected = {column.name for column in LegalHold.__table__.columns}
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    assert _column_names(db_session, "legal_hold") == expected
+    for table, model in FLAGGED.items():
+        assert "legal_hold" in _column_names(db_session, table)
+        assert model.__table__.columns["legal_hold"].nullable is False
+
+
+def test_the_flag_defaults_to_false_on_existing_rows(db_session, test_user):
+    """An upgrade must not freeze the records an account already has."""
+    from preloop.models import models
+
+    migration = _load_migration()
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    flow = models.Flow(
+        name="migration-default",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(flow_id=flow.id, status="COMPLETED")
+    db_session.add(execution)
+    db_session.flush()
+
+    assert execution.legal_hold is False
+
+
+def test_upgrade_recreates_the_one_active_hold_per_resource_index(db_session):
+    """The partial unique index is what stops two active holds on one row."""
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(db_session.connection()).get_indexes("legal_hold")
+    }
+    active = indexes["uq_legal_hold_active_resource"]
+    assert active["unique"] is True
+    assert active["column_names"] == ["account_id", "resource_type", "resource_id"]
+    # Partial: a released hold must not block holding the same record again.
+    assert "released_at IS NULL" in str(active.get("dialect_options", {}))
+
+
+def test_upgrade_keeps_the_cascade_that_stops_orphan_holds(db_session):
+    migration = _load_migration()
+
+    with _operations(db_session):
+        migration.downgrade()
+        migration.upgrade()
+
+    rules = {
+        tuple(fk["constrained_columns"]): fk["options"].get("ondelete")
+        for fk in inspect(db_session.connection()).get_foreign_keys("legal_hold")
+    }
+
+    assert rules[("account_id",)] == "CASCADE"
+    # A deleted operator must not take the hold they placed with them: the
+    # record of who froze the data is the point.
+    assert rules[("placed_by_user_id",)] == "SET NULL"
+    assert rules[("released_by_user_id",)] == "SET NULL"

--- a/backend/tests/services/test_audit_chain.py
+++ b/backend/tests/services/test_audit_chain.py
@@ -1,0 +1,360 @@
+"""The audit hash chain: building it, verifying it, and catching a break."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.models.audit_chain import GENESIS_HASH, AuditChainCheckpoint
+from preloop.models.models.audit_log import AuditLog
+from preloop.services import audit_chain, record_signing
+
+NO_LAG = timedelta(0)
+
+
+@pytest.fixture(autouse=True)
+def chain_enabled(monkeypatch):
+    """The sealer is on by default; make the bounds small and deterministic."""
+    monkeypatch.setattr(settings, "audit_chain_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "audit_chain_seal_lag_seconds", 0, raising=False)
+    monkeypatch.setattr(settings, "audit_chain_checkpoint_interval", 5, raising=False)
+
+
+@pytest.fixture
+def account_id(test_user):
+    return test_user.account_id
+
+
+def _rows(db_session, account_id, count, *, start_minutes: int = 600):
+    """Write ``count`` audit rows with strictly increasing timestamps."""
+    base = datetime.now(UTC) - timedelta(minutes=start_minutes)
+    written = []
+    for index in range(count):
+        row = AuditLog(
+            account_id=account_id,
+            action="permission_check",
+            resource_type="tool",
+            resource_id=f"tool-{index}",
+            status="success",
+            details={"index": index, "nested": {"b": 2, "a": 1}},
+            timestamp=base + timedelta(seconds=index),
+        )
+        db_session.add(row)
+        written.append(row)
+    db_session.flush()
+    return written
+
+
+def _seal(db_session, account_id, **kwargs):
+    return audit_chain.seal_account(
+        db_session, account_id=account_id, lag=NO_LAG, **kwargs
+    )
+
+
+def test_sealing_builds_a_chain_from_genesis(db_session, account_id):
+    _rows(db_session, account_id, 4)
+
+    result = _seal(db_session, account_id)
+
+    assert result.sealed == 4
+    sealed = (
+        db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.account_id == account_id)
+            .order_by(AuditLog.chain_seq)
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.chain_seq for row in sealed] == [1, 2, 3, 4]
+    assert sealed[0].prev_hash == GENESIS_HASH
+    for previous, current in zip(sealed, sealed[1:], strict=False):
+        assert current.prev_hash == previous.row_hash
+    assert all(row.sealed_at is not None for row in sealed)
+
+
+def test_row_hash_is_the_documented_computation(db_session, account_id):
+    row = _rows(db_session, account_id, 1)[0]
+
+    _seal(db_session, account_id)
+
+    payload = audit_chain.canonical_row(row, seq=1, prev_hash=GENESIS_HASH)
+    assert row.row_hash == audit_chain.hash_row(payload)
+    # Domain separated: the same canonical JSON hashed without the domain
+    # prefix must not collide with a row hash.
+    import hashlib
+
+    from preloop.cra.evidence_pack import canonical_manifest_json
+
+    assert row.row_hash != hashlib.sha256(canonical_manifest_json(payload)).hexdigest()
+
+
+def test_a_second_pass_continues_where_the_first_stopped(db_session, account_id):
+    _rows(db_session, account_id, 3)
+    _seal(db_session, account_id)
+    _rows(db_session, account_id, 2, start_minutes=300)
+
+    second = _seal(db_session, account_id)
+
+    assert second.sealed == 2
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+    assert report["status"] == audit_chain.STATUS_OK
+    assert report["head_seq"] == 5
+    assert report["checked_rows"] == 5
+
+
+def test_sealing_is_bounded_by_batch_size(db_session, account_id):
+    _rows(db_session, account_id, 7)
+
+    result = _seal(db_session, account_id, batch_size=3, max_batches=1)
+
+    assert result.sealed == 3
+    assert result.more_remaining is True
+    assert (
+        audit_chain.chain_status(db_session, account_id=account_id)["unsealed_rows"]
+        == 4
+    )
+
+
+def test_verify_reports_ok_and_counts_what_it_checked(db_session, account_id):
+    _rows(db_session, account_id, 6)
+    _seal(db_session, account_id)
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_OK
+    assert report["first_break"] is None
+    assert report["checked_rows"] == 6
+    assert report["unsealed_rows"] == 0
+
+
+def test_verify_on_an_empty_chain_is_empty_not_broken(db_session, account_id):
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_EMPTY
+    assert report["first_break"] is None
+
+
+def test_an_edited_row_breaks_at_that_row(db_session, account_id):
+    rows = _rows(db_session, account_id, 5)
+    _seal(db_session, account_id)
+    # The classic tamper: change the outcome of a denied action.
+    rows[2].status = "denied"
+    db_session.add(rows[2])
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_BROKEN
+    assert report["first_break"]["kind"] == audit_chain.BREAK_ROW_HASH
+    assert report["first_break"]["seq"] == 3
+    assert report["first_break"]["row_id"] == str(rows[2].id)
+    # The walk stops at the first break rather than reporting every row after
+    # it as broken too, which is what "first break" means.
+    assert report["checked_rows"] == 2
+
+
+def test_a_deleted_row_breaks_as_a_gap(db_session, account_id):
+    rows = _rows(db_session, account_id, 5)
+    _seal(db_session, account_id)
+    db_session.delete(rows[3])
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_BROKEN
+    assert report["first_break"]["kind"] == audit_chain.BREAK_MISSING_ROW
+    assert report["first_break"]["seq"] == 4
+
+
+def test_a_rewritten_prev_hash_breaks_the_link(db_session, account_id):
+    rows = _rows(db_session, account_id, 4)
+    _seal(db_session, account_id)
+    # Rehash one row consistently with a forged predecessor: the row hashes
+    # to its own stored value, so only the link catches it.
+    forged_prev = "f" * 64
+    rows[2].prev_hash = forged_prev
+    rows[2].row_hash = audit_chain.hash_row(
+        audit_chain.canonical_row(rows[2], seq=3, prev_hash=forged_prev)
+    )
+    db_session.add(rows[2])
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_BROKEN
+    assert report["first_break"]["kind"] == audit_chain.BREAK_PREV_HASH
+    assert report["first_break"]["seq"] == 3
+
+
+def test_rows_deleted_from_the_tail_are_reported(db_session, account_id):
+    rows = _rows(db_session, account_id, 4)
+    _seal(db_session, account_id)
+    db_session.delete(rows[3])
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_BROKEN
+    assert report["first_break"]["kind"] == audit_chain.BREAK_MISSING_ROW
+    assert report["first_break"]["seq"] == 4
+
+
+def test_a_purged_prefix_is_not_a_break(db_session, account_id):
+    rows = _rows(db_session, account_id, 5)
+    _seal(db_session, account_id)
+    for row in rows[:2]:
+        db_session.delete(row)
+    audit_chain.note_pruned(
+        db_session, account_id=account_id, up_to_seq=2, now=datetime.now(UTC)
+    )
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_OK
+    assert report["pruned_below_seq"] == 2
+    assert report["start_seq"] == 3
+    assert report["checked_rows"] == 3
+
+
+def test_checkpoints_are_written_every_n_rows_and_are_signed(db_session, account_id):
+    _rows(db_session, account_id, 11)
+
+    result = _seal(db_session, account_id)
+
+    assert result.checkpoints == 2
+    checkpoints = (
+        db_session.execute(
+            select(AuditChainCheckpoint)
+            .where(AuditChainCheckpoint.account_id == account_id)
+            .order_by(AuditChainCheckpoint.seq)
+        )
+        .scalars()
+        .all()
+    )
+    assert [cp.seq for cp in checkpoints] == [5, 10]
+    key = record_signing.get_active_key(db_session, account_id=account_id)
+    assert key is not None
+    for checkpoint in checkpoints:
+        assert checkpoint.signing_key_id == key.key_id
+        summary = audit_chain.checkpoint_summary(checkpoint)
+        document = {
+            "algorithm": "ed25519",
+            "key_id": checkpoint.signing_key_id,
+            "payload_type": audit_chain.CHECKPOINT_SCHEMA,
+            "digest": summary["digest"],
+            "signed_at": summary["checkpointed_at"],
+            "signature": checkpoint.signature,
+        }
+        assert record_signing.verify_signature_document(
+            document, public_key=key.public_key
+        )
+
+
+def test_a_checkpoint_that_no_longer_matches_the_chain_is_a_break(
+    db_session, account_id
+):
+    _rows(db_session, account_id, 5)
+    _seal(db_session, account_id)
+    checkpoint = db_session.execute(
+        select(AuditChainCheckpoint).where(
+            AuditChainCheckpoint.account_id == account_id
+        )
+    ).scalar_one()
+    checkpoint.chain_hash = "0" * 63 + "1"
+    db_session.add(checkpoint)
+    db_session.flush()
+
+    report = audit_chain.verify_chain(db_session, account_id=account_id)
+
+    assert report["status"] == audit_chain.STATUS_BROKEN
+    assert report["first_break"]["kind"] == "checkpoint_hash_mismatch"
+
+
+def test_the_segment_endpoint_material_recomputes_client_side(db_session, account_id):
+    _rows(db_session, account_id, 3)
+    _seal(db_session, account_id)
+
+    segment = audit_chain.chain_segment(db_session, account_id=account_id)
+
+    assert segment["head_seq"] == 3
+    assert len(segment["entries"]) == 3
+    previous = segment["genesis_hash"]
+    for entry in segment["entries"]:
+        assert entry["prev_hash"] == previous
+        assert audit_chain.hash_row(entry["payload"]) == entry["row_hash"]
+        previous = entry["row_hash"]
+
+
+def test_the_pass_skips_everything_when_the_chain_is_disabled(
+    db_session, account_id, monkeypatch
+):
+    monkeypatch.setattr(settings, "audit_chain_enabled", False, raising=False)
+    _rows(db_session, account_id, 2)
+
+    summary = audit_chain.run_seal_pass(db_session, lag=NO_LAG)
+
+    assert summary.skipped_reason == "disabled"
+    assert summary.sealed == 0
+
+
+def test_the_pass_seals_the_named_account(db_session, account_id):
+    _rows(db_session, account_id, 3)
+
+    summary = audit_chain.run_seal_pass(
+        db_session, account_ids=[account_id], lag=NO_LAG
+    )
+
+    assert summary.sealed == 3
+    assert summary.accounts == 1
+
+
+def test_the_lag_leaves_recent_rows_unsealed(db_session, account_id):
+    _rows(db_session, account_id, 2, start_minutes=0)
+
+    result = audit_chain.seal_account(
+        db_session, account_id=account_id, lag=timedelta(seconds=300)
+    )
+
+    assert result.sealed == 0
+    assert (
+        audit_chain.chain_status(db_session, account_id=account_id)["unsealed_rows"]
+        == 2
+    )
+
+
+def test_status_reports_the_head_and_the_pending_tail(db_session, account_id):
+    _rows(db_session, account_id, 5)
+    _seal(db_session, account_id, batch_size=2, max_batches=1)
+
+    status = audit_chain.chain_status(db_session, account_id=account_id)
+
+    assert status["head_seq"] == 2
+    assert status["sealed_rows"] == 2
+    assert status["unsealed_rows"] == 3
+    assert status["checkpoint_interval"] == 5
+    assert status["head_hash"] != GENESIS_HASH
+
+
+def test_one_account_chain_ignores_another_accounts_rows(db_session, test_user):
+    other = models.Account(organization_name="other-co", is_active=True)
+    db_session.add(other)
+    db_session.flush()
+    _rows(db_session, test_user.account_id, 3)
+    _rows(db_session, other.id, 2)
+
+    _seal(db_session, test_user.account_id)
+
+    assert (
+        audit_chain.chain_status(db_session, account_id=test_user.account_id)[
+            "head_seq"
+        ]
+        == 3
+    )
+    assert audit_chain.chain_status(db_session, account_id=other.id)["head_seq"] == 0
+    assert (
+        audit_chain.chain_status(db_session, account_id=other.id)["unsealed_rows"] == 2
+    )

--- a/backend/tests/services/test_flow_artifacts_db.py
+++ b/backend/tests/services/test_flow_artifacts_db.py
@@ -399,6 +399,66 @@ def test_uploaded_evidence_discoverable_via_execution_apis(
     assert download.headers["x-preloop-evidence-sha256"] == payload["sha256"]
 
 
+def test_an_uploaded_evidence_pack_is_signed_at_capture(
+    db_session, scope, test_user
+) -> None:
+    """The receipt carries a signature a holder of the pack can check (#558)."""
+    import base64
+    import hashlib
+
+    from preloop.api.auth import get_current_active_user
+    from preloop.api.endpoints import flows as flow_endpoints
+    from preloop.services import record_signing
+
+    body = _evidence_body()
+    token = mint_artifact_capability(**scope, kind="evidence", operation="put")
+    app = FastAPI()
+    app.include_router(router)
+    app.include_router(flow_endpoints.router)
+    app.dependency_overrides[get_db_session] = lambda: db_session
+    app.dependency_overrides[get_current_active_user] = lambda: test_user
+    client = TestClient(app)
+    uploaded = client.put(
+        f"/flows/executions/{scope['execution_id']}/artifacts",
+        headers={"Authorization": "Bearer " + token},
+        content=body,
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    reference = uploaded.json()
+    execution = db_session.get(models.FlowExecution, scope["execution_id"])
+    _apply_private_runner_completion(
+        db_session,
+        execution,
+        scope,
+        _private_complete_message("SUCCEEDED", evidence_upload="uploaded"),
+    )
+    db_session.refresh(execution)
+
+    payload = client.get(f"/flows/executions/{execution.id}/evidence-status").json()
+    signature = payload["signature"]
+    assert signature["payload_type"] == record_signing.PAYLOAD_EVIDENCE_PACK
+    assert payload["signing_key_id"] == signature["key_id"]
+
+    # What the signature covers is rebuildable from the bytes you downloaded.
+    download = client.get(f"/flows/executions/{execution.id}/evidence")
+    assert download.headers["x-preloop-signing-key-id"] == signature["key_id"]
+    assert signature["payload"]["archive_sha256"] == (
+        hashlib.sha256(download.content).hexdigest()
+    )
+    assert signature["payload"]["artifact_id"] == str(reference["artifact_id"])
+
+    key = record_signing.get_key_by_id(
+        db_session, account_id=scope["account_id"], key_id=signature["key_id"]
+    )
+    assert record_signing.verify_signature_document(
+        signature,
+        public_key=key.public_key,
+        payload_type=record_signing.PAYLOAD_EVIDENCE_PACK,
+        digest=record_signing.digest_of(signature["payload"]),
+    )
+    assert base64.b64decode(signature["signature"])
+
+
 def _private_complete_message(
     run_status: str, *, evidence_upload: str, result: dict | None = None
 ) -> dict:

--- a/backend/tests/services/test_legal_hold.py
+++ b/backend/tests/services/test_legal_hold.py
@@ -1,0 +1,428 @@
+"""Legal hold: actor, reason, what it freezes and what release restores."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.models import models
+from preloop.models.crud import flow_artifact as crud_artifact
+from preloop.models.models.audit_log import AuditLog
+from preloop.models.models.legal_hold import LegalHold
+from preloop.services.flow_artifacts import evidence_receipt
+from preloop.services.legal_hold import (
+    LegalHoldError,
+    place_hold,
+    release_hold,
+)
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+@pytest.fixture
+def pack(db_session, test_user):
+    """One execution with one evidence pack whose payload expires shortly."""
+    flow = models.Flow(
+        name=f"hold-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "a" * 64, "size_bytes": 12},
+        manifest_sha256="b" * 64,
+        ciphertext=b"cipher",
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+        availability="available",
+    )
+    db_session.add(artifact)
+    execution.evidence_receipt = {
+        "status": "available",
+        "artifact_id": str(artifact.id),
+        "kind": "evidence",
+        "legal_hold": False,
+    }
+    db_session.add(execution)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- the record ------------------------------------------------------------
+
+
+def test_a_hold_records_the_actor_and_the_reason(db_session, test_user, account, pack):
+    execution, _ = pack
+
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    assert outcome.hold.reason == "incident review INC-114"
+    assert outcome.hold.placed_by_user_id == test_user.id
+    assert outcome.hold.active is True
+    assert outcome.flagged["flow_execution"] == 1
+
+
+def test_a_hold_without_a_real_reason_is_refused(db_session, account, pack):
+    execution, _ = pack
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(execution.id),
+            reason="asdf",
+        )
+
+    assert excinfo.value.code == "reason_required"
+
+
+def test_a_hold_on_another_accounts_record_is_refused(db_session, account, pack):
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=uuid.uuid4(),
+            resource_type="execution",
+            resource_id=str(pack[0].id),
+            reason="fishing for someone else's records",
+        )
+
+    assert excinfo.value.code == "resource_not_found"
+
+
+def test_a_hold_on_a_nonexistent_record_is_refused(db_session, account):
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(uuid.uuid4()),
+            reason="matter 2026-04 discovery",
+        )
+
+    assert excinfo.value.code == "resource_not_found"
+
+
+def test_holding_the_same_record_twice_is_refused(db_session, account, pack):
+    execution, _ = pack
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        place_hold(
+            db_session,
+            account_id=account.id,
+            resource_type="execution",
+            resource_id=str(execution.id),
+            reason="incident review INC-114 again",
+        )
+
+    assert excinfo.value.code == "already_held"
+
+
+def test_a_released_record_can_be_held_again(db_session, account, pack):
+    execution, _ = pack
+    first = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=first.hold.id,
+        reason="review closed, nothing found",
+    )
+
+    second = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="reopened as INC-114b",
+    )
+
+    assert second.hold.id != first.hold.id
+    rows = (
+        db_session.execute(select(LegalHold).where(LegalHold.account_id == account.id))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+
+
+# --- what it freezes -------------------------------------------------------
+
+
+def test_a_held_pack_survives_the_janitor(db_session, account, pack):
+    """The whole point: expiry must not take bytes a hold is protecting."""
+    execution, artifact = pack
+    artifact_id = artifact.id
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact_id),
+        reason="regulator request 2026-05",
+    )
+
+    cleared = crud_artifact.cleanup(db_session, now=datetime.now(UTC))
+
+    row = db_session.get(models.FlowArtifact, artifact_id)
+    assert row.ciphertext is not None
+    assert row.availability == "available"
+    assert cleared == 0
+
+
+def test_an_unheld_pack_still_expires(db_session, account, pack):
+    _, artifact = pack
+    artifact_id = artifact.id
+
+    crud_artifact.cleanup(db_session, now=datetime.now(UTC))
+
+    row = db_session.get(models.FlowArtifact, artifact_id)
+    assert row.ciphertext is None
+    assert row.availability == "expired"
+
+
+def test_the_receipt_reports_the_hold(db_session, account, pack):
+    execution, artifact = pack
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+    db_session.refresh(artifact)
+
+    receipt = evidence_receipt(
+        status="available",
+        execution_id=execution.id,
+        transport="direct",
+        artifact=artifact,
+    )
+
+    assert receipt["legal_hold"] is True
+    # Preloop cannot verify a property of the storage layer beneath it.
+    assert receipt["object_lock"] is False
+
+
+def test_the_persisted_receipt_is_stamped_so_polling_agrees(db_session, account, pack):
+    execution, artifact = pack
+
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+
+    db_session.refresh(execution)
+    assert execution.evidence_receipt["legal_hold"] is True
+
+
+def test_an_execution_hold_reaches_its_packs(db_session, account, pack):
+    execution, artifact = pack
+
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    db_session.refresh(artifact)
+    assert artifact.legal_hold is True
+    assert outcome.flagged["flow_artifact"] == 1
+
+
+# --- release ---------------------------------------------------------------
+
+
+def test_release_clears_the_flags_and_keeps_the_record(
+    db_session, test_user, account, pack
+):
+    execution, artifact = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    released = release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+        user_id=test_user.id,
+    )
+
+    db_session.refresh(execution)
+    db_session.refresh(artifact)
+    assert execution.legal_hold is False
+    assert artifact.legal_hold is False
+    assert released.hold.released_at is not None
+    assert released.hold.release_reason == "review closed, nothing found"
+    assert released.hold.reason == "incident review INC-114"
+
+
+def test_overlapping_holds_do_not_cancel_each_other(db_session, account, pack):
+    """A pack under its own hold stays frozen when the execution hold lifts."""
+    execution, artifact = pack
+    execution_hold = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(artifact.id),
+        reason="regulator request 2026-05",
+    )
+
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=execution_hold.hold.id,
+        reason="review closed, the regulator matter is separate",
+    )
+
+    db_session.refresh(artifact)
+    db_session.refresh(execution)
+    assert artifact.legal_hold is True
+    assert execution.legal_hold is False
+
+
+def test_releasing_twice_is_refused(db_session, account, pack):
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        release_hold(
+            db_session,
+            account_id=account.id,
+            hold_id=outcome.hold.id,
+            reason="review closed, nothing found",
+        )
+
+    assert excinfo.value.code == "already_released"
+
+
+def test_releasing_another_accounts_hold_is_refused(db_session, account, pack):
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+    )
+
+    with pytest.raises(LegalHoldError) as excinfo:
+        release_hold(
+            db_session,
+            account_id=uuid.uuid4(),
+            hold_id=outcome.hold.id,
+            reason="lifting somebody else's hold",
+        )
+
+    assert excinfo.value.code == "hold_not_found"
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_placing_and_releasing_are_both_audited(db_session, test_user, account, pack):
+    """A hold that can be lifted without a trace proves nothing."""
+    execution, _ = pack
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="review closed, nothing found",
+        user_id=test_user.id,
+    )
+
+    rows = (
+        db_session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.account_id == account.id,
+                AuditLog.action.in_(["legal_hold_placed", "legal_hold_released"]),
+            )
+            .order_by(AuditLog.timestamp)
+        )
+        .scalars()
+        .all()
+    )
+
+    assert [row.action for row in rows] == [
+        "legal_hold_placed",
+        "legal_hold_released",
+    ]
+    assert all(row.user_id == test_user.id for row in rows)
+    assert rows[0].details["reason"] == "incident review INC-114"
+    assert rows[0].details["hold_id"] == str(outcome.hold.id)
+    assert rows[1].details["placed_reason"] == "incident review INC-114"

--- a/backend/tests/services/test_record_signing.py
+++ b/backend/tests/services/test_record_signing.py
@@ -1,0 +1,396 @@
+"""Signing keys, rotation, and what a signature does and does not verify.
+
+The point of these tests is a verifier that never trusts the code that made
+the signature: every check here rebuilds the signed bytes from the payload and
+checks them against the raw public key with ``cryptography``, not with our own
+helper, wherever the two could hide the same mistake.
+"""
+
+import base64
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+from sqlalchemy.exc import IntegrityError
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models import models
+from preloop.models.models.account_signing_key import AccountSigningKey
+from preloop.services import record_signing
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _raw_verify(public_key_b64: str, signature_b64: str, message: bytes) -> None:
+    """Verify with cryptography directly, not through our own verifier."""
+    key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+    key.verify(base64.b64decode(signature_b64), message)
+
+
+# --- keys ------------------------------------------------------------------
+
+
+def test_a_key_is_minted_on_first_use(db_session, account):
+    assert record_signing.get_active_key(db_session, account_id=account.id) is None
+
+    key = record_signing.ensure_key(db_session, account_id=account.id, commit=False)
+
+    assert key is not None
+    assert key.key_id.startswith("psk_")
+    assert key.algorithm == "ed25519"
+    assert key.active is True
+    assert len(base64.b64decode(key.public_key)) == 32
+
+
+def test_the_private_key_is_not_stored_in_the_clear(db_session, account):
+    key = record_signing.create_key(db_session, account_id=account.id, commit=False)
+
+    material = record_signing.load_material(key)
+    raw_private = material.private_key.private_bytes_raw()
+
+    assert base64.b64encode(raw_private).decode() not in key.private_key_encrypted
+    assert raw_private not in key.private_key_encrypted.encode()
+    # It round trips, so the encryption is real rather than lossy.
+    assert material.private_key.public_key().public_bytes_raw() == base64.b64decode(
+        key.public_key
+    )
+
+
+def test_the_public_summary_never_carries_private_material(db_session, account):
+    key = record_signing.create_key(db_session, account_id=account.id, commit=False)
+
+    summary = record_signing.public_key_summary(key)
+
+    assert set(summary) == {
+        "key_id",
+        "algorithm",
+        "public_key",
+        "active",
+        "created_at",
+        "retired_at",
+    }
+    assert key.private_key_encrypted not in str(summary)
+
+
+def test_only_one_key_is_active_at_a_time(db_session, account):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+
+    # The partial unique index refuses the second one, in the database rather
+    # than in a service check that concurrent callers can race past.
+    with pytest.raises(IntegrityError):
+        record_signing.create_key(db_session, account_id=account.id, commit=False)
+        db_session.flush()
+    db_session.rollback()
+
+
+# --- rotation --------------------------------------------------------------
+
+
+def test_rotation_retires_the_old_key_and_mints_a_new_one(
+    db_session, account, test_user
+):
+    first = record_signing.create_key(db_session, account_id=account.id, commit=False)
+
+    retired, active = record_signing.rotate_key(
+        db_session, account_id=account.id, user_id=test_user.id, commit=False
+    )
+
+    assert retired is not None and retired.key_id == first.key_id
+    assert retired.retired_at is not None
+    assert active.key_id != first.key_id
+    assert active.retired_at is None
+    assert record_signing.get_active_key(db_session, account_id=account.id).key_id == (
+        active.key_id
+    )
+
+
+def test_a_signature_from_a_retired_key_still_verifies(db_session, account):
+    manifest = {"schema": "test", "value": 1}
+    before = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest=manifest,
+        commit=False,
+    )
+    old_key_id = before["key_id"]
+
+    record_signing.rotate_key(db_session, account_id=account.id, commit=False)
+
+    old = record_signing.get_key_by_id(
+        db_session, account_id=account.id, key_id=old_key_id
+    )
+    assert old.retired_at is not None
+    assert record_signing.verify_signature_document(
+        before,
+        public_key=old.public_key,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        digest=record_signing.digest_of(manifest),
+    )
+
+
+def test_the_new_key_cannot_verify_what_the_old_one_signed(db_session, account):
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+
+    _, active = record_signing.rotate_key(
+        db_session, account_id=account.id, commit=False
+    )
+
+    assert not record_signing.verify_signature_document(
+        document, public_key=active.public_key
+    )
+
+
+def test_rotation_is_recorded_against_the_user_who_asked(
+    db_session, account, test_user
+):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+
+    _, active = record_signing.rotate_key(
+        db_session, account_id=account.id, user_id=test_user.id, commit=False
+    )
+
+    assert active.rotated_by_user_id == test_user.id
+
+
+# --- signatures ------------------------------------------------------------
+
+
+def test_the_signature_verifies_against_the_published_public_key(db_session, account):
+    manifest = {"schema": "test", "members": [{"name": "a", "sha256": "00"}]}
+
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest=manifest,
+        commit=False,
+    )
+
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+    message = record_signing.signed_bytes(
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        digest=hashlib.sha256(canonical_manifest_json(manifest)).hexdigest(),
+        signed_at=document["signed_at"],
+    )
+    _raw_verify(key.public_key, document["signature"], message)
+
+
+def test_a_changed_payload_fails_verification(db_session, account):
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test", "value": 1},
+        commit=False,
+    )
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    assert not record_signing.verify_signature_document(
+        document,
+        public_key=key.public_key,
+        digest=record_signing.digest_of({"schema": "test", "value": 2}),
+    )
+
+
+def test_a_signature_cannot_be_replayed_as_another_payload_type(db_session, account):
+    manifest = {"schema": "test"}
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_EVIDENCE_PACK,
+        manifest=manifest,
+        commit=False,
+    )
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    # The claimed type is inside the signed bytes, so relabelling the document
+    # breaks the signature rather than changing what it means.
+    forged = dict(document)
+    forged["payload_type"] = record_signing.PAYLOAD_PERIOD_EXPORT
+    assert not record_signing.verify_signature_document(
+        forged, public_key=key.public_key
+    )
+    with pytest.raises(InvalidSignature):
+        _raw_verify(
+            key.public_key,
+            document["signature"],
+            record_signing.signed_bytes(
+                payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+                digest=document["digest"],
+                signed_at=document["signed_at"],
+            ),
+        )
+
+
+def test_the_signing_time_is_covered_not_merely_claimed(db_session, account):
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    forged = dict(document)
+    forged["signed_at"] = "2020-01-01T00:00:00Z"
+
+    assert not record_signing.verify_signature_document(
+        forged, public_key=key.public_key
+    )
+
+
+def test_another_accounts_key_does_not_verify(db_session, account):
+    other = models.Account(organization_name="other-co")
+    db_session.add(other)
+    db_session.flush()
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+    stranger = record_signing.create_key(db_session, account_id=other.id, commit=False)
+
+    assert not record_signing.verify_signature_document(
+        document, public_key=stranger.public_key
+    )
+
+
+def test_a_garbled_signature_is_refused_rather_than_raising(db_session, account):
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    for bad in ["not base64 at all", "", "AAAA"]:
+        forged = dict(document)
+        forged["signature"] = bad
+        assert not record_signing.verify_signature_document(
+            forged, public_key=key.public_key
+        )
+
+
+def test_an_unusable_key_degrades_to_no_signature(db_session, account, monkeypatch):
+    record_signing.create_key(db_session, account_id=account.id, commit=False)
+    monkeypatch.setattr(
+        record_signing,
+        "decrypt_value",
+        lambda value: (_ for _ in ()).throw(ValueError("wrong key")),
+    )
+
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+        commit=False,
+    )
+
+    assert document is None
+
+
+# --- stored signatures over records ----------------------------------------
+
+
+def test_an_evidence_pack_signature_is_stored_once_and_reused(db_session, account):
+    first = record_signing.sign_evidence_pack(
+        db_session,
+        account_id=account.id,
+        artifact_id="11111111-1111-1111-1111-111111111111",
+        execution_id="22222222-2222-2222-2222-222222222222",
+        archive_sha256="ab" * 32,
+        size_bytes=17,
+        created_at=datetime(2026, 4, 1, tzinfo=UTC),
+        commit=False,
+    )
+
+    second = record_signing.sign_evidence_pack(
+        db_session,
+        account_id=account.id,
+        artifact_id="11111111-1111-1111-1111-111111111111",
+        execution_id="22222222-2222-2222-2222-222222222222",
+        archive_sha256="ab" * 32,
+        size_bytes=17,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+        commit=False,
+    )
+
+    assert first["signature"] == second["signature"]
+    assert first["signed_at"] == second["signed_at"]
+
+
+def test_the_stored_payload_is_what_a_downloader_can_rebuild(db_session, account):
+    document = record_signing.sign_evidence_pack(
+        db_session,
+        account_id=account.id,
+        artifact_id="11111111-1111-1111-1111-111111111111",
+        execution_id="22222222-2222-2222-2222-222222222222",
+        archive_sha256="cd" * 32,
+        size_bytes=99,
+        created_at=datetime(2026, 4, 1, tzinfo=UTC),
+        commit=False,
+    )
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    rebuilt = record_signing.evidence_pack_payload(
+        account_id=account.id,
+        artifact_id="11111111-1111-1111-1111-111111111111",
+        execution_id="22222222-2222-2222-2222-222222222222",
+        archive_sha256="cd" * 32,
+        size_bytes=99,
+        created_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+
+    assert record_signing.digest_of(rebuilt) == document["digest"]
+    _raw_verify(
+        key.public_key,
+        document["signature"],
+        record_signing.signed_bytes(
+            payload_type=record_signing.PAYLOAD_EVIDENCE_PACK,
+            digest=record_signing.digest_of(rebuilt),
+            signed_at=document["signed_at"],
+        ),
+    )
+
+
+def test_signing_failure_leaves_the_callers_work_intact(db_session, account):
+    marker = AccountSigningKey(
+        account_id=account.id,
+        key_id="psk_marker",
+        algorithm="ed25519",
+        public_key="AA",
+        private_key_encrypted="nonsense",
+    )
+    db_session.add(marker)
+    db_session.flush()
+
+    # An unusable key: signing gives up and the caller's row survives.
+    document = record_signing.sign_evidence_pack(
+        db_session,
+        account_id=account.id,
+        artifact_id="33333333-3333-3333-3333-333333333333",
+        execution_id=None,
+        archive_sha256="ef" * 32,
+        commit=False,
+    )
+
+    assert document is None
+    assert db_session.get(AccountSigningKey, marker.id) is not None

--- a/backend/tests/services/test_record_signing.py
+++ b/backend/tests/services/test_record_signing.py
@@ -371,6 +371,55 @@ def test_the_stored_payload_is_what_a_downloader_can_rebuild(db_session, account
     )
 
 
+def test_sign_manifest_does_not_commit_the_callers_session(
+    db_session, account, monkeypatch
+):
+    committed: list[bool] = []
+    real_commit = db_session.commit
+
+    def capture_commit() -> None:
+        committed.append(True)
+        real_commit()
+
+    monkeypatch.setattr(db_session, "commit", capture_commit)
+
+    document = record_signing.sign_manifest(
+        db_session,
+        account_id=account.id,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        manifest={"schema": "test"},
+    )
+
+    assert document is not None
+    assert committed == []
+
+
+def test_ensure_key_failure_does_not_roll_back_the_caller(
+    db_session, account, monkeypatch
+):
+    marker = AccountSigningKey(
+        account_id=account.id,
+        key_id="psk_marker_retired",
+        algorithm="ed25519",
+        public_key="AA",
+        private_key_encrypted="nonsense",
+        retired_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    db_session.add(marker)
+    db_session.flush()
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("mint failed")
+
+    monkeypatch.setattr(record_signing, "create_key", boom)
+
+    assert (
+        record_signing.ensure_key(db_session, account_id=account.id, commit=False)
+        is None
+    )
+    assert db_session.get(AccountSigningKey, marker.id) is not None
+
+
 def test_signing_failure_leaves_the_callers_work_intact(db_session, account):
     marker = AccountSigningKey(
         account_id=account.id,

--- a/backend/tests/services/test_retention_export.py
+++ b/backend/tests/services/test_retention_export.py
@@ -1,0 +1,427 @@
+"""Period export: manifest shape, digests, boundaries and the row cap."""
+
+import hashlib
+import io
+import json
+import tarfile
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from preloop.config import settings
+from preloop.cra.evidence_pack import canonical_manifest_json
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+from preloop.services.legal_hold import place_hold
+from preloop.services.retention_export import (
+    EXPORT_MANIFEST_SCHEMA,
+    MEMBER_APPROVALS,
+    MEMBER_AUDIT,
+    MEMBER_EVIDENCE,
+    MEMBER_HOLDS,
+    PeriodExportError,
+    audit_period_export,
+    build_period_export,
+)
+
+PERIOD_START = datetime(2026, 4, 1, tzinfo=UTC)
+PERIOD_END = datetime(2026, 5, 1, tzinfo=UTC)
+INSIDE = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _audit_row(db_session, account_id, when, action="permission_check"):
+    row = AuditLog(
+        account_id=account_id,
+        action=action,
+        resource_type="tool",
+        resource_id="send_payment",
+        status="success",
+        timestamp=when,
+        details={"decision": "allow"},
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _approval(db_session, test_user, when, *, status="approved"):
+    workflow = models.ApprovalWorkflow(
+        account_id=test_user.account_id,
+        name=f"wf-{uuid.uuid4().hex[:8]}",
+        approval_type="manual",
+        channel="email",
+    )
+    db_session.add(workflow)
+    db_session.flush()
+    config = models.ToolConfiguration(
+        account_id=test_user.account_id,
+        tool_name="send_payment",
+        tool_source="mcp",
+        approval_workflow_id=workflow.id,
+        is_enabled=True,
+        custom_config={},
+    )
+    db_session.add(config)
+    db_session.flush()
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="send_payment",
+        tool_args={"amount": 1000, "iban": "secret account number"},
+        summary="Pay invoice 12",
+        status=status,
+        requested_at=when.replace(tzinfo=None),
+    )
+    db_session.add(request)
+    db_session.flush()
+    return request
+
+
+def _evidence(db_session, test_user, when):
+    flow = models.Flow(
+        name=f"flow-{uuid.uuid4().hex[:8]}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "c" * 64, "size_bytes": 4096},
+        manifest_sha256="d" * 64,
+        ciphertext=b"cipher-bytes-nobody-should-see",
+        expires_at=when + timedelta(days=30),
+        created_at=when,
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+def _members(archive: bytes) -> dict[str, bytes]:
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        return {
+            member.name: tar.extractfile(member).read() for member in tar.getmembers()
+        }
+
+
+def _manifest(archive: bytes) -> dict:
+    return json.loads(_members(archive)["manifest.json"])
+
+
+# --- shape -----------------------------------------------------------------
+
+
+def test_the_archive_carries_a_manifest_and_one_file_per_class(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    _approval(db_session, test_user, INSIDE)
+    _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    names = set(_members(export.archive))
+    assert names == {
+        "manifest.json",
+        MEMBER_AUDIT,
+        MEMBER_APPROVALS,
+        MEMBER_EVIDENCE,
+        MEMBER_HOLDS,
+    }
+
+
+def test_the_manifest_digests_every_member(db_session, test_user, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    members = _members(export.archive)
+    manifest = _manifest(export.archive)
+    assert manifest["schema"] == EXPORT_MANIFEST_SCHEMA
+    for entry in manifest["members"]:
+        body = members[entry["name"]]
+        assert entry["size_bytes"] == len(body)
+        assert entry["sha256"] == hashlib.sha256(body).hexdigest()
+
+
+def test_the_members_digest_is_computed_the_way_evidence_packs_do_it(
+    db_session, test_user, account
+):
+    """#511's shape, so one verifier covers both and #558 signs one format."""
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    manifest = _manifest(export.archive)
+    expected = hashlib.sha256(canonical_manifest_json(manifest["members"])).hexdigest()
+    assert manifest["members_digest"] == expected
+
+
+def test_tampering_with_a_member_breaks_its_digest(db_session, test_user, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+    manifest = _manifest(export.archive)
+    entry = next(m for m in manifest["members"] if m["name"] == MEMBER_AUDIT)
+
+    altered = _members(export.archive)[MEMBER_AUDIT].replace(b"allow", b"deny_")
+
+    assert hashlib.sha256(altered).hexdigest() != entry["sha256"]
+
+
+def test_the_manifest_says_plainly_that_it_is_not_signed(
+    db_session, test_user, account
+):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert "not signed" in _manifest(export.archive)["note"]
+
+
+def test_the_manifest_records_the_retention_in_force(db_session, account):
+    account.meta_data = {"retention": {"audit": 400}}
+    db_session.add(account)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert _manifest(export.archive)["retention"]["audit"] == 400
+
+
+def test_the_same_rows_produce_the_same_archive_bytes(db_session, account):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    stamp = datetime(2026, 5, 2, 9, 0, tzinfo=UTC)
+
+    first = build_period_export(
+        db_session,
+        account=account,
+        start=PERIOD_START,
+        end=PERIOD_END,
+        generated_at=stamp,
+    )
+    second = build_period_export(
+        db_session,
+        account=account,
+        start=PERIOD_START,
+        end=PERIOD_END,
+        generated_at=stamp,
+    )
+
+    assert first.sha256 == second.sha256
+
+
+# --- contents --------------------------------------------------------------
+
+
+def test_only_rows_inside_the_period_are_exported(db_session, account):
+    _audit_row(db_session, account.id, PERIOD_START - timedelta(seconds=1), "before")
+    _audit_row(db_session, account.id, PERIOD_START, "at_start")
+    _audit_row(db_session, account.id, PERIOD_END, "at_end")
+    _audit_row(db_session, account.id, INSIDE, "inside")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_AUDIT].decode()
+    actions = {json.loads(line)["action"] for line in body.splitlines()}
+    # Start inclusive, end exclusive, so consecutive periods tile exactly.
+    assert actions == {"at_start", "inside"}
+
+
+def test_another_accounts_rows_are_never_exported(db_session, account):
+    from preloop.models.crud import crud_account
+
+    other = crud_account.create(
+        db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+    )
+    _audit_row(db_session, other.id, INSIDE, "theirs")
+    _audit_row(db_session, account.id, INSIDE, "ours")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_AUDIT].decode()
+    assert "theirs" not in body
+    assert "ours" in body
+
+
+def test_evidence_is_exported_by_receipt_not_by_payload(db_session, test_user, account):
+    """Inlining packs would be unbounded and would duplicate the download."""
+    execution, artifact = _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert b"cipher-bytes-nobody-should-see" not in export.archive
+    row = json.loads(_members(export.archive)[MEMBER_EVIDENCE].decode().strip())
+    assert row["artifact_id"] == str(artifact.id)
+    assert row["sha256"] == "c" * 64
+    assert row["payload_present"] is True
+    assert "object_lock" not in row
+
+
+def test_approval_tool_arguments_stay_out_of_the_export(db_session, test_user, account):
+    _approval(db_session, test_user, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    body = _members(export.archive)[MEMBER_APPROVALS].decode()
+    assert "secret account number" not in body
+    assert json.loads(body.strip())["summary"] == "Pay invoice 12"
+
+
+def test_holds_placed_in_the_period_explain_a_frozen_record(
+    db_session, test_user, account
+):
+    execution, _ = _evidence(db_session, test_user, INSIDE)
+    db_session.flush()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        now=INSIDE,
+        user_id=test_user.id,
+    )
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    row = json.loads(_members(export.archive)[MEMBER_HOLDS].decode().strip())
+    assert row["reason"] == "incident review INC-114"
+    assert row["active"] is True
+
+
+def test_an_empty_period_is_an_archive_not_an_error(db_session, account):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert export.counts == {
+        "audit": 0,
+        "approvals": 0,
+        "evidence": 0,
+        "legal_holds": 0,
+    }
+    assert _members(export.archive)[MEMBER_AUDIT] == b""
+
+
+# --- bounds ----------------------------------------------------------------
+
+
+def test_a_period_over_the_row_cap_is_refused_not_truncated(
+    db_session, account, monkeypatch
+):
+    """A silently short compliance export is worse than no export."""
+    monkeypatch.setattr(settings, "retention_export_max_rows", 2, raising=False)
+    for index in range(3):
+        _audit_row(db_session, account.id, INSIDE, f"row-{index}")
+    db_session.flush()
+
+    with pytest.raises(PeriodExportError) as excinfo:
+        build_period_export(
+            db_session, account=account, start=PERIOD_START, end=PERIOD_END
+        )
+
+    assert excinfo.value.code == "period_too_large"
+    assert "narrow" in str(excinfo.value)
+
+
+def test_exactly_at_the_cap_still_exports(db_session, account, monkeypatch):
+    monkeypatch.setattr(settings, "retention_export_max_rows", 2, raising=False)
+    for index in range(2):
+        _audit_row(db_session, account.id, INSIDE, f"row-{index}")
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    assert export.counts["audit"] == 2
+
+
+def test_an_inverted_period_is_refused(db_session, account):
+    with pytest.raises(PeriodExportError) as excinfo:
+        build_period_export(
+            db_session, account=account, start=PERIOD_END, end=PERIOD_START
+        )
+
+    assert excinfo.value.code == "invalid_period"
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_the_export_is_audited_with_the_digest_of_what_was_taken(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    audit_period_export(
+        db_session, account_id=account.id, user_id=test_user.id, export=export
+    )
+
+    from sqlalchemy import select
+
+    row = db_session.execute(
+        select(AuditLog).where(
+            AuditLog.account_id == account.id,
+            AuditLog.action == "retention_period_export",
+        )
+    ).scalar_one()
+    assert row.user_id == test_user.id
+    assert row.details["archive_sha256"] == export.sha256
+    assert row.details["period_start"] == "2026-04-01T00:00:00Z"
+    assert row.details["counts"]["audit"] == 1

--- a/backend/tests/services/test_retention_export.py
+++ b/backend/tests/services/test_retention_export.py
@@ -13,6 +13,7 @@ from preloop.config import settings
 from preloop.cra.evidence_pack import canonical_manifest_json
 from preloop.models import models
 from preloop.models.models.audit_log import AuditLog
+from preloop.services import record_signing
 from preloop.services.legal_hold import place_hold
 from preloop.services.retention_export import (
     EXPORT_MANIFEST_SCHEMA,
@@ -148,6 +149,7 @@ def test_the_archive_carries_a_manifest_and_one_file_per_class(
     names = set(_members(export.archive))
     assert names == {
         "manifest.json",
+        "signature.json",
         MEMBER_AUDIT,
         MEMBER_APPROVALS,
         MEMBER_EVIDENCE,
@@ -202,14 +204,16 @@ def test_tampering_with_a_member_breaks_its_digest(db_session, test_user, accoun
     assert hashlib.sha256(altered).hexdigest() != entry["sha256"]
 
 
-def test_the_manifest_says_plainly_that_it_is_not_signed(
+def test_the_manifest_says_plainly_what_the_signature_does_not_prove(
     db_session, test_user, account
 ):
     export = build_period_export(
         db_session, account=account, start=PERIOD_START, end=PERIOD_END
     )
 
-    assert "not signed" in _manifest(export.archive)["note"]
+    note = _manifest(export.archive)["note"]
+    assert "not show the records were true when they were written" in note
+    assert "same platform that wrote them" in note
 
 
 def test_the_manifest_records_the_retention_in_force(db_session, account):
@@ -425,3 +429,142 @@ def test_the_export_is_audited_with_the_digest_of_what_was_taken(
     assert row.details["archive_sha256"] == export.sha256
     assert row.details["period_start"] == "2026-04-01T00:00:00Z"
     assert row.details["counts"]["audit"] == 1
+
+
+# --- signature -------------------------------------------------------------
+
+
+def test_the_archive_carries_a_detached_signature_over_the_manifest(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    members = _members(export.archive)
+    document = json.loads(members["signature.json"])
+    manifest_bytes = members["manifest.json"]
+
+    assert document["payload_type"] == record_signing.PAYLOAD_PERIOD_EXPORT
+    assert document["digest"] == hashlib.sha256(manifest_bytes).hexdigest()
+    assert document["digest"] == export.manifest_sha256
+
+
+def test_the_signature_verifies_against_the_accounts_public_key(
+    db_session, test_user, account
+):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+    document = json.loads(_members(export.archive)["signature.json"])
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    # The verification a customer performs: digest the manifest bytes you
+    # hold, then check the signature over that digest with the public key.
+    digest = hashlib.sha256(_members(export.archive)["manifest.json"]).hexdigest()
+    verified = record_signing.verify_signature_document(
+        document,
+        public_key=key.public_key,
+        payload_type=record_signing.PAYLOAD_PERIOD_EXPORT,
+        digest=digest,
+    )
+
+    assert verified is True
+    assert document["key_id"] == key.key_id
+
+
+def test_editing_a_row_after_the_fact_breaks_the_signature(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, INSIDE)
+    db_session.flush()
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+    document = json.loads(_members(export.archive)["signature.json"])
+    key = record_signing.get_active_key(db_session, account_id=account.id)
+
+    # Rewrite one member and rebuild the manifest around it, the way an
+    # attacker with the archive but not the key would have to.
+    manifest = json.loads(_members(export.archive)["manifest.json"])
+    altered = _members(export.archive)[MEMBER_AUDIT].replace(b"allow", b"deny_")
+    for member in manifest["members"]:
+        if member["name"] == MEMBER_AUDIT:
+            member["sha256"] = hashlib.sha256(altered).hexdigest()
+    manifest["members_digest"] = hashlib.sha256(
+        canonical_manifest_json(manifest["members"])
+    ).hexdigest()
+    forged_digest = hashlib.sha256(canonical_manifest_json(manifest)).hexdigest()
+
+    assert not record_signing.verify_signature_document(
+        document, public_key=key.public_key, digest=forged_digest
+    )
+
+
+def test_the_signature_member_is_not_listed_among_the_members(
+    db_session, test_user, account
+):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    manifest = _manifest(export.archive)
+
+    # It cannot be: the signature covers the manifest that would have to list
+    # it. The manifest declares the member name instead.
+    assert "signature.json" not in {m["name"] for m in manifest["members"]}
+    assert manifest["signature"]["member"] == "signature.json"
+
+
+def test_the_exported_audit_rows_carry_their_chain_position(
+    db_session, test_user, account
+):
+    row = _audit_row(db_session, account.id, INSIDE)
+    row.chain_seq = 7
+    row.prev_hash = "aa" * 32
+    row.row_hash = "bb" * 32
+    db_session.add(row)
+    db_session.flush()
+
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    exported = json.loads(_members(export.archive)[MEMBER_AUDIT].splitlines()[0])
+    assert exported["chain_seq"] == 7
+    assert exported["prev_hash"] == "aa" * 32
+    assert exported["row_hash"] == "bb" * 32
+
+
+def test_an_unsigned_export_is_still_an_export(db_session, test_user, account):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END, sign=False
+    )
+
+    assert export.signature is None
+    assert "signature.json" not in _members(export.archive)
+    assert _manifest(export.archive)["members_digest"]
+
+
+def test_the_audit_row_names_the_key_that_signed_the_export(
+    db_session, test_user, account
+):
+    export = build_period_export(
+        db_session, account=account, start=PERIOD_START, end=PERIOD_END
+    )
+
+    audit_period_export(
+        db_session, account_id=account.id, user_id=test_user.id, export=export
+    )
+
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.action == "retention_period_export")
+        .order_by(AuditLog.timestamp.desc())
+        .first()
+    )
+    assert row.details["signing_key_id"] == export.key_id
+    assert row.details["manifest_sha256"] == export.manifest_sha256

--- a/backend/tests/services/test_retention_policy.py
+++ b/backend/tests/services/test_retention_policy.py
@@ -1,0 +1,118 @@
+"""The six month floor, and what a stored value under it resolves to."""
+
+import pytest
+
+from preloop.config import settings
+from preloop.services import retention_policy as policy
+
+
+def test_default_is_twelve_months_when_the_account_says_nothing():
+    resolved = policy.resolve_retention({}, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 365
+    assert resolved.source == "default"
+    assert resolved.floored is False
+
+
+def test_every_record_class_resolves():
+    resolved = policy.resolve_all(None)
+
+    assert set(resolved) == set(policy.RECORD_CLASSES)
+    assert all(
+        setting.days >= policy.ABSOLUTE_FLOOR_DAYS for setting in resolved.values()
+    )
+
+
+def test_account_value_above_the_floor_is_used_as_written():
+    meta = {"retention": {"audit": 800}}
+
+    resolved = policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 800
+    assert resolved.source == "account"
+    assert resolved.floored is False
+
+
+def test_a_write_below_the_floor_is_refused():
+    with pytest.raises(policy.RetentionFloorError) as excinfo:
+        policy.validate_retention_request({"audit": 30})
+
+    assert excinfo.value.floor_days == 183
+    assert excinfo.value.requested_days == 30
+    assert "183" in str(excinfo.value)
+
+
+def test_the_floor_is_exactly_six_months_and_inclusive():
+    assert policy.validate_retention_request({"audit": 183}) == {"audit": 183}
+    with pytest.raises(policy.RetentionFloorError):
+        policy.validate_retention_request({"audit": 182})
+
+
+def test_a_stored_value_under_the_floor_still_resolves_to_the_floor():
+    """A hand-edited row, or a deployment that raised its floor afterwards.
+
+    The floor is the reason this module exists, so it wins at read time too,
+    not only at write time.
+    """
+    meta = {"retention": {"audit": 10}}
+
+    resolved = policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT)
+
+    assert resolved.days == 183
+    assert resolved.floored is True
+
+
+def test_a_deployment_may_raise_the_floor_but_not_lower_it(monkeypatch):
+    monkeypatch.setattr(settings, "retention_floor_days", 400, raising=False)
+    assert policy.floor_days() == 400
+    with pytest.raises(policy.RetentionFloorError):
+        policy.validate_retention_request({"audit": 200})
+
+    monkeypatch.setattr(settings, "retention_floor_days", 10, raising=False)
+    assert policy.floor_days() == policy.ABSOLUTE_FLOOR_DAYS
+
+
+def test_a_default_below_the_floor_is_raised_to_it(monkeypatch):
+    monkeypatch.setattr(settings, "retention_default_days", 30, raising=False)
+
+    assert policy.default_days() == policy.ABSOLUTE_FLOOR_DAYS
+
+
+def test_an_unknown_record_class_is_refused_not_ignored():
+    with pytest.raises(ValueError, match="unknown record class"):
+        policy.validate_retention_request({"logs": 400})
+    with pytest.raises(ValueError, match="unknown record class"):
+        policy.resolve_retention({}, record_class="logs")
+
+
+def test_garbage_in_the_bucket_does_not_decide_retention():
+    meta = {"retention": {"audit": "soon", "usage": -5, "approvals": True}}
+
+    assert policy.normalize_retention_store(meta) == {}
+    assert policy.resolve_retention(meta, record_class=policy.CLASS_AUDIT).days == 365
+
+
+def test_set_retention_leaves_the_rest_of_account_metadata_alone():
+    meta = {"approval_window_max_seconds": 900, "retention": {"audit": 400}}
+
+    updated = policy.set_retention(meta, values={"usage": 200})
+
+    assert updated["approval_window_max_seconds"] == 900
+    assert updated["retention"] == {"usage": 200}
+    # The input is not mutated: callers hold the account's live dict.
+    assert meta["retention"] == {"audit": 400}
+
+
+def test_clearing_every_class_removes_the_bucket():
+    meta = {"retention": {"audit": 400}, "other": 1}
+
+    updated = policy.set_retention(meta, values={"audit": None})
+
+    assert "retention" not in updated
+    assert updated["other"] == 1
+
+
+def test_retention_is_capped_so_a_table_is_not_kept_forever():
+    cleaned = policy.validate_retention_request({"audit": 99999})
+
+    assert cleaned["audit"] == policy.MAX_RETENTION_DAYS

--- a/backend/tests/services/test_retention_purge.py
+++ b/backend/tests/services/test_retention_purge.py
@@ -1,0 +1,473 @@
+"""The purge: bounds, holds, audit rows and the off-peak window."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.models.audit_log import AuditLog
+from preloop.services import retention_purge as purge
+from preloop.services.legal_hold import place_hold
+from preloop.services.retention_policy import CLASS_AUDIT
+
+
+@pytest.fixture(autouse=True)
+def enabled_purge(monkeypatch):
+    """Tests exercise the job itself; the deployment default is off."""
+    monkeypatch.setattr(settings, "retention_purge_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_dry_run", False, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_window_utc", "", raising=False)
+
+
+def _exists(db_session, model, identifier) -> bool:
+    """Row presence read fresh.
+
+    ``Session.get`` would answer from the identity map and raise
+    ObjectDeletedError for a row the purge removed under it, which says the
+    same thing far less clearly.
+    """
+    return (
+        db_session.execute(
+            select(model.id).where(model.id == identifier)
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
+@pytest.fixture
+def account(db_session, test_user):
+    return db_session.get(models.Account, test_user.account_id)
+
+
+def _audit_row(db_session, account_id, *, age_days: int, action="permission_check"):
+    row = AuditLog(
+        account_id=account_id,
+        action=action,
+        resource_type="tool",
+        resource_id="x",
+        status="success",
+        timestamp=datetime.now(UTC) - timedelta(days=age_days),
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _approval(db_session, test_user, *, age_days: int, status: str = "approved"):
+    workflow = models.ApprovalWorkflow(
+        account_id=test_user.account_id,
+        name=f"wf-{uuid.uuid4().hex[:8]}",
+        approval_type="manual",
+        channel="email",
+    )
+    db_session.add(workflow)
+    db_session.flush()
+    config = models.ToolConfiguration(
+        account_id=test_user.account_id,
+        tool_name="send_payment",
+        tool_source="mcp",
+        approval_workflow_id=workflow.id,
+        is_enabled=True,
+        custom_config={},
+    )
+    db_session.add(config)
+    db_session.flush()
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="send_payment",
+        tool_args={"amount": 1},
+        status=status,
+        requested_at=datetime.utcnow() - timedelta(days=age_days),
+    )
+    db_session.add(request)
+    db_session.flush()
+    return request
+
+
+def _evidence(db_session, test_user, *, age_days: int):
+    flow = models.Flow(
+        name=f"flow-{age_days}",
+        prompt_template="t",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_user.account_id,
+    )
+    db_session.add(flow)
+    db_session.flush()
+    execution = models.FlowExecution(
+        flow_id=flow.id,
+        status="COMPLETED",
+        trigger_event_details={"_session_thread_id": "t"},
+    )
+    db_session.add(execution)
+    db_session.flush()
+    created = datetime.now(UTC) - timedelta(days=age_days)
+    artifact = models.FlowArtifact(
+        account_id=test_user.account_id,
+        flow_id=flow.id,
+        execution_id=execution.id,
+        thread_id="t",
+        kind="evidence",
+        manifest={"sha256": "a" * 64, "size_bytes": 10},
+        manifest_sha256="b" * 64,
+        ciphertext=b"cipher",
+        expires_at=created + timedelta(hours=1),
+        created_at=created,
+        availability="available",
+    )
+    db_session.add(artifact)
+    db_session.flush()
+    return execution, artifact
+
+
+# --- what gets removed -----------------------------------------------------
+
+
+def test_rows_inside_retention_are_left_alone(db_session, account):
+    keep = _audit_row(db_session, account.id, age_days=10)
+    db_session.commit()
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted == 0
+    assert _exists(db_session, AuditLog, keep.id) is True
+
+
+def test_rows_past_retention_are_removed(db_session, account):
+    old = _audit_row(db_session, account.id, age_days=400).id
+    recent = _audit_row(db_session, account.id, age_days=5).id
+    db_session.commit()
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.classes[CLASS_AUDIT] >= 1
+    assert _exists(db_session, AuditLog, old) is False
+    assert _exists(db_session, AuditLog, recent) is True
+
+
+def test_a_shorter_account_retention_removes_more(db_session, account):
+    row = _audit_row(db_session, account.id, age_days=200).id
+    account.meta_data = {"retention": {CLASS_AUDIT: 183}}
+    db_session.add(account)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, AuditLog, row) is False
+
+
+# --- holds -----------------------------------------------------------------
+
+
+def test_a_held_approval_survives_the_purge(db_session, test_user, account):
+    held = _approval(db_session, test_user, age_days=400).id
+    unheld = _approval(db_session, test_user, age_days=400).id
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="approval",
+        resource_id=str(held),
+        reason="litigation hold, matter 2026-04",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, held) is True
+    assert _exists(db_session, models.ApprovalRequest, unheld) is False
+
+
+def test_a_held_evidence_pack_survives_the_purge(db_session, test_user, account):
+    held = _evidence(db_session, test_user, age_days=500)[1].id
+    unheld = _evidence(db_session, test_user, age_days=500)[1].id
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="evidence_pack",
+        resource_id=str(held),
+        reason="regulator request 2026-05",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.FlowArtifact, held) is True
+    assert _exists(db_session, models.FlowArtifact, unheld) is False
+
+
+def test_an_execution_hold_covers_that_executions_packs(db_session, test_user, account):
+    execution, artifact = _evidence(db_session, test_user, age_days=500)
+    db_session.commit()
+    place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="execution",
+        resource_id=str(execution.id),
+        reason="incident review INC-114",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.FlowArtifact, artifact.id) is True
+
+
+def test_a_released_hold_stops_protecting_the_row(db_session, test_user, account):
+    approval = _approval(db_session, test_user, age_days=400).id
+    db_session.commit()
+    outcome = place_hold(
+        db_session,
+        account_id=account.id,
+        resource_type="approval",
+        resource_id=str(approval),
+        reason="litigation hold, matter 2026-04",
+        user_id=test_user.id,
+    )
+    from preloop.services.legal_hold import release_hold
+
+    release_hold(
+        db_session,
+        account_id=account.id,
+        hold_id=outcome.hold.id,
+        reason="matter closed 2026-06",
+        user_id=test_user.id,
+    )
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, approval) is False
+
+
+# --- what is never purged --------------------------------------------------
+
+
+def test_a_pending_approval_is_never_purged(db_session, test_user, account):
+    """A parked execution is waiting on that row."""
+    pending = _approval(db_session, test_user, age_days=900, status="pending")
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, models.ApprovalRequest, pending.id) is True
+
+
+def test_a_purged_pack_leaves_the_receipt_explained(db_session, test_user, account):
+    execution, artifact = _evidence(db_session, test_user, age_days=500)
+    execution.evidence_receipt = {
+        "status": "available",
+        "artifact_id": str(artifact.id),
+        "kind": "evidence",
+    }
+    db_session.add(execution)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+    db_session.expire(execution)
+
+    receipt = db_session.get(models.FlowExecution, execution.id).evidence_receipt
+    assert receipt["status"] == "expired"
+    assert receipt["error"] == "retention_purged"
+
+
+# --- bounds ----------------------------------------------------------------
+
+
+def test_the_pass_stops_at_the_batch_ceiling_and_says_so(
+    db_session, account, monkeypatch
+):
+    for _ in range(5):
+        _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_batch_size", 1, raising=False)
+    monkeypatch.setattr(settings, "retention_purge_max_batches", 2, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted == 2
+    assert result.budget_exhausted is True
+    remaining = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == "permission_check",
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(remaining) == 3
+
+
+def test_the_purge_is_off_unless_the_deployment_enables_it(
+    db_session, account, monkeypatch
+):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_enabled", False, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.skipped_reason == "disabled"
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+def test_a_dry_run_counts_without_deleting(db_session, account, monkeypatch):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_dry_run", True, raising=False)
+
+    result = purge.run_retention_purge(
+        db_session, account_ids=[account.id], ignore_window=True
+    )
+
+    assert result.deleted >= 1
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+def test_another_accounts_rows_are_never_touched(db_session, account, test_user):
+    from preloop.models.crud import crud_account
+
+    other = crud_account.create(
+        db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+    )
+    theirs = _audit_row(db_session, other.id, age_days=900)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    assert _exists(db_session, AuditLog, theirs.id) is True
+
+
+# --- the off-peak window ---------------------------------------------------
+
+
+def test_outside_the_window_the_pass_does_nothing(db_session, account, monkeypatch):
+    row = _audit_row(db_session, account.id, age_days=900)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_window_utc", "1-5", raising=False)
+
+    result = purge.run_retention_purge(
+        db_session,
+        account_ids=[account.id],
+        now=datetime(2026, 5, 5, 14, 0, tzinfo=UTC),
+    )
+
+    assert result.skipped_reason == "outside_window"
+    assert _exists(db_session, AuditLog, row.id) is True
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1-5", (1, 5)),
+        ("22-3", (22, 3)),
+        ("", None),
+        (None, None),
+        ("nonsense", None),
+        ("1-99", None),
+    ],
+)
+def test_window_parsing(raw, expected):
+    assert purge.parse_window(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "hour,window,inside",
+    [
+        (3, (1, 5), True),
+        (14, (1, 5), False),
+        (23, (22, 3), True),
+        (2, (22, 3), True),
+        (12, (22, 3), False),
+        (12, None, True),
+    ],
+)
+def test_window_membership_handles_midnight(hour, window, inside):
+    now = datetime(2026, 5, 5, hour, 30, tzinfo=UTC)
+    assert purge.in_window(now, window) is inside
+
+
+# --- audit -----------------------------------------------------------------
+
+
+def test_the_purge_writes_an_audit_row_with_the_count(db_session, account):
+    for _ in range(3):
+        _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PURGE,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    audit_class = [row for row in rows if row.resource_id == CLASS_AUDIT]
+    assert len(audit_class) == 1
+    details = audit_class[0].details
+    assert details["deleted"] == 3
+    assert details["retention_days"] == 365
+    assert details["cutoff"]
+
+
+def test_the_audit_row_the_purge_writes_is_not_purged_by_the_same_pass(
+    db_session, account
+):
+    """The record of a deletion must outlive the deletion it records."""
+    _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PURGE,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+def test_a_dry_run_audits_under_its_own_action(db_session, account, monkeypatch):
+    _audit_row(db_session, account.id, age_days=400)
+    db_session.commit()
+    monkeypatch.setattr(settings, "retention_purge_dry_run", True, raising=False)
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    rows = (
+        db_session.execute(
+            select(AuditLog).where(
+                AuditLog.account_id == account.id,
+                AuditLog.action == purge.AUDIT_ACTION_PREVIEW,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows

--- a/backend/tests/services/test_retention_purge.py
+++ b/backend/tests/services/test_retention_purge.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from preloop.config import settings
 from preloop.models import models
 from preloop.models.models.audit_log import AuditLog
+from preloop.services import audit_chain
 from preloop.services import retention_purge as purge
 from preloop.services.legal_hold import place_hold
 from preloop.services.retention_policy import CLASS_AUDIT
@@ -471,3 +472,47 @@ def test_a_dry_run_audits_under_its_own_action(db_session, account, monkeypatch)
         .all()
     )
     assert rows
+
+
+# --- the chain floor -------------------------------------------------------
+
+
+def test_purging_audit_rows_raises_the_chain_floor(db_session, test_user, account):
+    """A retention purge must not read as tampering (#558)."""
+    old = [_audit_row(db_session, account.id, age_days=500) for _ in range(3)]
+    recent = _audit_row(db_session, account.id, age_days=1)
+    audit_chain.seal_account(
+        db_session,
+        account_id=account.id,
+        now=datetime.now(UTC) + timedelta(hours=1),
+        lag=timedelta(0),
+    )
+    db_session.commit()
+    highest_purged = max(row.chain_seq for row in old)
+    assert recent.chain_seq > highest_purged
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    state = audit_chain.get_state(db_session, account_id=account.id, create=False)
+    assert state.pruned_below_seq >= highest_purged
+    report = audit_chain.verify_chain(db_session, account_id=account.id)
+    assert report["status"] == "ok"
+    assert report["start_seq"] > highest_purged
+
+
+def test_a_purge_that_removes_nothing_leaves_the_floor_where_it_was(
+    db_session, test_user, account
+):
+    _audit_row(db_session, account.id, age_days=1)
+    audit_chain.seal_account(
+        db_session,
+        account_id=account.id,
+        now=datetime.now(UTC) + timedelta(hours=1),
+        lag=timedelta(0),
+    )
+    db_session.commit()
+
+    purge.run_retention_purge(db_session, account_ids=[account.id], ignore_window=True)
+
+    state = audit_chain.get_state(db_session, account_id=account.id, create=False)
+    assert int(state.pruned_below_seq) == 0

--- a/cli/internal/cmd/audit.go
+++ b/cli/internal/cmd/audit.go
@@ -230,7 +230,14 @@ func runAuditVerify(cmd *cobra.Command, args []string) error {
 	if after < 0 {
 		after = 0
 	}
-	walk := verify.NewChainWalk(verify.RowDomainV1, after, "")
+	// Empty expectedPrev means "take the first row's word for it", which is
+	// honest only for a mid-chain start. From sequence 1 the first row must
+	// commit to genesis, matching the server walk and the package tests.
+	expectedPrev := ""
+	if after < 1 {
+		expectedPrev = verify.GenesisHash
+	}
+	walk := verify.NewChainWalk(verify.RowDomainV1, after, expectedPrev)
 	watched := make([]int64, 0, len(checkpoints))
 	for _, checkpoint := range checkpoints {
 		watched = append(watched, checkpoint.Seq)
@@ -284,7 +291,7 @@ func runAuditVerify(cmd *cobra.Command, args []string) error {
 		}
 		report.Checkpoints = checkCheckpoints(checkpoints, keys, walk)
 		for _, checked := range report.Checkpoints {
-			if !checked.SignatureOK || !checked.MatchesLocalRow {
+			if checkpointFails(checked) {
 				report.Status = "broken"
 				if report.FirstBreak == nil {
 					report.FirstBreak = &verify.Break{
@@ -352,7 +359,7 @@ func printAuditVerify(cmd *cobra.Command, status chainStatus, report auditVerify
 	}
 	for _, checked := range report.Checkpoints {
 		state := "verified"
-		if !checked.SignatureOK || !checked.MatchesLocalRow {
+		if checkpointFails(checked) {
 			state = "FAILED"
 		}
 		fmt.Fprintf(out, "Checkpoint at sequence %d: %s (key %s)\n", checked.Seq, state, checked.KeyID)
@@ -404,12 +411,29 @@ func runAuditKeys(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// checkpointOutsideWalk is reported when a checkpoint's sequence was never
+// in the rows this walk fetched. A valid signature still stands; it just
+// was not held against local rows, so matches_local_rows stays false.
+const checkpointOutsideWalk = "outside the walked range"
+
+// checkpointFails reports whether this checkpoint contradicts the walk.
+// A signature that verifies for a sequence we did not walk is not a break.
+func checkpointFails(v checkpointVerdict) bool {
+	if !v.SignatureOK {
+		return true
+	}
+	if v.Detail == checkpointOutsideWalk {
+		return false
+	}
+	return !v.MatchesLocalRow
+}
+
 // checkCheckpoints verifies each anchor's signature and holds it against the
 // rows this walk actually fetched.
 func checkCheckpoints(checkpoints []chainCheckpoint, keys verify.KeyList, walk *verify.ChainWalk) []checkpointVerdict {
 	verdicts := make([]checkpointVerdict, 0, len(checkpoints))
 	for _, checkpoint := range checkpoints {
-		verdict := checkpointVerdict{Seq: checkpoint.Seq, KeyID: checkpoint.SigningKeyID, MatchesLocalRow: true}
+		verdict := checkpointVerdict{Seq: checkpoint.Seq, KeyID: checkpoint.SigningKeyID}
 		if checkpoint.SignatureDocument == nil {
 			verdict.Detail = "this checkpoint carries no signature, so it anchors nothing outside the database"
 			verdicts = append(verdicts, verdict)
@@ -433,12 +457,20 @@ func checkCheckpoints(checkpoints []chainCheckpoint, keys verify.KeyList, walk *
 			continue
 		}
 		verdict.SignatureOK = true
-		if observed, walked := walk.Observed[checkpoint.Seq]; walked && observed != checkpoint.ChainHash {
-			verdict.MatchesLocalRow = false
+		observed, walked := walk.Observed[checkpoint.Seq]
+		if !walked {
+			verdict.Detail = checkpointOutsideWalk
+			verdicts = append(verdicts, verdict)
+			continue
+		}
+		if observed != checkpoint.ChainHash {
 			verdict.Detail = fmt.Sprintf(
 				"the checkpoint anchors %s at this sequence but the rows served now hash to %s",
 				checkpoint.ChainHash, observed)
+			verdicts = append(verdicts, verdict)
+			continue
 		}
+		verdict.MatchesLocalRow = true
 		verdicts = append(verdicts, verdict)
 	}
 	sort.Slice(verdicts, func(i, j int) bool { return verdicts[i].Seq < verdicts[j].Seq })

--- a/cli/internal/cmd/audit.go
+++ b/cli/internal/cmd/audit.go
@@ -1,0 +1,505 @@
+// Audit chain verification (#558).
+//
+// The point of this command is that it does not trust our answer. The server
+// has an endpoint that walks its own chain and reports a verdict, and that
+// verdict is worth exactly the trust the caller already places in the server,
+// which for a tamper evidence feature is the wrong amount. So this command
+// asks for the material (canonical row payloads and stored hashes), recomputes
+// every hash locally, and says plainly when its verdict differs from ours.
+//
+// What a clean walk proves: the rows in the range are in the order they were
+// sealed in, none was removed from the middle, and none was edited after
+// sealing. What it does not prove: that any row was true when it was written.
+// The chain is built by the same platform that writes the rows.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/verify"
+)
+
+const (
+	auditChainStatusPath      = "/api/v1/audit/chain/status"
+	auditChainVerifyPath      = "/api/v1/audit/chain/verify"
+	auditChainSegmentPath     = "/api/v1/audit/chain/segment"
+	auditChainCheckpointsPath = "/api/v1/audit/chain/checkpoints"
+	signingKeysPath           = "/api/v1/signing/keys"
+
+	auditSegmentPageSize = 500
+	// auditMaxPages bounds one run at half a million rows. A chain longer
+	// than that wants a range, not a bigger default.
+	auditMaxPages = 1000
+)
+
+// chainStatus is GET /audit/chain/status.
+type chainStatus struct {
+	Enabled            bool             `json:"enabled"`
+	HeadSeq            int64            `json:"head_seq"`
+	HeadHash           string           `json:"head_hash"`
+	LastSealedAt       string           `json:"last_sealed_at"`
+	PrunedBelowSeq     int64            `json:"pruned_below_seq"`
+	SealedRows         int64            `json:"sealed_rows"`
+	UnsealedRows       int64            `json:"unsealed_rows"`
+	SealLagSeconds     int64            `json:"seal_lag_seconds"`
+	CheckpointInterval int64            `json:"checkpoint_interval"`
+	LatestCheckpoint   *chainCheckpoint `json:"latest_checkpoint"`
+	ActiveKeyID        string           `json:"active_key_id"`
+}
+
+// chainCheckpoint is one signed anchor over the chain head at a sequence.
+type chainCheckpoint struct {
+	Seq               int64                     `json:"seq"`
+	ChainHash         string                    `json:"chain_hash"`
+	RowCount          int64                     `json:"row_count"`
+	CheckpointedAt    string                    `json:"checkpointed_at"`
+	SigningKeyID      string                    `json:"signing_key_id"`
+	Signature         string                    `json:"signature"`
+	SignedPayload     map[string]interface{}    `json:"signed_payload"`
+	Digest            string                    `json:"digest"`
+	SignatureDocument *verify.SignatureDocument `json:"signature_document"`
+}
+
+// serverChainVerdict is GET /audit/chain/verify, kept only so a disagreement
+// between our answer and the local walk is visible.
+type serverChainVerdict struct {
+	Status       string `json:"status"`
+	CheckedRows  int64  `json:"checked_rows"`
+	StartSeq     int64  `json:"start_seq"`
+	EndSeq       int64  `json:"end_seq"`
+	HeadSeq      int64  `json:"head_seq"`
+	UnsealedRows int64  `json:"unsealed_rows"`
+	FirstBreak   *struct {
+		Kind   string `json:"kind"`
+		Seq    int64  `json:"seq"`
+		RowID  string `json:"row_id"`
+		Detail string `json:"detail"`
+	} `json:"first_break"`
+}
+
+// auditVerifyReport is the --json shape. It is deliberately explicit about
+// scope: a verdict without a range is not a verdict.
+type auditVerifyReport struct {
+	Status         string                 `json:"status"`
+	CheckedRows    int64                  `json:"checked_rows"`
+	StartSeq       int64                  `json:"start_seq"`
+	EndSeq         int64                  `json:"end_seq"`
+	HeadSeq        int64                  `json:"head_seq"`
+	PrunedBelowSeq int64                  `json:"pruned_below_seq"`
+	UnsealedRows   int64                  `json:"unsealed_rows"`
+	FirstBreak     *verify.Break          `json:"first_break,omitempty"`
+	Checkpoints    []checkpointVerdict    `json:"checkpoints,omitempty"`
+	ServerStatus   string                 `json:"server_status,omitempty"`
+	ServerAgrees   bool                   `json:"server_agrees"`
+	Proves         map[string]interface{} `json:"proves"`
+}
+
+// checkpointVerdict is one anchor checked against the rows in hand.
+type checkpointVerdict struct {
+	Seq             int64  `json:"seq"`
+	KeyID           string `json:"key_id"`
+	SignatureOK     bool   `json:"signature_ok"`
+	MatchesLocalRow bool   `json:"matches_local_rows"`
+	Detail          string `json:"detail,omitempty"`
+}
+
+var (
+	auditStartSeq int64
+	auditEndSeq   int64
+	auditJSON     bool
+)
+
+// auditCmd is the parent for audit trail commands.
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Inspect and verify the tamper-evident audit trail",
+	Long: `Work with the per-account audit hash chain.
+
+Audit rows are chained: each sealed row commits to the row before it, so a
+row that was edited or removed after sealing breaks the chain from that point
+on. Checkpoints over the chain head are signed with the account's Ed25519 key,
+which is what lets a checkpoint you stored last quarter contradict a chain
+rewritten today.`,
+}
+
+// auditVerifyCmd implements `preloop audit verify`.
+var auditVerifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Walk the audit hash chain locally and report the first break",
+	Long: `Fetch the chain material and recompute every hash on this machine.
+
+The command asks the server for each row's canonical payload and the hashes
+it stored, then recomputes sha256(row_domain + canonical JSON) itself and
+checks that each row commits to the one before it. It reports the first break
+and stops there: everything after the first break is a consequence of it.
+
+Signed checkpoints are verified against the account's published public keys,
+and each checkpoint is held against the rows fetched now, so a chain rebuilt
+after the fact fails against an anchor made before it.
+
+Scope, which is the honest part: rows below the retention purge floor are
+gone under a stated policy and are not verified, and rows written since the
+last sealing pass are not chained yet. A clean walk proves order and
+non-deletion within the range it names. It does not prove any row was true
+when it was written: the chain is built by the platform that writes the rows.
+
+Exit status is 1 when the chain is broken, so CI can gate on it.
+
+Examples:
+  preloop audit verify
+  preloop audit verify --start-seq 1000 --end-seq 2000
+  preloop audit verify --json`,
+	RunE: runAuditVerify,
+}
+
+// auditKeysCmd implements `preloop audit keys`.
+var auditKeysCmd = &cobra.Command{
+	Use:   "keys",
+	Short: "Show the account's signing keys (public halves only)",
+	Long: `List every signing key the account has held, newest first.
+
+Retired keys stay listed on purpose: every signature they made is still
+valid, and a bundle exported last year needs the key that signed it.
+
+Keep a copy of these somewhere we cannot reach. A public key you fetch from
+us at verification time only proves the bundle matches whatever key we serve
+you today.`,
+	RunE: runAuditKeys,
+}
+
+func init() {
+	auditVerifyCmd.Flags().Int64Var(&auditStartSeq, "start-seq", 0, "first chain sequence to check (default: the purge floor)")
+	auditVerifyCmd.Flags().Int64Var(&auditEndSeq, "end-seq", 0, "last chain sequence to check (default: the chain head)")
+	auditVerifyCmd.Flags().BoolVar(&auditJSON, "json", false, "emit the verdict as JSON")
+	auditKeysCmd.Flags().BoolVar(&auditJSON, "json", false, "emit the keys as JSON")
+
+	auditCmd.AddCommand(auditVerifyCmd)
+	auditCmd.AddCommand(auditKeysCmd)
+}
+
+func runAuditVerify(cmd *cobra.Command, args []string) error {
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+
+	var status chainStatus
+	if err := client.Get(auditChainStatusPath, &status); err != nil {
+		return fmt.Errorf("could not read the chain status: %w", err)
+	}
+
+	report := auditVerifyReport{
+		HeadSeq:        status.HeadSeq,
+		PrunedBelowSeq: status.PrunedBelowSeq,
+		UnsealedRows:   status.UnsealedRows,
+		ServerAgrees:   true,
+	}
+
+	// The server's own verdict, fetched first so that a disagreement is
+	// reportable. It is not the answer, and it is recorded in the audit trail
+	// on their side, which is where a verification belongs.
+	var verdict serverChainVerdict
+	verdictPath := auditChainVerifyPath
+	if query := seqQuery(auditStartSeq, auditEndSeq); query != "" {
+		verdictPath += "?" + query
+	}
+	if err := client.Get(verdictPath, &verdict); err != nil {
+		// A server that cannot give its own verdict does not stop a local
+		// walk. It is one more thing to report, not a reason to give up.
+		fmt.Fprintf(cmd.ErrOrStderr(), "note: the server verdict is unavailable (%v); walking locally anyway\n", err)
+	} else {
+		report.ServerStatus = verdict.Status
+	}
+
+	checkpoints, err := fetchCheckpoints(client, auditStartSeq)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "note: checkpoints are unavailable (%v)\n", err)
+	}
+
+	after := auditStartSeq - 1
+	if after < status.PrunedBelowSeq {
+		after = status.PrunedBelowSeq
+	}
+	if after < 0 {
+		after = 0
+	}
+	walk := verify.NewChainWalk(verify.RowDomainV1, after, "")
+	watched := make([]int64, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		watched = append(watched, checkpoint.Seq)
+	}
+	walk.Watch(watched)
+
+	pages := 0
+	for {
+		segment, err := fetchSegment(client, after)
+		if err != nil {
+			return fmt.Errorf("could not read the chain: %w", err)
+		}
+		if segment.RowDomain != "" {
+			walk.SetRowDomain(segment.RowDomain)
+		}
+		entries := trimToEnd(segment.Entries, auditEndSeq)
+		walk.Feed(entries)
+		if walk.Break != nil {
+			break
+		}
+		after = walk.LastSeq
+		if len(entries) < len(segment.Entries) || !segment.HasMore || len(segment.Entries) == 0 {
+			break
+		}
+		pages++
+		if pages >= auditMaxPages {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"note: stopping after %d pages; narrow the range with --start-seq and --end-seq\n",
+				pages)
+			break
+		}
+	}
+
+	report.CheckedRows = walk.Checked
+	report.StartSeq = walk.FirstSeq
+	report.EndSeq = walk.LastSeq
+	report.FirstBreak = walk.Break
+	switch {
+	case walk.Break != nil:
+		report.Status = "broken"
+	case walk.Checked == 0:
+		report.Status = "empty"
+	default:
+		report.Status = "ok"
+	}
+
+	if len(checkpoints) > 0 {
+		keys, keyErr := fetchKeys(client)
+		if keyErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "note: public keys are unavailable (%v)\n", keyErr)
+		}
+		report.Checkpoints = checkCheckpoints(checkpoints, keys, walk)
+		for _, checked := range report.Checkpoints {
+			if !checked.SignatureOK || !checked.MatchesLocalRow {
+				report.Status = "broken"
+				if report.FirstBreak == nil {
+					report.FirstBreak = &verify.Break{
+						Kind:   "checkpoint_mismatch",
+						Seq:    checked.Seq,
+						Detail: checked.Detail,
+					}
+				}
+			}
+		}
+	}
+
+	if report.ServerStatus != "" {
+		serverBroken := report.ServerStatus == "broken"
+		localBroken := report.Status == "broken"
+		report.ServerAgrees = serverBroken == localBroken
+	}
+	report.Proves = map[string]interface{}{
+		"order_and_no_deletion_between": []int64{report.StartSeq, report.EndSeq},
+		"rows_not_verified": map[string]int64{
+			"below_purge_floor": status.PrunedBelowSeq,
+			"not_yet_sealed":    status.UnsealedRows,
+		},
+		"note": "a clean walk shows the rows were not reordered, removed or " +
+			"edited after sealing. It does not show they were true when written.",
+	}
+
+	if auditJSON {
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(report); err != nil {
+			return err
+		}
+	} else {
+		printAuditVerify(cmd, status, report)
+	}
+	if report.Status == "broken" {
+		return fmt.Errorf("the audit chain is broken at sequence %d", breakSeq(report.FirstBreak))
+	}
+	return nil
+}
+
+func printAuditVerify(cmd *cobra.Command, status chainStatus, report auditVerifyReport) {
+	out := cmd.OutOrStdout()
+	switch report.Status {
+	case "ok":
+		fmt.Fprintf(out, "Chain intact: %d rows, sequences %d to %d.\n",
+			report.CheckedRows, report.StartSeq, report.EndSeq)
+	case "empty":
+		fmt.Fprintln(out, "Nothing to verify: no sealed rows in this range.")
+	default:
+		fmt.Fprintf(out, "CHAIN BROKEN after %d good rows.\n", report.CheckedRows)
+		if report.FirstBreak != nil {
+			fmt.Fprintf(out, "  first break: %s at sequence %d\n",
+				report.FirstBreak.Kind, report.FirstBreak.Seq)
+			if report.FirstBreak.RowID != "" {
+				fmt.Fprintf(out, "  row:         %s\n", report.FirstBreak.RowID)
+			}
+			fmt.Fprintf(out, "  detail:      %s\n", report.FirstBreak.Detail)
+			if report.FirstBreak.Expected != "" {
+				fmt.Fprintf(out, "  expected:    %s\n", report.FirstBreak.Expected)
+				fmt.Fprintf(out, "  computed:    %s\n", report.FirstBreak.Found)
+			}
+		}
+	}
+	for _, checked := range report.Checkpoints {
+		state := "verified"
+		if !checked.SignatureOK || !checked.MatchesLocalRow {
+			state = "FAILED"
+		}
+		fmt.Fprintf(out, "Checkpoint at sequence %d: %s (key %s)\n", checked.Seq, state, checked.KeyID)
+		if checked.Detail != "" {
+			fmt.Fprintf(out, "  %s\n", checked.Detail)
+		}
+	}
+	if report.ServerStatus != "" && !report.ServerAgrees {
+		fmt.Fprintf(out, "\nThe server reports %q and this local walk reports %q. Trust the walk: it used the row content.\n",
+			report.ServerStatus, report.Status)
+	}
+	if status.UnsealedRows > 0 {
+		fmt.Fprintf(out, "\n%d row(s) are written but not sealed yet, so they are outside this result.\n", status.UnsealedRows)
+	}
+	if status.PrunedBelowSeq > 0 {
+		fmt.Fprintf(out, "Rows below sequence %d were removed by the retention purge under policy, not verified here.\n", status.PrunedBelowSeq)
+	}
+	fmt.Fprintln(out, "\nThis shows the rows were not reordered, removed or edited after sealing.")
+	fmt.Fprintln(out, "It does not show they were true when they were written.")
+}
+
+func runAuditKeys(cmd *cobra.Command, args []string) error {
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return err
+	}
+	keys, err := fetchKeys(client)
+	if err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if auditJSON {
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(keys)
+	}
+	fmt.Fprintf(out, "Signature format: %s\n", keys.SignedBytesFormat)
+	fmt.Fprintf(out, "Active key:       %s\n\n", keys.ActiveKeyID)
+	for _, key := range keys.Keys {
+		state := "retired " + key.RetiredAt
+		if key.Active {
+			state = "active"
+		}
+		fmt.Fprintf(out, "%s  %s  %s\n", key.KeyID, key.Algorithm, state)
+		fmt.Fprintf(out, "  %s\n", key.PublicKey)
+	}
+	fmt.Fprintln(out, "\nKeep your own copy. A key fetched at verification time only shows")
+	fmt.Fprintln(out, "the bundle matches whatever key the server serves you today.")
+	return nil
+}
+
+// checkCheckpoints verifies each anchor's signature and holds it against the
+// rows this walk actually fetched.
+func checkCheckpoints(checkpoints []chainCheckpoint, keys verify.KeyList, walk *verify.ChainWalk) []checkpointVerdict {
+	verdicts := make([]checkpointVerdict, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		verdict := checkpointVerdict{Seq: checkpoint.Seq, KeyID: checkpoint.SigningKeyID, MatchesLocalRow: true}
+		if checkpoint.SignatureDocument == nil {
+			verdict.Detail = "this checkpoint carries no signature, so it anchors nothing outside the database"
+			verdicts = append(verdicts, verdict)
+			continue
+		}
+		digest, err := verify.DigestOf(checkpoint.SignedPayload)
+		if err != nil {
+			verdict.Detail = fmt.Sprintf("checkpoint payload cannot be canonicalised: %v", err)
+			verdicts = append(verdicts, verdict)
+			continue
+		}
+		key, found := keys.Find(checkpoint.SigningKeyID)
+		if !found {
+			verdict.Detail = "no published public key for " + checkpoint.SigningKeyID
+			verdicts = append(verdicts, verdict)
+			continue
+		}
+		if err := verify.CheckSignature(*checkpoint.SignatureDocument, key, digest); err != nil {
+			verdict.Detail = err.Error()
+			verdicts = append(verdicts, verdict)
+			continue
+		}
+		verdict.SignatureOK = true
+		if observed, walked := walk.Observed[checkpoint.Seq]; walked && observed != checkpoint.ChainHash {
+			verdict.MatchesLocalRow = false
+			verdict.Detail = fmt.Sprintf(
+				"the checkpoint anchors %s at this sequence but the rows served now hash to %s",
+				checkpoint.ChainHash, observed)
+		}
+		verdicts = append(verdicts, verdict)
+	}
+	sort.Slice(verdicts, func(i, j int) bool { return verdicts[i].Seq < verdicts[j].Seq })
+	return verdicts
+}
+
+func fetchSegment(client *api.Client, afterSeq int64) (verify.Segment, error) {
+	var segment verify.Segment
+	path := fmt.Sprintf("%s?after_seq=%d&limit=%d", auditChainSegmentPath, afterSeq, auditSegmentPageSize)
+	err := client.Get(path, &segment)
+	return segment, err
+}
+
+func fetchCheckpoints(client *api.Client, afterSeq int64) ([]chainCheckpoint, error) {
+	after := afterSeq - 1
+	if after < 0 {
+		after = 0
+	}
+	var checkpoints []chainCheckpoint
+	path := fmt.Sprintf("%s?after_seq=%d&limit=%d", auditChainCheckpointsPath, after, 200)
+	err := client.Get(path, &checkpoints)
+	return checkpoints, err
+}
+
+func fetchKeys(client *api.Client) (verify.KeyList, error) {
+	var keys verify.KeyList
+	err := client.Get(signingKeysPath, &keys)
+	return keys, err
+}
+
+// trimToEnd cuts a page at --end-seq, so a bounded range does not silently
+// verify past what the caller asked about.
+func trimToEnd(entries []verify.SegmentEntry, endSeq int64) []verify.SegmentEntry {
+	if endSeq <= 0 {
+		return entries
+	}
+	for index, entry := range entries {
+		if entry.Seq > endSeq {
+			return entries[:index]
+		}
+	}
+	return entries
+}
+
+func seqQuery(startSeq, endSeq int64) string {
+	query := ""
+	if startSeq > 0 {
+		query = fmt.Sprintf("start_seq=%d", startSeq)
+	}
+	if endSeq > 0 {
+		if query != "" {
+			query += "&"
+		}
+		query += fmt.Sprintf("end_seq=%d", endSeq)
+	}
+	return query
+}
+
+func breakSeq(found *verify.Break) int64 {
+	if found == nil {
+		return 0
+	}
+	return found.Seq
+}

--- a/cli/internal/cmd/audit_test.go
+++ b/cli/internal/cmd/audit_test.go
@@ -1,0 +1,311 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+	"github.com/preloop/preloop/cli/internal/verify"
+)
+
+// fakeChain is a server side chain the CLI can be pointed at, including the
+// ability to serve rows that no longer match their sealed hashes.
+type fakeChain struct {
+	entries     []verify.SegmentEntry
+	checkpoints []chainCheckpoint
+	keys        verify.KeyList
+	private     ed25519.PrivateKey
+	verdict     string
+}
+
+func newFakeChain(t *testing.T, rows int) *fakeChain {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := &fakeChain{
+		private: private,
+		verdict: "ok",
+		keys: verify.KeyList{
+			ActiveKeyID:     "key-1",
+			SignatureSchema: "preloop.signature/v1",
+			Keys: []verify.PublicKey{{
+				KeyID:     "key-1",
+				Algorithm: verify.AlgorithmEd25519,
+				PublicKey: base64.StdEncoding.EncodeToString(public),
+				Active:    true,
+			}},
+		},
+	}
+	prev := verify.GenesisHash
+	for index := 1; index <= rows; index++ {
+		payload := map[string]interface{}{
+			"seq":       index,
+			"prev_hash": prev,
+			"action":    fmt.Sprintf("action_%d", index),
+			"status":    "success",
+		}
+		hash, err := verify.RowHash(verify.RowDomainV1, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chain.entries = append(chain.entries, verify.SegmentEntry{
+			Seq:      int64(index),
+			RowID:    fmt.Sprintf("row-%d", index),
+			PrevHash: prev,
+			RowHash:  hash,
+			Payload:  payload,
+		})
+		prev = hash
+	}
+	return chain
+}
+
+// addCheckpoint signs an anchor over the chain head at seq, the way the
+// sealer does.
+func (c *fakeChain) addCheckpoint(t *testing.T, seq int64, chainHash string) {
+	t.Helper()
+	payload := map[string]interface{}{
+		"schema":     "preloop.audit.chain_checkpoint/v1",
+		"seq":        seq,
+		"chain_hash": chainHash,
+		"row_count":  seq,
+		"taken_at":   "2026-09-10T12:00:00Z",
+	}
+	digest, err := verify.DigestOf(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(c.private,
+		verify.SignedBytes("preloop.audit.chain_checkpoint/v1", digest, "2026-09-10T12:00:00Z"))
+	c.checkpoints = append(c.checkpoints, chainCheckpoint{
+		Seq:            seq,
+		ChainHash:      chainHash,
+		RowCount:       seq,
+		CheckpointedAt: "2026-09-10T12:00:00Z",
+		SigningKeyID:   "key-1",
+		Signature:      base64.StdEncoding.EncodeToString(signature),
+		SignedPayload:  payload,
+		Digest:         digest,
+		SignatureDocument: &verify.SignatureDocument{
+			Schema:      "preloop.signature/v1",
+			Algorithm:   verify.AlgorithmEd25519,
+			KeyID:       "key-1",
+			PayloadType: "preloop.audit.chain_checkpoint/v1",
+			Digest:      digest,
+			SignedAt:    "2026-09-10T12:00:00Z",
+			Signature:   base64.StdEncoding.EncodeToString(signature),
+		},
+	})
+}
+
+func (c *fakeChain) serve(t *testing.T) *httptest.Server {
+	t.Helper()
+	head := int64(len(c.entries))
+	headHash := verify.GenesisHash
+	if head > 0 {
+		headHash = c.entries[head-1].RowHash
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case auditChainStatusPath:
+			_ = json.NewEncoder(w).Encode(chainStatus{
+				Enabled: true, HeadSeq: head, HeadHash: headHash,
+				SealedRows: head, CheckpointInterval: 1000, ActiveKeyID: "key-1",
+			})
+		case auditChainVerifyPath:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": c.verdict, "checked_rows": head, "start_seq": 1,
+				"end_seq": head, "head_seq": head, "unsealed_rows": 0,
+			})
+		case auditChainSegmentPath:
+			after := int64(0)
+			_, _ = fmt.Sscanf(r.URL.Query().Get("after_seq"), "%d", &after)
+			entries := []verify.SegmentEntry{}
+			for _, entry := range c.entries {
+				if entry.Seq > after && int64(len(entries)) < 3 {
+					entries = append(entries, entry)
+				}
+			}
+			_ = json.NewEncoder(w).Encode(verify.Segment{
+				AccountID: "acct", RowDomain: verify.RowDomainV1,
+				AfterSeq: after, HeadSeq: head, GenesisHash: verify.GenesisHash,
+				Entries: entries, HasMore: after+int64(len(entries)) < head,
+			})
+		case auditChainCheckpointsPath:
+			_ = json.NewEncoder(w).Encode(c.checkpoints)
+		case signingKeysPath:
+			_ = json.NewEncoder(w).Encode(c.keys)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// pointCLIAt aims the CLI at a local test server and nothing else.
+func pointCLIAt(t *testing.T, url string) {
+	t.Helper()
+	testenv.SetHome(t, t.TempDir())
+	oldToken, oldURL := FlagToken, FlagURL
+	FlagToken, FlagURL = "test-token", url
+	t.Cleanup(func() { FlagToken, FlagURL = oldToken, oldURL })
+}
+
+func runAudit(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	auditVerifyCmd.SetOut(&out)
+	auditVerifyCmd.SetErr(&out)
+	t.Cleanup(func() {
+		auditStartSeq, auditEndSeq, auditJSON = 0, 0, false
+	})
+	err := runAuditVerify(auditVerifyCmd, args)
+	return out.String(), err
+}
+
+func TestAuditVerifyWalksEveryPageAndReportsIntact(t *testing.T) {
+	chain := newFakeChain(t, 7)
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatalf("a good chain failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Chain intact: 7 rows, sequences 1 to 7") {
+		t.Fatalf("output = %q", out)
+	}
+	// The honesty line is part of the output, not a footnote in the docs.
+	if !strings.Contains(out, "does not show they were true when they were written") {
+		t.Fatalf("missing the scope statement: %q", out)
+	}
+}
+
+func TestAuditVerifyReportsTheFirstBrokenRow(t *testing.T) {
+	chain := newFakeChain(t, 8)
+	// The server serves a row whose content no longer matches its hash.
+	chain.entries[3].Payload["status"] = "failure"
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err == nil {
+		t.Fatalf("a broken chain exited zero:\n%s", out)
+	}
+	if !strings.Contains(out, "CHAIN BROKEN after 3 good rows") {
+		t.Fatalf("output = %q", out)
+	}
+	if !strings.Contains(out, "row_hash_mismatch at sequence 4") || !strings.Contains(out, "row-4") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestAuditVerifyContradictsAServerThatClaimsAllIsWell(t *testing.T) {
+	chain := newFakeChain(t, 5)
+	chain.entries[1].Payload["action"] = "something_else"
+	chain.verdict = "ok" // the server insists
+
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err == nil {
+		t.Fatal("the CLI accepted the server's verdict over its own walk")
+	}
+	if !strings.Contains(out, `The server reports "ok" and this local walk reports "broken"`) {
+		t.Fatalf("the disagreement was not reported: %q", out)
+	}
+}
+
+func TestAuditVerifyChecksCheckpointSignatures(t *testing.T) {
+	chain := newFakeChain(t, 6)
+	chain.addCheckpoint(t, 5, chain.entries[4].RowHash)
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatalf("verify failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Checkpoint at sequence 5: verified") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestAuditVerifyFailsWhenACheckpointAnchorsOtherRows(t *testing.T) {
+	chain := newFakeChain(t, 6)
+	// A checkpoint kept from before, over a head the rows served now do not
+	// produce. This is the case a rewritten chain cannot talk its way out of.
+	chain.addCheckpoint(t, 5, "cc"+strings.Repeat("dd", 31))
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err == nil {
+		t.Fatalf("a contradicted checkpoint passed:\n%s", out)
+	}
+	if !strings.Contains(out, "Checkpoint at sequence 5: FAILED") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestAuditVerifyEmitsJSONWithItsScope(t *testing.T) {
+	chain := newFakeChain(t, 4)
+	pointCLIAt(t, chain.serve(t).URL)
+	auditJSON = true
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if report["status"] != "ok" || report["checked_rows"].(float64) != 4 {
+		t.Fatalf("report = %#v", report)
+	}
+	if _, ok := report["proves"]; !ok {
+		t.Fatal("the JSON verdict does not say what it proves")
+	}
+}
+
+func TestAuditVerifyStopsAtTheRequestedEndSequence(t *testing.T) {
+	chain := newFakeChain(t, 9)
+	pointCLIAt(t, chain.serve(t).URL)
+	auditEndSeq = 5
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "sequences 1 to 5") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestAuditVerifyOnAnEmptyChainSaysSo(t *testing.T) {
+	chain := newFakeChain(t, 0)
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Nothing to verify") {
+		t.Fatalf("output = %q", out)
+	}
+}

--- a/cli/internal/cmd/audit_test.go
+++ b/cli/internal/cmd/audit_test.go
@@ -309,3 +309,65 @@ func TestAuditVerifyOnAnEmptyChainSaysSo(t *testing.T) {
 		t.Fatalf("output = %q", out)
 	}
 }
+
+func TestAuditVerifyRejectsAForgedGenesisPrevHash(t *testing.T) {
+	chain := newFakeChain(t, 4)
+	bogus := strings.Repeat("ab", 32)
+	prev := bogus
+	for i := range chain.entries {
+		chain.entries[i].PrevHash = prev
+		chain.entries[i].Payload["prev_hash"] = prev
+		hash, err := verify.RowHash(verify.RowDomainV1, chain.entries[i].Payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chain.entries[i].RowHash = hash
+		prev = hash
+	}
+	pointCLIAt(t, chain.serve(t).URL)
+
+	out, err := runAudit(t)
+
+	if err == nil {
+		t.Fatalf("a forged genesis prev_hash passed:\n%s", out)
+	}
+	if !strings.Contains(out, "prev_hash_mismatch at sequence 1") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestAuditVerifyReportsUnwalkedCheckpointsHonestly(t *testing.T) {
+	chain := newFakeChain(t, 6)
+	chain.addCheckpoint(t, 6, chain.entries[5].RowHash)
+	pointCLIAt(t, chain.serve(t).URL)
+	auditJSON = true
+	auditEndSeq = 3
+
+	out, err := runAudit(t)
+
+	if err != nil {
+		t.Fatalf("an out-of-range checkpoint failed the walk: %v\n%s", err, out)
+	}
+	var report map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if report["status"] != "ok" {
+		t.Fatalf("status = %#v", report["status"])
+	}
+	checkpoints, _ := report["checkpoints"].([]interface{})
+	if len(checkpoints) != 1 {
+		t.Fatalf("checkpoints = %#v", report["checkpoints"])
+	}
+	checked, _ := checkpoints[0].(map[string]interface{})
+	if checked["matches_local_rows"] != false {
+		t.Fatalf("unwalked checkpoint claimed a local match: %#v", checked)
+	}
+	detail, _ := checked["detail"].(string)
+	if !strings.Contains(detail, "outside the walked range") {
+		t.Fatalf("detail = %q", detail)
+	}
+	if checked["signature_ok"] != true {
+		t.Fatalf("signature should still verify: %#v", checked)
+	}
+}

--- a/cli/internal/cmd/evidence.go
+++ b/cli/internal/cmd/evidence.go
@@ -1,0 +1,312 @@
+// Signed export and evidence pack verification (#558).
+//
+// Everything here works on bytes the caller already holds. That is the only
+// verification worth running: a check that downloads the artifact and the
+// answer from the same place at the same moment proves very little.
+//
+// Two shapes are handled, because two things are signed. A period export
+// (from `preloop` retention exports) carries manifest.json and a detached
+// signature.json over the manifest bytes. An evidence pack is content
+// addressed the moment it is stored, so appending a signature to the archive
+// would change the digest the receipt already promised; its signature is
+// served beside the pack on the receipt instead.
+
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/verify"
+)
+
+const evidenceStatusPathFormat = "/api/v1/flows/executions/%s/evidence-status"
+
+var (
+	evidenceExecutionID string
+	evidencePublicKey   string
+	evidenceOffline     bool
+	evidenceJSON        bool
+)
+
+// evidenceReceipt is the part of an evidence status response this command
+// needs: the detached signature, with the payload that was signed.
+type evidenceReceipt struct {
+	Status       string                    `json:"status"`
+	ArtifactID   string                    `json:"artifact_id"`
+	Sha256       string                    `json:"sha256"`
+	SizeBytes    int64                     `json:"size_bytes"`
+	SigningKeyID string                    `json:"signing_key_id"`
+	Signature    *verify.SignatureDocument `json:"signature"`
+}
+
+// evidenceVerifyReport is the --json shape.
+type evidenceVerifyReport struct {
+	Kind          string                 `json:"kind"`
+	File          string                 `json:"file"`
+	Sha256        string                 `json:"sha256"`
+	ContentOK     bool                   `json:"content_ok"`
+	SignatureOK   bool                   `json:"signature_ok"`
+	KeyID         string                 `json:"key_id,omitempty"`
+	KeySource     string                 `json:"key_source,omitempty"`
+	SignedAt      string                 `json:"signed_at,omitempty"`
+	Members       []verify.MemberResult  `json:"members,omitempty"`
+	MembersDigest map[string]interface{} `json:"members_digest,omitempty"`
+	Problems      []string               `json:"problems,omitempty"`
+	Proves        string                 `json:"proves"`
+}
+
+// evidenceCmd is the parent for evidence verification.
+var evidenceCmd = &cobra.Command{
+	Use:   "evidence",
+	Short: "Verify signed exports and evidence packs",
+	Long:  `Check a bundle you were given against the signature Preloop made for it.`,
+}
+
+// evidenceVerifyCmd implements `preloop evidence verify`.
+var evidenceVerifyCmd = &cobra.Command{
+	Use:   "verify <archive>",
+	Short: "Verify a period export or an evidence pack against its signature",
+	Long: `Verify bytes you hold, not bytes fetched for the occasion.
+
+Period export (default):
+  Expands the archive, recomputes the sha256 of every member and the digest
+  over the member list, then checks the detached Ed25519 signature in
+  signature.json against the account's public key.
+
+Evidence pack (--execution):
+  Hashes the archive and compares it with the digest inside the signed
+  payload the receipt carries, then checks the signature over that payload.
+  The pack is signed at capture, not at download, so re-serving it cannot
+  change what was signed.
+
+Use --public-key with a base64 key or a file holding one to verify without
+talking to us at all. Otherwise the public key is fetched from the account,
+which is weaker: it shows the bundle matches the key the server serves today.
+
+What a pass means: this bundle is the one Preloop built and nothing in it has
+moved since. What it does not mean: that the records inside were true when
+they were written. The signing key lives on the same platform that wrote them.
+
+Exit status is 1 when verification fails.
+
+Examples:
+  preloop evidence verify preloop-period-export-2026-04-01-to-2026-05-01.tar.gz
+  preloop evidence verify evidence.tar.gz --execution 8f1c...
+  preloop evidence verify bundle.tar.gz --public-key ./account-key.pub`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEvidenceVerify,
+}
+
+func init() {
+	evidenceVerifyCmd.Flags().StringVar(&evidenceExecutionID, "execution", "", "verify an evidence pack captured for this execution")
+	evidenceVerifyCmd.Flags().StringVar(&evidencePublicKey, "public-key", "", "base64 Ed25519 public key, or a path to a file holding one")
+	evidenceVerifyCmd.Flags().BoolVar(&evidenceOffline, "offline", false, "check digests only, never contact the API")
+	evidenceVerifyCmd.Flags().BoolVar(&evidenceJSON, "json", false, "emit the verdict as JSON")
+
+	evidenceCmd.AddCommand(evidenceVerifyCmd)
+}
+
+func runEvidenceVerify(cmd *cobra.Command, args []string) error {
+	archive, err := os.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("could not read %s: %w", args[0], err)
+	}
+	report := evidenceVerifyReport{File: args[0], Sha256: verify.DigestOfBytes(archive)}
+	if evidenceExecutionID != "" {
+		report.Kind = "evidence_pack"
+		err = verifyEvidencePack(cmd, archive, &report)
+	} else {
+		report.Kind = "period_export"
+		err = verifyPeriodExport(cmd, archive, &report)
+	}
+	if err != nil {
+		return err
+	}
+	if evidenceJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		if encodeErr := encoder.Encode(report); encodeErr != nil {
+			return encodeErr
+		}
+	} else {
+		printEvidenceVerify(cmd, report)
+	}
+	if !report.ContentOK || !report.SignatureOK {
+		return fmt.Errorf("verification failed for %s", args[0])
+	}
+	return nil
+}
+
+func verifyPeriodExport(cmd *cobra.Command, archive []byte, report *evidenceVerifyReport) error {
+	result, err := verify.ReadExport(archive)
+	if err != nil {
+		return err
+	}
+	report.ContentOK = result.ContentOK()
+	report.Members = result.Members
+	report.MembersDigest = map[string]interface{}{
+		"declared": result.MembersDigest.Declared,
+		"computed": result.MembersDigest.Computed,
+		"ok":       result.MembersDigest.OK,
+	}
+	report.Problems = result.Problems
+	report.Proves = "the archive is the one Preloop built and nothing in it has moved since. " +
+		"Not that the records were true when written."
+
+	if result.Signature == nil {
+		report.Problems = append(report.Problems, "this archive carries no signature")
+		return nil
+	}
+	report.KeyID = result.Signature.KeyID
+	report.SignedAt = result.Signature.SignedAt
+	key, source, err := resolvePublicKey(cmd, result.Signature.KeyID, "")
+	if err != nil {
+		report.Problems = append(report.Problems, err.Error())
+		return nil
+	}
+	report.KeySource = source
+	if err := verify.CheckSignature(*result.Signature, key, result.ManifestSha256); err != nil {
+		report.Problems = append(report.Problems, err.Error())
+		return nil
+	}
+	report.SignatureOK = true
+	return nil
+}
+
+func verifyEvidencePack(cmd *cobra.Command, archive []byte, report *evidenceVerifyReport) error {
+	if evidenceOffline {
+		return fmt.Errorf("an evidence pack signature is served with the receipt, so --offline cannot verify one")
+	}
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return err
+	}
+	var receipt evidenceReceipt
+	path := fmt.Sprintf(evidenceStatusPathFormat, evidenceExecutionID)
+	if err := client.Get(path, &receipt); err != nil {
+		return fmt.Errorf("could not read the evidence receipt: %w", err)
+	}
+	report.Proves = "this archive is the evidence pack Preloop captured for that execution. " +
+		"Not that its contents were true when captured."
+	if receipt.Signature == nil {
+		report.Problems = append(report.Problems,
+			"this pack has no signature: it was captured before signing existed, or the account has no usable key")
+		return nil
+	}
+	document := *receipt.Signature
+	report.KeyID = document.KeyID
+	report.SignedAt = document.SignedAt
+
+	// The digest inside the signed payload is the one claim about these bytes
+	// that was made at capture time.
+	signedDigest, _ := document.Payload["archive_sha256"].(string)
+	if signedDigest == "" {
+		report.Problems = append(report.Problems, "the signed payload names no archive digest")
+		return nil
+	}
+	if signedDigest != report.Sha256 {
+		report.Problems = append(report.Problems, fmt.Sprintf(
+			"the signature covers archive %s but this file is %s", signedDigest, report.Sha256))
+		return nil
+	}
+	report.ContentOK = true
+
+	payloadDigest, err := verify.DigestOf(document.Payload)
+	if err != nil {
+		return fmt.Errorf("the signed payload cannot be canonicalised: %w", err)
+	}
+	key, source, err := resolvePublicKey(cmd, document.KeyID, receipt.SigningKeyID)
+	if err != nil {
+		report.Problems = append(report.Problems, err.Error())
+		return nil
+	}
+	report.KeySource = source
+	if err := verify.CheckSignature(document, key, payloadDigest); err != nil {
+		report.Problems = append(report.Problems, err.Error())
+		return nil
+	}
+	report.SignatureOK = true
+	return nil
+}
+
+// resolvePublicKey prefers a key the caller brought. Fetching the key from
+// the same server that made the signature is the weaker check, and the report
+// says which one happened.
+func resolvePublicKey(cmd *cobra.Command, keyID, fallbackKeyID string) (verify.PublicKey, string, error) {
+	if keyID == "" {
+		keyID = fallbackKeyID
+	}
+	if evidencePublicKey != "" {
+		raw := strings.TrimSpace(evidencePublicKey)
+		if body, err := os.ReadFile(raw); err == nil {
+			raw = strings.TrimSpace(string(body))
+		}
+		if _, err := base64.StdEncoding.DecodeString(raw); err != nil {
+			return verify.PublicKey{}, "", fmt.Errorf("--public-key is neither base64 nor a readable file")
+		}
+		return verify.PublicKey{
+			KeyID:     keyID,
+			Algorithm: verify.AlgorithmEd25519,
+			PublicKey: raw,
+		}, "flag", nil
+	}
+	if evidenceOffline {
+		return verify.PublicKey{}, "", fmt.Errorf("--offline was given and no --public-key: digests checked, signature not")
+	}
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return verify.PublicKey{}, "", err
+	}
+	keys, err := fetchKeys(client)
+	if err != nil {
+		return verify.PublicKey{}, "", fmt.Errorf("could not fetch the public keys: %w", err)
+	}
+	key, found := keys.Find(keyID)
+	if !found {
+		return verify.PublicKey{}, "", fmt.Errorf("the account publishes no key with id %s", keyID)
+	}
+	return key, "api", nil
+}
+
+func printEvidenceVerify(cmd *cobra.Command, report evidenceVerifyReport) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "File:   %s\n", report.File)
+	fmt.Fprintf(out, "sha256: %s\n", report.Sha256)
+	for _, member := range report.Members {
+		state := "ok"
+		if !member.OK {
+			state = "ALTERED"
+		}
+		fmt.Fprintf(out, "  %-40s %8d bytes  %s\n", member.Name, member.Size, state)
+	}
+	if report.MembersDigest != nil {
+		state := "ok"
+		if report.MembersDigest["ok"] != true {
+			state = "MISMATCH"
+		}
+		fmt.Fprintf(out, "  member list digest: %s\n", state)
+	}
+	if report.SignatureOK {
+		fmt.Fprintf(out, "\nSignature verified with key %s", report.KeyID)
+		if report.KeySource == "api" {
+			fmt.Fprint(out, " (fetched from the API, so it shows the bundle matches today's published key)")
+		}
+		fmt.Fprintln(out)
+		if report.SignedAt != "" {
+			fmt.Fprintf(out, "Signed at %s\n", report.SignedAt)
+		}
+	} else {
+		fmt.Fprintln(out, "\nSIGNATURE NOT VERIFIED")
+	}
+	for _, problem := range report.Problems {
+		fmt.Fprintf(out, "  - %s\n", problem)
+	}
+	fmt.Fprintf(out, "\nWhat this shows: %s\n", report.Proves)
+}

--- a/cli/internal/cmd/evidence_test.go
+++ b/cli/internal/cmd/evidence_test.go
@@ -1,0 +1,344 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/verify"
+)
+
+const testSignedAt = "2026-09-10T12:00:00Z"
+
+// signedExport packs a period export the way the backend does and signs the
+// manifest bytes with a throwaway key. packedRows is what actually lands in
+// the archive, which is normally the same bytes the manifest digests and is
+// deliberately different when a test wants an edited member.
+func signedExport(t *testing.T, private ed25519.PrivateKey, rows, packedRows string) []byte {
+	t.Helper()
+	members := map[string][]byte{"audit/audit_log.jsonl": []byte(packedRows)}
+	entries := []interface{}{map[string]interface{}{
+		"name":       "audit/audit_log.jsonl",
+		"size_bytes": len(rows),
+		"sha256":     verify.DigestOfBytes([]byte(rows)),
+	}}
+	membersDigest, err := verify.DigestOf(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]interface{}{
+		"schema":         "preloop.retention.period_export_manifest/v1",
+		"members":        entries,
+		"members_digest": membersDigest,
+	}
+	manifestBody, err := verify.CanonicalJSON(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{verify.ManifestMember: manifestBody}
+	for name, body := range members {
+		files[name] = body
+	}
+	digest := verify.DigestOfBytes(manifestBody)
+	signature := ed25519.Sign(private,
+		verify.SignedBytes(verify.PayloadPeriodExport, digest, testSignedAt))
+	document, err := json.Marshal(map[string]interface{}{
+		"schema":       "preloop.signature/v1",
+		"algorithm":    verify.AlgorithmEd25519,
+		"key_id":       "key-1",
+		"payload_type": verify.PayloadPeriodExport,
+		"digest":       digest,
+		"signed_at":    testSignedAt,
+		"signature":    base64.StdEncoding.EncodeToString(signature),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	files[verify.SignatureMember] = document
+	return tarGz(t, files)
+}
+
+func tarGz(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gz := gzip.NewWriter(&buffer)
+	writer := tar.NewWriter(gz)
+	for name, body := range files {
+		if err := writer.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(body))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func writeTemp(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func serveKeys(t *testing.T, public ed25519.PublicKey, receipt interface{}) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == signingKeysPath:
+			_ = json.NewEncoder(w).Encode(verify.KeyList{
+				ActiveKeyID: "key-1",
+				Keys: []verify.PublicKey{{
+					KeyID:     "key-1",
+					Algorithm: verify.AlgorithmEd25519,
+					PublicKey: base64.StdEncoding.EncodeToString(public),
+					Active:    true,
+				}},
+			})
+		case strings.HasSuffix(r.URL.Path, "/evidence-status") && receipt != nil:
+			_ = json.NewEncoder(w).Encode(receipt)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func runEvidence(t *testing.T, path string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	evidenceVerifyCmd.SetOut(&out)
+	evidenceVerifyCmd.SetErr(&out)
+	t.Cleanup(func() {
+		evidenceExecutionID, evidencePublicKey = "", ""
+		evidenceOffline, evidenceJSON = false, false
+	})
+	err := runEvidenceVerify(evidenceVerifyCmd, []string{path})
+	return out.String(), err
+}
+
+func TestEvidenceVerifyAcceptsASignedPeriodExport(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := writeTemp(t, "export.tar.gz", signedExport(t, private, "{\"decision\":\"allow\"}\n", "{\"decision\":\"allow\"}\n"))
+	pointCLIAt(t, serveKeys(t, public, nil).URL)
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr != nil {
+		t.Fatalf("a genuine export was refused: %v\n%s", verifyErr, out)
+	}
+	if !strings.Contains(out, "Signature verified with key key-1") {
+		t.Fatalf("output = %q", out)
+	}
+	if !strings.Contains(out, "Not that the records were true when written") {
+		t.Fatalf("the scope statement is missing: %q", out)
+	}
+}
+
+func TestEvidenceVerifyRefusesAnEditedExport(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One member edited, manifest untouched: the digest catches it before a
+	// key is ever needed.
+	edited := signedExport(t, private, "{\"decision\":\"allow\"}\n", "{\"decision\":\"deny_\"}\n")
+	path := writeTemp(t, "export.tar.gz", edited)
+	pointCLIAt(t, serveKeys(t, public, nil).URL)
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr == nil {
+		t.Fatalf("an edited export passed:\n%s", out)
+	}
+}
+
+func TestEvidenceVerifyRefusesAnExportSignedByAnotherKey(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPublic, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := writeTemp(t, "export.tar.gz", signedExport(t, private, "x", "x"))
+	pointCLIAt(t, serveKeys(t, otherPublic, nil).URL)
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr == nil {
+		t.Fatalf("a signature from an unpublished key passed:\n%s", out)
+	}
+	if !strings.Contains(out, "SIGNATURE NOT VERIFIED") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestEvidenceVerifyUsesAKeyTheCallerBrought(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := writeTemp(t, "export.tar.gz", signedExport(t, private, "x", "x"))
+	keyPath := writeTemp(t, "key.pub", []byte(base64.StdEncoding.EncodeToString(public)))
+	// No server at all: verification against a key you kept yourself is the
+	// strong form, and it must not need us.
+	pointCLIAt(t, "http://127.0.0.1:1")
+	evidencePublicKey = keyPath
+	evidenceJSON = true
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr != nil {
+		t.Fatalf("offline verification failed: %v\n%s", verifyErr, out)
+	}
+	var report evidenceVerifyReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if !report.SignatureOK || report.KeySource != "flag" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestEvidenceVerifyChecksAnEvidencePackAgainstItsReceipt(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := []byte("evidence pack bytes")
+	payload := map[string]interface{}{
+		"schema":         verify.PayloadEvidencePack,
+		"account_id":     "acct",
+		"artifact_id":    "artifact-1",
+		"execution_id":   "exec-1",
+		"archive_sha256": verify.DigestOfBytes(archive),
+		"size_bytes":     len(archive),
+		"created_at":     testSignedAt,
+	}
+	digest, err := verify.DigestOf(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(private, verify.SignedBytes(verify.PayloadEvidencePack, digest, testSignedAt))
+	receipt := map[string]interface{}{
+		"status":         "available",
+		"artifact_id":    "artifact-1",
+		"signing_key_id": "key-1",
+		"signature": map[string]interface{}{
+			"schema":       "preloop.signature/v1",
+			"algorithm":    verify.AlgorithmEd25519,
+			"key_id":       "key-1",
+			"payload_type": verify.PayloadEvidencePack,
+			"digest":       digest,
+			"signed_at":    testSignedAt,
+			"signature":    base64.StdEncoding.EncodeToString(signature),
+			"payload":      payload,
+		},
+	}
+	path := writeTemp(t, "evidence.tar.gz", archive)
+	pointCLIAt(t, serveKeys(t, public, receipt).URL)
+	evidenceExecutionID = "exec-1"
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr != nil {
+		t.Fatalf("a genuine pack was refused: %v\n%s", verifyErr, out)
+	}
+	if !strings.Contains(out, "Signature verified with key key-1") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestEvidenceVerifyRefusesAPackThatIsNotTheSignedOne(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := map[string]interface{}{
+		"schema":         verify.PayloadEvidencePack,
+		"artifact_id":    "artifact-1",
+		"archive_sha256": verify.DigestOfBytes([]byte("the pack that was captured")),
+	}
+	digest, err := verify.DigestOf(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(private, verify.SignedBytes(verify.PayloadEvidencePack, digest, testSignedAt))
+	receipt := map[string]interface{}{
+		"artifact_id": "artifact-1",
+		"signature": map[string]interface{}{
+			"algorithm":    verify.AlgorithmEd25519,
+			"key_id":       "key-1",
+			"payload_type": verify.PayloadEvidencePack,
+			"digest":       digest,
+			"signed_at":    testSignedAt,
+			"signature":    base64.StdEncoding.EncodeToString(signature),
+			"payload":      payload,
+		},
+	}
+	path := writeTemp(t, "evidence.tar.gz", []byte("a different pack entirely"))
+	pointCLIAt(t, serveKeys(t, public, receipt).URL)
+	evidenceExecutionID = "exec-1"
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr == nil {
+		t.Fatalf("the wrong archive passed:\n%s", out)
+	}
+	if !strings.Contains(out, "but this file is") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestEvidenceVerifySaysWhenAPackWasNeverSigned(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := map[string]interface{}{"artifact_id": "artifact-1", "signature": nil}
+	path := writeTemp(t, "evidence.tar.gz", []byte("bytes"))
+	pointCLIAt(t, serveKeys(t, public, receipt).URL)
+	evidenceExecutionID = "exec-1"
+
+	out, verifyErr := runEvidence(t, path)
+
+	if verifyErr == nil {
+		t.Fatal("an unsigned pack must not report a pass")
+	}
+	if !strings.Contains(out, "no signature") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestEvidenceVerifyReportsAMissingFilePlainly(t *testing.T) {
+	pointCLIAt(t, "http://127.0.0.1:1")
+
+	_, err := runEvidence(t, filepath.Join(t.TempDir(), "absent.tar.gz"))
+
+	if err == nil || !strings.Contains(err.Error(), "could not read") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -124,4 +124,6 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(flowCmd)
 	rootCmd.AddCommand(runnerCmd)
+	rootCmd.AddCommand(auditCmd)
+	rootCmd.AddCommand(evidenceCmd)
 }

--- a/cli/internal/verify/canonical.go
+++ b/cli/internal/verify/canonical.go
@@ -1,0 +1,168 @@
+// Package verify holds the client side of Preloop's tamper evidence: the
+// canonical JSON the platform hashes, the audit chain walk, and Ed25519
+// signature checking over exports and evidence packs.
+//
+// It exists as its own package for one reason. A verification that runs on
+// the server is worth exactly the trust you already place in the server, and
+// the whole point of a hash chain and a detached signature is to be checkable
+// by someone who does not extend that trust. Everything here recomputes from
+// material the API hands over, and disagreeing with the API is a supported
+// outcome.
+package verify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CanonicalJSON renders a decoded JSON value the way the platform does when
+// it hashes one: keys sorted, no insignificant whitespace, UTF-8 rather than
+// escaped non-ASCII.
+//
+// This mirrors Python's json.dumps(sort_keys=True, separators=(",", ":"),
+// ensure_ascii=False) rather than using encoding/json, which differs in three
+// ways that would each produce a wrong digest: it escapes HTML characters, it
+// escapes U+2028 and U+2029, and it spells the backspace and form feed
+// control characters in their six character form where Python uses the two
+// character escapes.
+//
+// Numbers are passed through as they arrived on the wire. The server produced
+// those digits when it hashed the value, so re-formatting them here could only
+// introduce a disagreement that is ours, not the server's.
+func CanonicalJSON(value interface{}) ([]byte, error) {
+	var out bytes.Buffer
+	if err := writeCanonical(&out, value); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// DecodeCanonical parses JSON in the form CanonicalJSON can re-render
+// faithfully: numbers keep their literal spelling instead of becoming
+// float64.
+func DecodeCanonical(raw []byte) (interface{}, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func writeCanonical(out *bytes.Buffer, value interface{}) error {
+	switch typed := value.(type) {
+	case nil:
+		out.WriteString("null")
+	case bool:
+		if typed {
+			out.WriteString("true")
+		} else {
+			out.WriteString("false")
+		}
+	case string:
+		writeCanonicalString(out, typed)
+	case json.Number:
+		out.WriteString(typed.String())
+	case float64:
+		// Only reachable when a caller decoded without UseNumber. Formatted
+		// the way encoding/json would, so the common cases still agree.
+		out.WriteString(formatFloat(typed))
+	case int:
+		fmt.Fprintf(out, "%d", typed)
+	case int64:
+		fmt.Fprintf(out, "%d", typed)
+	case []interface{}:
+		out.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				out.WriteByte(',')
+			}
+			if err := writeCanonical(out, item); err != nil {
+				return err
+			}
+		}
+		out.WriteByte(']')
+	case map[string]interface{}:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		// Byte order over valid UTF-8 is code point order, which is what
+		// Python's sorted() gives.
+		sort.Strings(keys)
+		out.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				out.WriteByte(',')
+			}
+			writeCanonicalString(out, key)
+			out.WriteByte(':')
+			if err := writeCanonical(out, typed[key]); err != nil {
+				return err
+			}
+		}
+		out.WriteByte('}')
+	default:
+		return fmt.Errorf("cannot canonicalise %T", value)
+	}
+	return nil
+}
+
+func formatFloat(value float64) string {
+	rendered, err := json.Marshal(value)
+	if err != nil {
+		return "0"
+	}
+	return string(rendered)
+}
+
+func writeCanonicalString(out *bytes.Buffer, value string) {
+	out.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"':
+			out.WriteString(`\"`)
+		case '\\':
+			out.WriteString(`\\`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\r':
+			out.WriteString(`\r`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\b':
+			out.WriteString(`\b`)
+		case '\f':
+			out.WriteString(`\f`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(out, `\u%04x`, r)
+				continue
+			}
+			out.WriteRune(r)
+		}
+	}
+	out.WriteByte('"')
+}
+
+// CanonicalFromRaw canonicalises a raw JSON document in one step.
+func CanonicalFromRaw(raw []byte) ([]byte, error) {
+	value, err := DecodeCanonical(raw)
+	if err != nil {
+		return nil, fmt.Errorf("not valid JSON: %w", err)
+	}
+	return CanonicalJSON(value)
+}
+
+// Indent renders a value for human output. Verification never depends on it.
+func Indent(value interface{}) string {
+	rendered, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return strings.TrimSpace(string(rendered))
+}

--- a/cli/internal/verify/canonical_test.go
+++ b/cli/internal/verify/canonical_test.go
@@ -1,0 +1,182 @@
+package verify
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// Fixtures produced by the backend itself (json.dumps with sort_keys=True,
+// separators=(",", ":"), ensure_ascii=False). If Go and Python ever disagree
+// about a byte, every digest downstream disagrees too, so these are pinned
+// rather than derived.
+const (
+	pythonSimple  = `{"a":"x","b":1}`
+	pythonEscapes = "{\"back\":\"a\\\\b\",\"ctrl\":\"\\u0000\\u001f\",\"ls\":\"\u2028\",\"nl\":\"l1\\nl2\",\"quote\":\"he said \\\"hi\\\"\",\"tab\":\"\\t\",\"unicode\":\"héllo → ✓\"}"
+	pythonNumbers = `{"nested":{"z":[{"k":"v"}]},"null":null,"nums":[1,-2,3.5,1e+30,0.1],"true":true}`
+	pythonHTML    = `{"html":"<a href=\"x\">&amp;</a>"}`
+
+	// One sealed audit row, exactly as the chain hashes it.
+	pythonRowPayload = `{"account_id":"11111111-2222-4333-8444-555555555555","action":"tool_call_approved","details":{"amount":1000,"note":"héllo → ✓","quote":"he said \"hi\""},"prev_hash":"0000000000000000000000000000000000000000000000000000000000000000","resource_id":"send_payment","resource_type":"tool","seq":1,"status":"success","timestamp":"2026-09-10T12:00:00Z","user_id":null}`
+	pythonRowHash    = "ae72cf4cfed8f69d496bfdbdb2a882c2b649490aff71d8a227111fb682a684a3"
+
+	// A period export manifest, its digest, and a real Ed25519 signature made
+	// by the backend's signing helper over the documented signed bytes.
+	pythonManifest       = `{"members":[{"name":"a.jsonl","sha256":"abababababababababababababababababababababababababababababababab","size_bytes":3}],"schema":"preloop.retention.period_export_manifest/v1"}`
+	pythonManifestDigest = "0817faab16f36165276b90f9abe2c3c0e05985bdebec816f12c6a106e50f1c55"
+	pythonPublicKey      = "qIM9T+5jtMNY1L4e/QiY6q/Axe9dIKfefLKKiejuJCQ="
+	pythonSignature      = "eCHzwR9c4CQFHj5NbTJRYfzhflMRZzoEiL2EDOSZWt4AMf2qYwqilhvCPuiJrY6ijhR9g9nJeI/+ZVkhCm4IDg=="
+	pythonSignedAt       = "2026-09-10T12:00:00Z"
+)
+
+func canonicalOf(t *testing.T, raw string) string {
+	t.Helper()
+	out, err := CanonicalFromRaw([]byte(raw))
+	if err != nil {
+		t.Fatalf("canonicalise %q: %v", raw, err)
+	}
+	return string(out)
+}
+
+func TestCanonicalJSONReproducesThePlatformsBytes(t *testing.T) {
+	for _, fixture := range []string{
+		pythonSimple, pythonEscapes, pythonNumbers, pythonHTML, `[]`, `{}`,
+		pythonRowPayload, pythonManifest,
+	} {
+		if got := canonicalOf(t, fixture); got != fixture {
+			t.Fatalf("canonical JSON differs from the platform\n want %s\n got  %s", fixture, got)
+		}
+	}
+}
+
+func TestCanonicalJSONSortsKeysAndDropsWhitespace(t *testing.T) {
+	got := canonicalOf(t, "{\n  \"b\": 1,\n  \"a\": \"x\"\n}")
+
+	if got != pythonSimple {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestRowHashMatchesTheServersHashForTheSameRow(t *testing.T) {
+	payload, err := DecodeCanonical([]byte(pythonRowPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := RowHash(RowDomainV1, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != pythonRowHash {
+		t.Fatalf("row hash = %s, want %s", got, pythonRowHash)
+	}
+}
+
+func TestRowHashChangesWhenTheDomainDoes(t *testing.T) {
+	payload, _ := DecodeCanonical([]byte(pythonRowPayload))
+
+	// Domain separation is the reason a signature over one payload type
+	// cannot be replayed as another. If the domain were ignored, this would
+	// come back equal.
+	got, err := RowHash("preloop.audit.chain/v2\n", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got == pythonRowHash {
+		t.Fatal("the domain separator is not being hashed")
+	}
+}
+
+func TestDigestOfMatchesTheServerForAManifest(t *testing.T) {
+	manifest, _ := DecodeCanonical([]byte(pythonManifest))
+
+	digest, err := DigestOf(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if digest != pythonManifestDigest {
+		t.Fatalf("digest = %s, want %s", digest, pythonManifestDigest)
+	}
+}
+
+func pythonSignedDocument() SignatureDocument {
+	return SignatureDocument{
+		Schema:      "preloop.signature/v1",
+		Algorithm:   AlgorithmEd25519,
+		KeyID:       "key-1",
+		PayloadType: PayloadPeriodExport,
+		Digest:      pythonManifestDigest,
+		SignedAt:    pythonSignedAt,
+		Signature:   pythonSignature,
+	}
+}
+
+func pythonKey() PublicKey {
+	return PublicKey{KeyID: "key-1", Algorithm: AlgorithmEd25519, PublicKey: pythonPublicKey, Active: true}
+}
+
+func TestASignatureMadeByTheBackendVerifiesHere(t *testing.T) {
+	if err := CheckSignature(pythonSignedDocument(), pythonKey(), pythonManifestDigest); err != nil {
+		t.Fatalf("a genuine signature was refused: %v", err)
+	}
+}
+
+func TestASignatureIsRefusedForOtherBytes(t *testing.T) {
+	document := pythonSignedDocument()
+
+	err := CheckSignature(document, pythonKey(), "ff"+pythonManifestDigest[2:])
+
+	if err == nil {
+		t.Fatal("a digest that is not the signed one was accepted")
+	}
+}
+
+func TestASignatureCannotBeReplayedAsAnotherPayloadType(t *testing.T) {
+	document := pythonSignedDocument()
+	document.PayloadType = PayloadEvidencePack
+
+	// The payload type is inside the signed bytes precisely so that a
+	// manifest signature cannot be presented as an evidence pack signature.
+	if err := CheckSignature(document, pythonKey(), pythonManifestDigest); err == nil {
+		t.Fatal("a signature was accepted under a different payload type")
+	}
+}
+
+func TestASignatureIsRefusedWhenTheTimestampIsChanged(t *testing.T) {
+	document := pythonSignedDocument()
+	document.SignedAt = "2026-09-11T12:00:00Z"
+
+	if err := CheckSignature(document, pythonKey(), pythonManifestDigest); err == nil {
+		t.Fatal("signed_at is not covered by the signature")
+	}
+}
+
+func TestAnotherKeyDoesNotVerifyThisSignature(t *testing.T) {
+	other := pythonKey()
+	raw, _ := base64.StdEncoding.DecodeString(pythonPublicKey)
+	raw[0] ^= 0xff
+	other.PublicKey = base64.StdEncoding.EncodeToString(raw)
+
+	if err := CheckSignature(pythonSignedDocument(), other, pythonManifestDigest); err == nil {
+		t.Fatal("a wrong key verified the signature")
+	}
+}
+
+func TestAMissingKeyIsNotAPass(t *testing.T) {
+	err := CheckSignature(pythonSignedDocument(), PublicKey{}, pythonManifestDigest)
+
+	if err == nil {
+		t.Fatal("verification with no key must not succeed")
+	}
+}
+
+func TestGarbageInThePlaceOfASignatureIsRefused(t *testing.T) {
+	document := pythonSignedDocument()
+	document.Signature = "not base64 at all !!"
+
+	if err := CheckSignature(document, pythonKey(), pythonManifestDigest); err == nil {
+		t.Fatal("a malformed signature was accepted")
+	}
+}

--- a/cli/internal/verify/chain.go
+++ b/cli/internal/verify/chain.go
@@ -1,0 +1,216 @@
+package verify
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenesisHash is the prev_hash of the first row in an account's chain.
+const GenesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// RowDomainV1 is the domain separator hashed in front of every row payload.
+// It is served with each segment as well, so a future version does not need a
+// new CLI, but a default here means a walk never depends on the server to
+// tell it how to hash.
+const RowDomainV1 = "preloop.audit.chain/v1\n"
+
+// Break kinds, spelled the same as the server's so a report from either side
+// can be compared without translation.
+const (
+	BreakMissingRow   = "missing_row"
+	BreakPrevHash     = "prev_hash_mismatch"
+	BreakRowHash      = "row_hash_mismatch"
+	BreakDuplicateSeq = "duplicate_seq"
+)
+
+// SegmentEntry is one row's chain material as the segment endpoint serves it.
+type SegmentEntry struct {
+	Seq      int64                  `json:"seq"`
+	RowID    string                 `json:"row_id"`
+	PrevHash string                 `json:"prev_hash"`
+	RowHash  string                 `json:"row_hash"`
+	Payload  map[string]interface{} `json:"payload"`
+}
+
+// Segment is one page of the chain.
+type Segment struct {
+	AccountID      string         `json:"account_id"`
+	RowDomain      string         `json:"row_domain"`
+	AfterSeq       int64          `json:"after_seq"`
+	HeadSeq        int64          `json:"head_seq"`
+	PrunedBelowSeq int64          `json:"pruned_below_seq"`
+	GenesisHash    string         `json:"genesis_hash"`
+	Entries        []SegmentEntry `json:"entries"`
+	HasMore        bool           `json:"has_more"`
+	Note           string         `json:"note"`
+}
+
+// Break is the first place a local walk stopped agreeing with the chain.
+type Break struct {
+	Kind     string `json:"kind"`
+	Seq      int64  `json:"seq"`
+	RowID    string `json:"row_id,omitempty"`
+	Expected string `json:"expected,omitempty"`
+	Found    string `json:"found,omitempty"`
+	Detail   string `json:"detail"`
+}
+
+// ChainWalk accumulates a verification across pages of the chain.
+type ChainWalk struct {
+	rowDomain    string
+	expectedPrev string
+	expectedSeq  int64
+	started      bool
+
+	// Checked is how many rows this walk recomputed.
+	Checked int64
+	// FirstSeq and LastSeq bound what was actually covered, which is the
+	// only range the result speaks about.
+	FirstSeq int64
+	LastSeq  int64
+	// Break is nil while the chain still agrees with itself.
+	Break *Break
+
+	watch map[int64]bool
+	// Observed holds the recomputed row hash at each watched sequence.
+	Observed map[int64]string
+}
+
+// NewChainWalk starts a walk that expects the row after afterSeq next.
+//
+// expectedPrev is the row_hash the first row must commit to: the genesis hash
+// when starting from the beginning, otherwise the hash of the row before the
+// range. Passing an empty string means "take the first row's word for it",
+// which is the honest state when a walk starts in the middle and the caller
+// has nothing to anchor against.
+func NewChainWalk(rowDomain string, afterSeq int64, expectedPrev string) *ChainWalk {
+	return &ChainWalk{
+		rowDomain:    rowDomain,
+		expectedPrev: expectedPrev,
+		expectedSeq:  afterSeq + 1,
+	}
+}
+
+// RowHash recomputes one row's hash from the payload the API served.
+func RowHash(rowDomain string, payload interface{}) (string, error) {
+	body, err := CanonicalJSON(payload)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.New()
+	digest.Write([]byte(rowDomain))
+	digest.Write(body)
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+// Feed walks one page. It returns false once a break is found: everything
+// after the first break is a consequence of it, and reporting the cascade
+// would bury the one row that matters.
+func (w *ChainWalk) Feed(entries []SegmentEntry) bool {
+	for _, entry := range entries {
+		if w.Break != nil {
+			return false
+		}
+		if entry.Seq < w.expectedSeq {
+			w.Break = &Break{
+				Kind:   BreakDuplicateSeq,
+				Seq:    entry.Seq,
+				RowID:  entry.RowID,
+				Detail: "two rows share one chain sequence",
+			}
+			return false
+		}
+		if entry.Seq > w.expectedSeq {
+			w.Break = &Break{
+				Kind: BreakMissingRow,
+				Seq:  w.expectedSeq,
+				Detail: fmt.Sprintf(
+					"sequence %d is missing; the chain jumps to %d",
+					w.expectedSeq, entry.Seq,
+				),
+			}
+			return false
+		}
+		if w.expectedPrev != "" && entry.PrevHash != w.expectedPrev {
+			w.Break = &Break{
+				Kind:     BreakPrevHash,
+				Seq:      entry.Seq,
+				RowID:    entry.RowID,
+				Expected: w.expectedPrev,
+				Found:    entry.PrevHash,
+				Detail:   "this row does not point at the row before it",
+			}
+			return false
+		}
+		computed, err := RowHash(w.rowDomain, entry.Payload)
+		if err != nil {
+			w.Break = &Break{
+				Kind:   BreakRowHash,
+				Seq:    entry.Seq,
+				RowID:  entry.RowID,
+				Detail: fmt.Sprintf("row payload cannot be canonicalised: %v", err),
+			}
+			return false
+		}
+		if computed != entry.RowHash {
+			w.Break = &Break{
+				Kind:     BreakRowHash,
+				Seq:      entry.Seq,
+				RowID:    entry.RowID,
+				Expected: entry.RowHash,
+				Found:    computed,
+				Detail:   "the row content does not match the hash sealed for it",
+			}
+			return false
+		}
+		if !w.started {
+			w.FirstSeq = entry.Seq
+			w.started = true
+		}
+		w.LastSeq = entry.Seq
+		w.Checked++
+		if w.watch[entry.Seq] {
+			w.Observed[entry.Seq] = computed
+		}
+		w.expectedPrev = entry.RowHash
+		w.expectedSeq = entry.Seq + 1
+	}
+	return true
+}
+
+// Head is the row_hash the walk ended on, which is what a checkpoint at that
+// sequence has to agree with.
+func (w *ChainWalk) Head() string {
+	return w.expectedPrev
+}
+
+// OK reports whether the walk found no break. An empty range is not a
+// failure: there was nothing to disagree with.
+func (w *ChainWalk) OK() bool {
+	return w.Break == nil
+}
+
+// Watch asks the walk to remember the row hash at these sequences, so a
+// checkpoint taken at one of them can be held against what the rows in hand
+// actually hash to today.
+func (w *ChainWalk) Watch(seqs []int64) {
+	if w.watch == nil {
+		w.watch = map[int64]bool{}
+	}
+	if w.Observed == nil {
+		w.Observed = map[int64]string{}
+	}
+	for _, seq := range seqs {
+		w.watch[seq] = true
+	}
+}
+
+// SetRowDomain adopts the domain separator the server serves with a segment.
+// A server that changes it mid walk changes every hash from that point, which
+// the walk then reports as a break rather than quietly accepting.
+func (w *ChainWalk) SetRowDomain(domain string) {
+	if domain != "" {
+		w.rowDomain = domain
+	}
+}

--- a/cli/internal/verify/chain_test.go
+++ b/cli/internal/verify/chain_test.go
@@ -1,0 +1,188 @@
+package verify
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildChain makes a chain of n rows the way the sealer does, so the walk is
+// tested against material that hashes the same way the platform's does.
+func buildChain(t *testing.T, count int) []SegmentEntry {
+	t.Helper()
+	entries := make([]SegmentEntry, 0, count)
+	prev := GenesisHash
+	for index := 1; index <= count; index++ {
+		payload := map[string]interface{}{
+			"seq":           index,
+			"prev_hash":     prev,
+			"action":        fmt.Sprintf("action_%d", index),
+			"resource_type": "tool",
+			"status":        "success",
+		}
+		hash, err := RowHash(RowDomainV1, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, SegmentEntry{
+			Seq:      int64(index),
+			RowID:    fmt.Sprintf("row-%d", index),
+			PrevHash: prev,
+			RowHash:  hash,
+			Payload:  payload,
+		})
+		prev = hash
+	}
+	return entries
+}
+
+func walkAll(entries []SegmentEntry) *ChainWalk {
+	walk := NewChainWalk(RowDomainV1, 0, GenesisHash)
+	walk.Feed(entries)
+	return walk
+}
+
+func TestAWholeChainWalksClean(t *testing.T) {
+	walk := walkAll(buildChain(t, 25))
+
+	if !walk.OK() {
+		t.Fatalf("a good chain reported a break: %+v", walk.Break)
+	}
+	if walk.Checked != 25 || walk.FirstSeq != 1 || walk.LastSeq != 25 {
+		t.Fatalf("checked %d rows, %d to %d", walk.Checked, walk.FirstSeq, walk.LastSeq)
+	}
+}
+
+func TestAnEditedRowIsCaughtAtItsOwnSequence(t *testing.T) {
+	entries := buildChain(t, 10)
+	// The edit a tamperer would make: change the record, leave the hashes.
+	entries[4].Payload["status"] = "failure"
+
+	walk := walkAll(entries)
+
+	if walk.OK() {
+		t.Fatal("an edited row walked clean")
+	}
+	if walk.Break.Kind != BreakRowHash || walk.Break.Seq != 5 {
+		t.Fatalf("break = %+v", walk.Break)
+	}
+	if walk.Break.RowID != "row-5" {
+		t.Fatalf("break names row %q", walk.Break.RowID)
+	}
+	if walk.Checked != 4 {
+		t.Fatalf("checked %d rows before the break", walk.Checked)
+	}
+}
+
+func TestARowDeletedFromTheMiddleIsCaught(t *testing.T) {
+	entries := buildChain(t, 10)
+	entries = append(entries[:3], entries[4:]...)
+
+	walk := walkAll(entries)
+
+	if walk.OK() {
+		t.Fatal("a deleted row walked clean")
+	}
+	if walk.Break.Kind != BreakMissingRow || walk.Break.Seq != 4 {
+		t.Fatalf("break = %+v", walk.Break)
+	}
+}
+
+func TestARelinkedRowIsCaughtByItsPrevHash(t *testing.T) {
+	entries := buildChain(t, 6)
+	// Re-hash a row over a different predecessor: the row hash is now
+	// self-consistent, and the link to the row before it is not.
+	entries[3].PrevHash = GenesisHash
+	entries[3].Payload["prev_hash"] = GenesisHash
+	rehashed, err := RowHash(RowDomainV1, entries[3].Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries[3].RowHash = rehashed
+
+	walk := walkAll(entries)
+
+	if walk.OK() {
+		t.Fatal("a relinked row walked clean")
+	}
+	if walk.Break.Kind != BreakPrevHash || walk.Break.Seq != 4 {
+		t.Fatalf("break = %+v", walk.Break)
+	}
+}
+
+func TestOnlyTheFirstBreakIsReported(t *testing.T) {
+	entries := buildChain(t, 10)
+	entries[2].Payload["status"] = "failure"
+	entries[7].Payload["status"] = "failure"
+
+	walk := walkAll(entries)
+
+	// Everything after the first break is a consequence of it, and burying
+	// the one row that matters under the cascade helps nobody.
+	if walk.Break.Seq != 3 {
+		t.Fatalf("break = %+v", walk.Break)
+	}
+}
+
+func TestAWalkResumesAcrossPages(t *testing.T) {
+	entries := buildChain(t, 30)
+	walk := NewChainWalk(RowDomainV1, 0, GenesisHash)
+
+	walk.Feed(entries[:10])
+	walk.Feed(entries[10:20])
+	walk.Feed(entries[20:])
+
+	if !walk.OK() || walk.Checked != 30 {
+		t.Fatalf("paged walk: checked %d, break %+v", walk.Checked, walk.Break)
+	}
+	if walk.Head() != entries[29].RowHash {
+		t.Fatal("the walk did not end on the last row hash")
+	}
+}
+
+func TestAWalkStartingInTheMiddleTakesTheFirstRowsWord(t *testing.T) {
+	entries := buildChain(t, 20)
+
+	// Starting after a retention purge there is nothing to anchor against,
+	// and pretending otherwise would report the purge as tampering.
+	walk := NewChainWalk(RowDomainV1, 10, "")
+	walk.Feed(entries[10:])
+
+	if !walk.OK() || walk.FirstSeq != 11 || walk.Checked != 10 {
+		t.Fatalf("partial walk: %d rows from %d, break %+v", walk.Checked, walk.FirstSeq, walk.Break)
+	}
+}
+
+func TestAnEmptyRangeIsNotAFailure(t *testing.T) {
+	walk := NewChainWalk(RowDomainV1, 0, GenesisHash)
+
+	walk.Feed(nil)
+
+	if !walk.OK() || walk.Checked != 0 {
+		t.Fatalf("empty walk: %+v", walk.Break)
+	}
+}
+
+func TestWatchedSequencesRecordWhatTheRowsHashToNow(t *testing.T) {
+	entries := buildChain(t, 12)
+	walk := NewChainWalk(RowDomainV1, 0, GenesisHash)
+	walk.Watch([]int64{10})
+
+	walk.Feed(entries)
+
+	// This is what makes a checkpoint worth keeping: the anchor from before
+	// is compared with what the rows served today hash to.
+	if walk.Observed[10] != entries[9].RowHash {
+		t.Fatalf("observed %q at seq 10", walk.Observed[10])
+	}
+}
+
+func TestARepeatedSequenceIsCaught(t *testing.T) {
+	entries := buildChain(t, 5)
+	entries = append(entries, entries[4])
+
+	walk := walkAll(entries)
+
+	if walk.OK() || walk.Break.Kind != BreakDuplicateSeq {
+		t.Fatalf("break = %+v", walk.Break)
+	}
+}

--- a/cli/internal/verify/export.go
+++ b/cli/internal/verify/export.go
@@ -1,0 +1,186 @@
+package verify
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Member names fixed by the server side builder
+// (backend/preloop/services/retention_export.py).
+const (
+	ManifestMember  = "manifest.json"
+	SignatureMember = "signature.json"
+)
+
+// maxArchiveBytes bounds what a verifier will expand from an archive it was
+// handed. A period export is a compliance artifact of known scale, and a
+// verifier that can be made to allocate without limit by the file it is
+// checking is not much of a verifier.
+const maxArchiveBytes = 512 << 20
+
+// MemberResult is one member of an export and whether its bytes still match
+// the digest the manifest claims.
+type MemberResult struct {
+	Name     string `json:"name"`
+	Declared string `json:"declared_sha256"`
+	Computed string `json:"computed_sha256"`
+	Size     int    `json:"size_bytes"`
+	OK       bool   `json:"ok"`
+	Problem  string `json:"problem,omitempty"`
+}
+
+// ExportResult is everything a local check of a period export can establish
+// before a key is involved.
+type ExportResult struct {
+	ArchiveSha256  string                 `json:"archive_sha256"`
+	ManifestSha256 string                 `json:"manifest_sha256"`
+	Manifest       map[string]interface{} `json:"-"`
+	Members        []MemberResult         `json:"members"`
+	MembersDigest  struct {
+		Declared string `json:"declared"`
+		Computed string `json:"computed"`
+		OK       bool   `json:"ok"`
+	} `json:"members_digest"`
+	Signature *SignatureDocument `json:"signature,omitempty"`
+	// Problems are the failures found without needing a key: a member whose
+	// bytes moved, a manifest that lists a member the archive does not hold.
+	Problems []string `json:"problems,omitempty"`
+}
+
+// ContentOK reports whether the archive is internally consistent. It says
+// nothing about who built it: that is what the signature is for.
+func (r ExportResult) ContentOK() bool {
+	return len(r.Problems) == 0
+}
+
+// ReadExport unpacks a period export and checks it against its own manifest.
+func ReadExport(archive []byte) (ExportResult, error) {
+	result := ExportResult{ArchiveSha256: DigestOfBytes(archive)}
+	members, err := untar(archive)
+	if err != nil {
+		return result, err
+	}
+	manifestBody, ok := members[ManifestMember]
+	if !ok {
+		return result, fmt.Errorf("the archive has no %s", ManifestMember)
+	}
+	result.ManifestSha256 = DigestOfBytes(manifestBody)
+	manifest, err := DecodeCanonical(manifestBody)
+	if err != nil {
+		return result, fmt.Errorf("%s is not JSON: %w", ManifestMember, err)
+	}
+	object, ok := manifest.(map[string]interface{})
+	if !ok {
+		return result, fmt.Errorf("%s is not a JSON object", ManifestMember)
+	}
+	result.Manifest = object
+
+	declared, _ := object["members"].([]interface{})
+	seen := map[string]bool{ManifestMember: true, SignatureMember: true}
+	for _, raw := range declared {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			result.Problems = append(result.Problems, "a member entry is not an object")
+			continue
+		}
+		name, _ := entry["name"].(string)
+		wanted, _ := entry["sha256"].(string)
+		seen[name] = true
+		body, present := members[name]
+		if !present {
+			result.Members = append(result.Members, MemberResult{
+				Name: name, Declared: wanted,
+				Problem: "the manifest lists this member but the archive does not hold it",
+			})
+			result.Problems = append(result.Problems, "missing member "+name)
+			continue
+		}
+		computed := DigestOfBytes(body)
+		member := MemberResult{
+			Name:     name,
+			Declared: wanted,
+			Computed: computed,
+			Size:     len(body),
+			OK:       computed == wanted,
+		}
+		if !member.OK {
+			member.Problem = "the bytes in the archive do not match the digest the manifest claims"
+			result.Problems = append(result.Problems, "altered member "+name)
+		}
+		result.Members = append(result.Members, member)
+	}
+	for name := range members {
+		if !seen[name] {
+			// An extra member is not automatically an attack, but the
+			// manifest is supposed to be the complete list, so an unlisted
+			// file is outside everything the signature covers.
+			result.Problems = append(result.Problems, "unlisted member "+name)
+		}
+	}
+	sort.Slice(result.Members, func(i, j int) bool {
+		return result.Members[i].Name < result.Members[j].Name
+	})
+
+	result.MembersDigest.Declared, _ = object["members_digest"].(string)
+	if declared != nil {
+		computed, err := DigestOf(declared)
+		if err != nil {
+			return result, fmt.Errorf("cannot canonicalise the member list: %w", err)
+		}
+		result.MembersDigest.Computed = computed
+	}
+	result.MembersDigest.OK = result.MembersDigest.Declared != "" &&
+		result.MembersDigest.Declared == result.MembersDigest.Computed
+	if !result.MembersDigest.OK {
+		result.Problems = append(result.Problems, "members_digest does not cover this member list")
+	}
+
+	if body, present := members[SignatureMember]; present {
+		var document SignatureDocument
+		if err := json.Unmarshal(body, &document); err != nil {
+			return result, fmt.Errorf("%s is not JSON: %w", SignatureMember, err)
+		}
+		result.Signature = &document
+	}
+	return result, nil
+}
+
+// untar expands a gzipped tar into memory, refusing paths that try to escape.
+func untar(archive []byte) (map[string][]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("not a gzip archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	reader := tar.NewReader(gz)
+	members := map[string][]byte{}
+	budget := int64(maxArchiveBytes)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("not a tar archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		body, err := io.ReadAll(io.LimitReader(reader, budget+1))
+		if err != nil {
+			return nil, fmt.Errorf("cannot read member %q: %w", header.Name, err)
+		}
+		budget -= int64(len(body))
+		if budget < 0 {
+			return nil, errors.New("archive expands past the size a verifier will hold in memory")
+		}
+		members[header.Name] = body
+	}
+	return members, nil
+}

--- a/cli/internal/verify/export_test.go
+++ b/cli/internal/verify/export_test.go
@@ -1,0 +1,279 @@
+package verify
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// buildExport packs an archive the way build_period_export does: a manifest
+// that digests every member, plus a detached signature over the manifest
+// bytes as packed.
+func buildExport(t *testing.T, members map[string][]byte, signer ed25519.PrivateKey) []byte {
+	t.Helper()
+	entries := []interface{}{}
+	for _, name := range sortedNames(members) {
+		entries = append(entries, map[string]interface{}{
+			"name":       name,
+			"size_bytes": len(members[name]),
+			"sha256":     DigestOfBytes(members[name]),
+		})
+	}
+	membersDigest, err := DigestOf(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]interface{}{
+		"schema":         "preloop.retention.period_export_manifest/v1",
+		"account_id":     "acct",
+		"members":        entries,
+		"members_digest": membersDigest,
+	}
+	manifestBody, err := CanonicalJSON(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{ManifestMember: manifestBody}
+	for name, body := range members {
+		files[name] = body
+	}
+	if signer != nil {
+		digest := DigestOfBytes(manifestBody)
+		signature := ed25519.Sign(signer, SignedBytes(PayloadPeriodExport, digest, pythonSignedAt))
+		document := map[string]interface{}{
+			"schema":       "preloop.signature/v1",
+			"algorithm":    AlgorithmEd25519,
+			"key_id":       "key-1",
+			"payload_type": PayloadPeriodExport,
+			"digest":       digest,
+			"signed_at":    pythonSignedAt,
+			"signature":    base64.StdEncoding.EncodeToString(signature),
+		}
+		body, err := json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[SignatureMember] = body
+	}
+	return packTar(t, files)
+}
+
+func sortedNames(members map[string][]byte) []string {
+	names := make([]string, 0, len(members))
+	for name := range members {
+		names = append(names, name)
+	}
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[j] < names[i] {
+				names[i], names[j] = names[j], names[i]
+			}
+		}
+	}
+	return names
+}
+
+func packTar(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gz := gzip.NewWriter(&buffer)
+	writer := tar.NewWriter(gz)
+	for _, name := range sortedNames(files) {
+		header := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(files[name]))}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(files[name]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func testKeyPair(t *testing.T) (ed25519.PrivateKey, PublicKey) {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return private, PublicKey{
+		KeyID:     "key-1",
+		Algorithm: AlgorithmEd25519,
+		PublicKey: base64.StdEncoding.EncodeToString(public),
+		Active:    true,
+	}
+}
+
+func TestAWellFormedExportChecksOutAndVerifies(t *testing.T) {
+	private, public := testKeyPair(t)
+	archive := buildExport(t, map[string][]byte{
+		"audit/audit_log.jsonl":  []byte("{\"action\":\"a\"}\n"),
+		"holds/legal_hold.jsonl": []byte(""),
+	}, private)
+
+	result, err := ReadExport(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.ContentOK() {
+		t.Fatalf("problems on a good archive: %v", result.Problems)
+	}
+	if result.Signature == nil {
+		t.Fatal("no signature found")
+	}
+	if err := CheckSignature(*result.Signature, public, result.ManifestSha256); err != nil {
+		t.Fatalf("signature refused: %v", err)
+	}
+}
+
+func TestAnAlteredMemberIsCaughtWithoutAnyKey(t *testing.T) {
+	private, _ := testKeyPair(t)
+	archive := buildExport(t, map[string][]byte{
+		"audit/audit_log.jsonl": []byte("{\"decision\":\"allow\"}\n"),
+	}, private)
+	// Rebuild the archive with one byte of the member changed and the
+	// manifest left alone, which is the cheapest tamper available.
+	tampered := buildTamperedExport(t, archive)
+	after, err := ReadExport(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.ContentOK() {
+		t.Fatal("an altered member passed the digest check")
+	}
+	if len(after.Problems) == 0 || after.Members[0].OK {
+		t.Fatalf("problems = %v", after.Problems)
+	}
+}
+
+// buildTamperedExport re-packs an archive with one member's bytes changed
+// and the manifest untouched.
+func buildTamperedExport(t *testing.T, archive []byte) []byte {
+	t.Helper()
+	members, err := untar(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members["audit/audit_log.jsonl"] = bytes.Replace(
+		members["audit/audit_log.jsonl"], []byte("allow"), []byte("deny_"), 1)
+	return packTar(t, members)
+}
+
+func TestAMemberTheManifestNeverListedIsReported(t *testing.T) {
+	private, _ := testKeyPair(t)
+	archive := buildExport(t, map[string][]byte{"audit/audit_log.jsonl": []byte("x")}, private)
+	members, err := untar(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members["extra/notes.txt"] = []byte("added later")
+
+	result, err := ReadExport(packTar(t, members))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An unlisted file is outside everything the signature covers, so it is
+	// reported rather than ignored.
+	if result.ContentOK() {
+		t.Fatal("an unlisted member passed")
+	}
+}
+
+func TestAMemberRemovedFromTheArchiveIsReported(t *testing.T) {
+	private, _ := testKeyPair(t)
+	archive := buildExport(t, map[string][]byte{
+		"audit/audit_log.jsonl":  []byte("x"),
+		"holds/legal_hold.jsonl": []byte("y"),
+	}, private)
+	members, err := untar(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(members, "holds/legal_hold.jsonl")
+
+	result, err := ReadExport(packTar(t, members))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ContentOK() {
+		t.Fatal("a missing member passed")
+	}
+}
+
+func TestARewrittenManifestBreaksTheSignature(t *testing.T) {
+	private, public := testKeyPair(t)
+	archive := buildExport(t, map[string][]byte{"audit/audit_log.jsonl": []byte("allow")}, private)
+	members, err := untar(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The full forgery: change the member and repair the manifest around it.
+	members["audit/audit_log.jsonl"] = []byte("deny_")
+	manifest, err := DecodeCanonical(members[ManifestMember])
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := manifest.(map[string]interface{})
+	entries := object["members"].([]interface{})
+	entries[0].(map[string]interface{})["sha256"] = DigestOfBytes(members["audit/audit_log.jsonl"])
+	digest, err := DigestOf(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object["members_digest"] = digest
+	rebuilt, err := CanonicalJSON(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members[ManifestMember] = rebuilt
+
+	result, err := ReadExport(packTar(t, members))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The archive is now internally consistent, which is exactly why the
+	// signature is the part that matters.
+	if !result.ContentOK() {
+		t.Fatalf("expected a self-consistent forgery, problems: %v", result.Problems)
+	}
+	if err := CheckSignature(*result.Signature, public, result.ManifestSha256); err == nil {
+		t.Fatal("a forged manifest verified")
+	}
+}
+
+func TestAnArchiveWithoutASignatureIsStillReadable(t *testing.T) {
+	archive := buildExport(t, map[string][]byte{"audit/audit_log.jsonl": []byte("x")}, nil)
+
+	result, err := ReadExport(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Signature != nil {
+		t.Fatal("found a signature that was never made")
+	}
+	if !result.ContentOK() {
+		t.Fatalf("problems = %v", result.Problems)
+	}
+}
+
+func TestSomethingThatIsNotAnArchiveIsAnError(t *testing.T) {
+	if _, err := ReadExport([]byte("this is not a tar.gz")); err == nil {
+		t.Fatal("expected an error")
+	}
+}

--- a/cli/internal/verify/signature.go
+++ b/cli/internal/verify/signature.go
@@ -1,0 +1,125 @@
+package verify
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// The signature wire format, documented here because a verifier has to
+// reproduce it byte for byte.
+const (
+	SignatureDomain      = "preloop.signature/v1\n"
+	PayloadPeriodExport  = "preloop.retention.period_export_manifest/v1"
+	PayloadEvidencePack  = "preloop.cra.evidence_manifest/v1"
+	PayloadAuditCheckpnt = "preloop.audit.chain_checkpoint/v1"
+	AlgorithmEd25519     = "ed25519"
+)
+
+// ErrNoKey is returned when nothing published a public key for the key id a
+// signature names. It is a distinct error because it is not a failed
+// verification: it is a verification that could not be performed.
+var ErrNoKey = errors.New("no public key for this key id")
+
+// SignatureDocument is a detached signature as it appears in signature.json,
+// on a receipt, or beside a checkpoint.
+type SignatureDocument struct {
+	Schema      string                 `json:"schema"`
+	Algorithm   string                 `json:"algorithm"`
+	KeyID       string                 `json:"key_id"`
+	PayloadType string                 `json:"payload_type"`
+	Digest      string                 `json:"digest"`
+	SignedAt    string                 `json:"signed_at"`
+	Signature   string                 `json:"signature"`
+	Payload     map[string]interface{} `json:"payload,omitempty"`
+}
+
+// PublicKey is one published key, public half only.
+type PublicKey struct {
+	KeyID     string `json:"key_id"`
+	Algorithm string `json:"algorithm"`
+	PublicKey string `json:"public_key"`
+	Active    bool   `json:"active"`
+	CreatedAt string `json:"created_at"`
+	RetiredAt string `json:"retired_at"`
+}
+
+// KeyList is the response of the signing keys endpoint.
+type KeyList struct {
+	ActiveKeyID       string      `json:"active_key_id"`
+	SignatureSchema   string      `json:"signature_schema"`
+	SignedBytesFormat string      `json:"signed_bytes_format"`
+	Keys              []PublicKey `json:"keys"`
+}
+
+// Find returns the published key with this id.
+func (l KeyList) Find(keyID string) (PublicKey, bool) {
+	for _, key := range l.Keys {
+		if key.KeyID == keyID {
+			return key, true
+		}
+	}
+	return PublicKey{}, false
+}
+
+// SignedBytes rebuilds the exact bytes a signature covers.
+func SignedBytes(payloadType, digest, signedAt string) []byte {
+	return []byte(SignatureDomain + payloadType + "\n" + digest + "\n" + signedAt)
+}
+
+// DigestOf is the sha256 over the canonical JSON of a payload, which is the
+// only thing a Preloop signature ever covers.
+func DigestOf(payload interface{}) (string, error) {
+	body, err := CanonicalJSON(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// DigestOfBytes is the sha256 of bytes exactly as they are held, used for the
+// manifest of a period export, which is signed as packed.
+func DigestOfBytes(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+// CheckSignature verifies a detached signature against a published key.
+//
+// expectedDigest is what the caller computed for itself. Passing "" skips
+// that comparison and checks only that the document is internally consistent,
+// which proves far less: a well formed signature over a digest nobody
+// recomputed says only that we signed something.
+func CheckSignature(doc SignatureDocument, key PublicKey, expectedDigest string) error {
+	if doc.Algorithm != AlgorithmEd25519 {
+		return fmt.Errorf("unsupported signature algorithm %q", doc.Algorithm)
+	}
+	if key.PublicKey == "" {
+		return ErrNoKey
+	}
+	if expectedDigest != "" && doc.Digest != expectedDigest {
+		return fmt.Errorf(
+			"the signature covers digest %s but the bytes here digest to %s",
+			doc.Digest, expectedDigest,
+		)
+	}
+	raw, err := base64.StdEncoding.DecodeString(key.PublicKey)
+	if err != nil {
+		return fmt.Errorf("published public key is not base64: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return fmt.Errorf("published public key is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	signature, err := base64.StdEncoding.DecodeString(doc.Signature)
+	if err != nil {
+		return fmt.Errorf("signature is not base64: %w", err)
+	}
+	if !ed25519.Verify(ed25519.PublicKey(raw), SignedBytes(doc.PayloadType, doc.Digest, doc.SignedAt), signature) {
+		return errors.New("signature does not verify against this key")
+	}
+	return nil
+}

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -91,7 +91,9 @@ the shared encrypted artifact API (`kind=evidence`); Kubernetes logs carry
 status markers only. `GET .../result` and `GET .../evidence-status` report the
 persisted receipt (`kind=evidence`) without decrypt; download verifies digest
 and tenancy and reports `available` / `missing` / `expired` / `failed`
-distinctly. See
+distinctly. Packs are signed at capture with the account Ed25519 key; the
+signature lives beside the archive so the content-addressed digest does not
+change. See
 [evidence-storage.md](../guide/flows/evidence-storage.md). This is operational
 retention, not object-lock.
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,6 +1,6 @@
 # Security Considerations
 
-Auth, tenancy, redaction, and secret custody are platform concerns, not agent self-reporting. This chapter covers the security checklist, redaction policy, secret service, security-screen scoring, and `preloop.security`.
+Auth, tenancy, redaction, and secret custody are platform concerns, not agent self-reporting. This chapter covers the security checklist, redaction policy, secret service, the tamper-evident audit chain and record signatures, security-screen scoring, and `preloop.security`.
 
 ## Security Screen Scoring (QM Proxy Contract)
 *   **Purpose:** Let external agent platforms delegate content security screening to Preloop through a documented HTTP contract, starting with QM's `securityScreen: { backend: "proxy" }` deployment option.
@@ -21,6 +21,13 @@ Auth, tenancy, redaction, and secret custody are platform concerns, not agent se
 *   **Git Guard:** `git_guard.py` allow-lists metadata-only git invocations so no historical blob contents can be dumped into logs or transcripts. It has no production callers yet; it is the enforcement half of the planned follow-up that wires `validate_gap_register` into result ingestion.
 *   **Waiver Inputs:** `waivers.py` deterministically factors human-authored waiver entries (`{id, reason, author, date}`, plus optional scope/expiry/package/version and the platform approval id for interactively collected ones) into a severity-gate outcome: alias-aware matching (a CVE id waives the same advisory surfaced under a GHSA/OSV alias), verbatim echo of applied entries, unmatched/invalid entries surfaced rather than dropped, and an unwaived failure always keeps the gate failed. Interactive `006` waivers bind stored `ask_user` `tool_result`/`responses` (exact finding id and human reason), not `status=approved` or question text. Ambiguous `request_approval` prose, including a `waive_finding` operation, is not a waiver. AI-judged and auto-approved rows cannot authenticate a human waiver or due-diligence decision. The severity gate is KEV or CVSS >= 9.0 unless trigger/CI `gate.fail_on_kev` / `gate.fail_on_cvss_gte` (in `[0, 10]`) override it — never model-authored `gate.policy` display text. There is no per-product policy table.
 *   **Scanner Boundary:** Scanners (gitleaks, zizmor) are installed and run inside the agent execution sandbox per the release security audit preset (`backend/presets/006-release-security-audit.yaml`), never on the platform control plane.
+
+## Tamper-evident audit trail and signed records
+*   **Chain:** A background pass seals audit rows per account into a hash chain (`chain_seq`, `prev_hash`, `row_hash`). Editing, deleting, or reordering a sealed row breaks every hash from that point. Sealing is off the request path so a chain error cannot fail the audited action. Signed checkpoints over the chain head are the artifact a customer can keep off the platform.
+*   **Keys:** One active Ed25519 key per account. The private half is Fernet-encrypted with `SECURITY__ENCRYPTION_KEY`; the public half is published. Rotation retires the old key without invalidating signatures it already made.
+*   **Signatures:** Detached, over a digest, with the payload type inside the signed bytes so a period-export signature cannot be replayed as an evidence-pack signature. Evidence packs are signed at capture, not at download. Signing is never a precondition: an unsigned export or pack is still served.
+*   **Verification:** `preloop audit verify` and `preloop evidence verify` recompute hashes and signatures on the caller's machine and tell the caller to trust that walk over the server's verdict. Operator guide: [Evidence storage and signed records](../guide/flows/evidence-storage.md).
+*   **What this does not prove:** A compromised server can forge a record before it is signed. The chain is not WORM. Rows below the retention purge floor and rows not yet sealed are outside any result.
 
 ## Authentication & Authorization
 

--- a/docs/guide/flows/evidence-storage.md
+++ b/docs/guide/flows/evidence-storage.md
@@ -3,9 +3,12 @@
 Audit-style flows write a human-readable pack under `/workspace/evidence/`
 plus `/workspace/result.json`. This page is the operator runbook for how
 that pack is transported, stored, retrieved and retained. It does **not**
-claim legal hold, WORM, object-lock, certification, or CRA Article 14
-filing. Cross-link the [security audit presets](security-audit-presets.md)
-guide for the JSON contracts themselves.
+claim WORM, object-lock, certification, or CRA Article 14 filing. It does
+now carry a legal hold, which is a Preloop-level control and not a storage
+guarantee: see [Retention and legal hold](#retention-and-legal-hold) for
+exactly what that does and does not mean. Cross-link the
+[security audit presets](security-audit-presets.md) guide for the JSON
+contracts themselves.
 
 ## Two transports
 
@@ -123,7 +126,11 @@ Receipt fields include `kind=evidence`, `artifact_id`, `sha256`/`digest`,
 from a poll as insufficient; they must use the stored artifact id and digest,
 then confirm on download.
 
-`object_lock` and `legal_hold` are always `false`. Do not treat a passing
+`object_lock` is always `false` (see
+[Retention and legal hold](#retention-and-legal-hold)). `legal_hold` is
+`true` while a hold covers the pack or its execution, and false otherwise.
+A held pack is not reported `expired` and its ciphertext is not cleared,
+so `available` on a held pack means the bytes are still there. Do not treat a passing
 CRA `result.json` as proof the pack is available: check the receipt, then
 download. Fail-result runs retain evidence the same way as pass runs.
 
@@ -141,6 +148,120 @@ Direct-upload failure emits `evidence error` / `result error` markers
 and a `failed` or `missing` receipt — never cleartext pack bytes on the
 log channel.
 
+## Retention and legal hold
+
+Two different clocks, and confusing them is the mistake this section exists
+to prevent.
+
+**The evidence payload window** is `FLOW_EVIDENCE_RETENTION_HOURS` (720, 30
+days). It governs the encrypted bytes and it is an operational review window,
+sized for the people who read packs, not for an archive.
+
+**Record retention** is per account and per record class, in days, with a
+**floor of 183 days (six months)** and a default of 365. It governs the
+records: audit rows, approval requests, evidence pack rows (manifest, digest,
+receipt metadata), runtime sessions and usage rows. The floor exists because
+AI Act Art. 26(6) asks a deployer to keep automatically generated logs for at
+least six months and DORA asks for comparable record keeping. Nothing can be
+set below it. A deployment may raise the floor with `RETENTION_FLOOR_DAYS`; it
+cannot lower it.
+
+So an evidence pack row survives for the record retention while the encrypted
+pack itself is cleared after the payload window. That is deliberate. Keeping
+every pack for six months by default would multiply stored bytes against the
+per-account artifact quota on upgrade, without anybody asking for it. If a
+specific pack has to survive, place a legal hold on it or export the period.
+
+| Record class | Covers |
+| --- | --- |
+| `audit` | Audit log rows |
+| `approvals` | Approval requests and their events |
+| `evidence` | Evidence pack records (manifest and digest), not the payload |
+| `runtime_sessions` | Runtime sessions and session activity |
+| `usage` | API and gateway usage rows |
+
+```
+GET  /api/v1/retention/settings        # resolved days per class, plus the floor
+PUT  /api/v1/retention/settings        # {"classes": {"audit": 400}}; below the floor is a 422
+GET  /api/v1/retention/purge-preview   # what today's purge would remove, per class
+```
+
+### The purge
+
+Records past retention are deleted by a background sweeper, never on a
+request. It is **off by default**: set `RETENTION_PURGE_ENABLED=true` to turn
+it on. An upgrade must not silently start deleting audit history, so until an
+operator enables it, retention is a stated policy that nothing enforces, and
+`GET /api/v1/retention/settings` says so in `purge_enabled`.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `RETENTION_PURGE_ENABLED` | `false` | Nothing is deleted while this is false |
+| `RETENTION_PURGE_DRY_RUN` | `false` | Count and audit, delete nothing |
+| `RETENTION_PURGE_WINDOW_UTC` | `1-5` | Off-peak UTC hours; empty means any hour |
+| `RETENTION_PURGE_INTERVAL_SECONDS` | `3600` | Time between passes |
+| `RETENTION_PURGE_BATCH_SIZE` | `1000` | Rows per DELETE |
+| `RETENTION_PURGE_MAX_BATCHES` | `50` | Batch ceiling per class per pass |
+| `RETENTION_PURGE_MAX_SECONDS` | `300` | Wall-clock budget per pass |
+
+A pass that hits a bound stops and resumes next time rather than running long.
+Every pass that removed anything writes an audit row per record class with the
+cutoff and the count, so the deletion of records is itself a record.
+
+### Legal hold
+
+A hold freezes one execution, approval request or evidence pack. While it is
+in force the purge skips the row and the janitor leaves the ciphertext alone
+past `expires_at`, so a held pack stays downloadable. A reason is mandatory,
+the actor is recorded, and both placing and releasing write audit rows.
+
+```
+GET  /api/v1/retention/holds
+POST /api/v1/retention/holds                  # {"resource_type": "execution", "resource_id": "...", "reason": "..."}
+POST /api/v1/retention/holds/{id}/release     # {"reason": "..."}
+```
+
+A hold on an execution also covers that execution's evidence packs. Holds
+overlap safely: releasing an execution hold does not unfreeze a pack that
+carries its own hold.
+
+**What a legal hold is not.** It is a Preloop control, enforced by Preloop
+code against the Preloop database. It is not WORM, and it is not S3 Object
+Lock. `object_lock` stays `false` on every receipt because Preloop cannot
+verify a property of the storage layer beneath it: an operator with database
+access can still delete a held row, and a backup restore can still reintroduce
+a purged one. If your obligation requires immutability that survives a
+platform administrator, put that control in the storage layer and use the
+period export to hold the record somewhere Preloop cannot reach.
+
+### Period export
+
+`POST /api/v1/retention/exports?start=YYYY-MM-DD&end=YYYY-MM-DD` returns a
+`tar.gz` of one period (start inclusive, end exclusive, so consecutive
+periods tile without double counting).
+
+```
+manifest.json                    schema preloop.retention.period_export_manifest/v1
+approvals/approval_request.jsonl
+audit/audit_log.jsonl
+evidence/receipts.jsonl          receipts, not payloads: artifact id and digest
+holds/legal_hold.jsonl
+```
+
+`manifest.json` carries `members` with a `sha256` and `size_bytes` per member
+and a `members_digest` over that list, the same shape and the same computation
+an evidence pack manifest uses, so one verifier covers both. The response
+headers repeat the digests (`X-Preloop-Archive-Sha256`,
+`X-Preloop-Members-Digest`). Every export writes an audit row naming the
+period, the counts and the archive digest.
+
+The bundle is **not signed**. The digests show the archive was not altered
+after Preloop built it. They do not show the records were true when they were
+written; that is the audit hash chain in #558. Exports are capped at
+`RETENTION_EXPORT_MAX_ROWS` (100000) per record class and 366 days per
+archive, and going over is an error asking for a narrower period rather than a
+truncated archive somebody later mistakes for the whole period.
+
 ## Operator checklist
 
 1. Enable `FLOW_ARTIFACT_DIRECT_UPLOAD` only after runners can reach the
@@ -154,3 +275,10 @@ log channel.
    skippable warning.
 5. Keep Kubernetes RBAC for pod logs tight on clusters that still run the
    legacy log channel (`FLOW_ARTIFACT_DIRECT_UPLOAD=false`).
+6. Decide record retention per class and set `RETENTION_PURGE_ENABLED`
+   deliberately. Until it is on, nothing is deleted and the stated retention
+   is not enforced. Run `GET /api/v1/retention/purge-preview` before the
+   first enabled pass.
+7. Place a legal hold before an incident review starts, not after the
+   payload window has closed. A hold pins bytes that are still there; it
+   cannot bring back bytes already cleared.

--- a/docs/guide/flows/evidence-storage.md
+++ b/docs/guide/flows/evidence-storage.md
@@ -252,15 +252,158 @@ holds/legal_hold.jsonl
 and a `members_digest` over that list, the same shape and the same computation
 an evidence pack manifest uses, so one verifier covers both. The response
 headers repeat the digests (`X-Preloop-Archive-Sha256`,
-`X-Preloop-Members-Digest`). Every export writes an audit row naming the
-period, the counts and the archive digest.
+`X-Preloop-Members-Digest`, `X-Preloop-Manifest-Sha256`). Every export writes
+an audit row naming the period, the counts, the archive digest and the key
+that signed it.
 
-The bundle is **not signed**. The digests show the archive was not altered
-after Preloop built it. They do not show the records were true when they were
-written; that is the audit hash chain in #558. Exports are capped at
-`RETENTION_EXPORT_MAX_ROWS` (100000) per record class and 366 days per
-archive, and going over is an error asking for a narrower period rather than a
-truncated archive somebody later mistakes for the whole period.
+The bundle also carries `signature.json`: a detached Ed25519 signature over
+the sha256 of `manifest.json` as packed, made with the account's signing key
+(see [Signed records](#signed-records)). Verify it with
+`preloop evidence verify <archive>`, or by hand: digest the manifest bytes,
+rebuild the signed bytes, check them against the published public key. The
+signature member is not listed in `members`, because it cannot be: it covers
+the manifest that would have to list it.
+
+Exports are capped at `RETENTION_EXPORT_MAX_ROWS` (100000) per record class
+and 366 days per archive, and going over is an error asking for a narrower
+period rather than a truncated archive somebody later mistakes for the whole
+period.
+
+Exported audit rows carry their chain position (`chain_seq`, `prev_hash`,
+`row_hash`), so a bundle taken today can be checked against a checkpoint kept
+years ago without asking Preloop for anything.
+
+## Tamper-evident audit trail
+
+Audit rows are chained per account. A background pass seals rows in timestamp
+order: each sealed row gets a `chain_seq`, the `row_hash` of the row before it
+as `prev_hash`, and its own `row_hash` over a canonical serialisation of the
+record. Editing a sealed row, deleting one from the middle, or reordering two
+breaks every hash from that point on.
+
+```
+GET  /api/v1/audit/chain/status        head, purge floor, sealing lag, newest checkpoint
+GET  /api/v1/audit/chain/verify        a server-side walk over a range
+GET  /api/v1/audit/chain/segment       canonical payloads and stored hashes, for your own walk
+GET  /api/v1/audit/chain/checkpoints   signed anchors over the chain head
+```
+
+`preloop audit verify` uses the segment endpoint rather than the verdict: it
+recomputes every hash on your machine, checks the checkpoint signatures, and
+reports the first break with its sequence and row id. Exit status is 1 on a
+break, so CI can gate on it. When Preloop's verdict and the local walk
+disagree, the CLI prints both and tells you to trust the walk.
+
+```
+preloop audit verify
+preloop audit verify --start-seq 1000 --end-seq 2000 --json
+```
+
+Two ranges are outside any result, and both are stated in the output rather
+than glossed over. Rows below `pruned_below_seq` were removed by the retention
+purge under a stated policy: the purge raises that floor as it deletes, so
+enforcing retention does not read as tampering. Rows written since the last
+sealing pass are not chained yet (`unsealed_rows`).
+
+Every `AUDIT_CHAIN_CHECKPOINT_INTERVAL` sealed rows, Preloop signs a
+checkpoint over the chain head. A checkpoint you copied off the platform is
+the one artifact here that a rewritten chain cannot reproduce, because it was
+signed before the rewrite and it names the head at that sequence. Fetch and
+keep them.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `AUDIT_CHAIN_ENABLED` | `true` | Seal rows into the chain. Adds hashes, removes nothing |
+| `AUDIT_CHAIN_SEAL_INTERVAL_SECONDS` | `60` | Time between sealing passes |
+| `AUDIT_CHAIN_SEAL_LAG_SECONDS` | `60` | How far behind now the sealer stays |
+| `AUDIT_CHAIN_CHECKPOINT_INTERVAL` | `1000` | Sealed rows between signed checkpoints |
+| `AUDIT_CHAIN_VERIFY_MAX_ROWS` | `50000` | Rows one verify request walks before truncating |
+
+## Signed records
+
+Each account has an Ed25519 signing key. The private half is stored encrypted
+with `SECURITY__ENCRYPTION_KEY`, like every other secret; the public half is
+served to anyone with `view_audit_logs`.
+
+```
+GET  /api/v1/signing/keys          every key the account has held, public halves
+POST /api/v1/signing/keys/rotate   retire the active key, mint its replacement
+```
+
+Rotation keeps old keys listed and old signatures valid. Invalidating them
+would revoke the customer's own evidence, which is the opposite of the point.
+Every signature names the `key_id` that made it.
+
+A signature covers these bytes and nothing else:
+
+```
+preloop.signature/v1\n<payload_type>\n<digest>\n<signed_at>
+```
+
+`payload_type` is in there so a signature over a period export manifest cannot
+be presented as a signature over an evidence pack. `digest` is the sha256 of
+the canonical JSON of the signed payload (sorted keys, no insignificant
+whitespace, UTF-8), or of the manifest bytes for a period export.
+
+Evidence packs are signed at capture, not at download, so re-serving a pack
+cannot change what was signed. The signature lives beside the pack rather than
+inside it: an evidence archive is content addressed the moment it is stored,
+and appending a member would change the digest the receipt already promised.
+`GET .../evidence-status` and the evidence download return the signature and
+`signing_key_id`, and the download repeats them in `X-Preloop-Signature`,
+`X-Preloop-Signing-Key-Id` and `X-Preloop-Signed-At`.
+
+```
+preloop evidence verify export.tar.gz
+preloop evidence verify evidence.tar.gz --execution <execution-id>
+preloop evidence verify export.tar.gz --public-key ./account-key.pub
+```
+
+`--public-key` is the version worth running. A public key fetched from us at
+verification time only shows that the bundle matches whatever key we serve you
+today; a key you copied when the bundle was issued does not depend on us at
+all. `preloop audit keys` prints them for that purpose.
+
+Packs captured before signing existed, and accounts whose key could not be
+minted, have no signature. The receipt says `signature: null` rather than
+pretending, and signing is never a precondition for storing evidence: bytes
+that cannot be re-captured outweigh a signature that can be added later.
+
+## What this proves and what it does not
+
+Being precise here matters more than sounding strong, so the limits come
+first.
+
+**A compromised server can forge anything before it is signed.** The signing
+key lives on the same platform that writes the records. Anyone who can write
+an audit row can write a false one, and it will be sealed into the chain and
+signed like any other. Nothing in this feature makes Preloop's own claims
+trustworthy; it makes them *fixed*. Signing and chaining defend against
+changing history after the fact, not against writing it wrong the first time.
+
+**The chain proves order and non-deletion within a range.** A clean walk over
+sequences 1000 to 2000 shows that those rows are in the order they were sealed
+in, that none was removed from between them, and that none was edited after
+sealing. It does not extend past the range: rows below the purge floor are
+gone, and rows not yet sealed are outside the chain. It says nothing at all
+about whether a row's contents were true.
+
+**A signature proves origin and integrity, not truth.** A verified period
+export is the bundle Preloop built, unchanged since. Whether the approvals
+inside it reflect what really happened is a question about the platform, not
+about the signature.
+
+**A checkpoint is only as good as where you keep it.** Its value comes from
+being outside our reach. A checkpoint we hold and a chain we hold prove
+consistency between two things under the same control. Copy checkpoints and
+public keys somewhere Preloop cannot write.
+
+**None of this is WORM.** An operator with database access can still delete
+rows. The difference is that after this change, deleting sealed rows leaves a
+gap the next verification names, instead of leaving nothing at all. A gap in
+the chain is evidence; it is not prevention. If your obligation needs
+immutability that survives a platform administrator, that control belongs in
+the storage layer.
 
 ## Operator checklist
 
@@ -282,3 +425,8 @@ truncated archive somebody later mistakes for the whole period.
 7. Place a legal hold before an incident review starts, not after the
    payload window has closed. A hold pins bytes that are still there; it
    cannot bring back bytes already cleared.
+8. Copy signed checkpoints (`GET /api/v1/audit/chain/checkpoints`) and the
+   public keys (`preloop audit keys`) somewhere Preloop cannot write. Held
+   only here, they prove consistency between two things under the same
+   control. Run `preloop audit verify` on a schedule and treat a break as an
+   incident.

--- a/docs/guide/flows/product-evidence.md
+++ b/docs/guide/flows/product-evidence.md
@@ -112,11 +112,15 @@ it could:
 - Human approval invented from model output. Reviewer names and
   timestamps come from the approval audit trail, or they are omitted.
 - Certification, CE marking, or a completed conformity assessment.
-- Legal hold, object-lock, or WORM retention of evidence blobs. The
-  dossier copies a server-owned `kind=evidence` receipt (`sha256`,
-  status, retention hours, `integrity_verified`) from
-  `inspect_evidence` / `load_evidence`. Availability polls are not
-  download integrity. `retained` is true only after a verified receipt.
+- Object-lock or WORM retention of evidence blobs. A Preloop legal hold
+  does exist now (see
+  [evidence storage](evidence-storage.md#retention-and-legal-hold)): it
+  blocks purge and payload expiry inside Preloop, and it is not a
+  storage-layer guarantee. The dossier copies a server-owned
+  `kind=evidence` receipt (`sha256`, status, retention hours,
+  `legal_hold`, `integrity_verified`) from `inspect_evidence` /
+  `load_evidence`. Availability polls are not download integrity.
+  `retained` is true only after a verified receipt.
 - A successful **product** publication when any one repository failed
   to push or open its pull request. Local commits are not success.
   Partial remote receipts stay on the execution; the run is failed.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4768,6 +4768,235 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/settings:
+    get:
+      tags:
+      - Retention
+      summary: Get Retention Settings
+      description: Return this account's retention per record class, and the floor.
+      operationId: get_retention_settings_api_v1_retention_settings_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionSettingsRead'
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - Retention
+      summary: Update Retention Settings
+      description: 'Set retention per record class, never below the six month floor.
+
+
+        The body is the full desired state: a class the caller omits, or sets to
+
+        null, goes back to the deployment default.'
+      operationId: update_retention_settings_api_v1_retention_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetentionSettingsUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionSettingsRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /api/v1/retention/purge-preview:
+    get:
+      tags:
+      - Retention
+      summary: Preview Retention Purge
+      description: 'Count what the purge would remove today, without removing anything.
+
+
+        Nobody should discover the effect of a retention setting by watching rows
+
+        disappear. Rows under a legal hold are already excluded by the same
+
+        filters the purge uses, so the count is the count.'
+      operationId: preview_retention_purge_api_v1_retention_purge_preview_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPurgePreview'
+      security:
+      - bearerAuth: []
+  /api/v1/retention/holds:
+    get:
+      tags:
+      - Retention
+      summary: List Legal Holds
+      description: List this account's legal holds, newest first.
+      operationId: list_legal_holds_api_v1_retention_holds_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: active_only
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Hide released holds
+          default: true
+          title: Active Only
+        description: Hide released holds
+      - name: resource_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resource Type
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalHoldRead'
+                title: Response List Legal Holds Api V1 Retention Holds Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - Retention
+      summary: Create Legal Hold
+      description: Freeze one execution, approval or evidence pack until released.
+      operationId: create_legal_hold_api_v1_retention_holds_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalHoldCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalHoldRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/holds/{hold_id}/release:
+    post:
+      tags:
+      - Retention
+      summary: Release Legal Hold
+      description: Lift a hold. The record stays, with who lifted it and why.
+      operationId: release_legal_hold_api_v1_retention_holds__hold_id__release_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: hold_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Hold Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalHoldRelease'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalHoldRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/retention/exports:
+    post:
+      tags:
+      - Retention
+      summary: Create Period Export
+      description: 'Build a tar.gz of one period: audit rows, approvals, receipts,
+        holds.
+
+
+        The archive carries ``manifest.json`` with a sha256 per member and a
+
+        digest over the member list, in the same shape an evidence pack manifest
+
+        uses, so one verifier covers both.'
+      operationId: create_period_export_api_v1_retention_exports_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: start
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Period start, inclusive (YYYY-MM-DD)
+          title: Start
+        description: Period start, inclusive (YYYY-MM-DD)
+      - name: end
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Period end, exclusive (YYYY-MM-DD)
+          title: End
+        description: Period end, exclusive (YYYY-MM-DD)
+      responses:
+        '200':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/notification-preferences/me:
     get:
       tags:
@@ -9135,9 +9364,13 @@ paths:
 
         Served from the persisted execution receipt (no decrypt). Availability
 
-        is not integrity proof. ``object_lock`` and ``legal_hold`` are always
+        is not integrity proof. ``object_lock`` is always false: this API does
 
-        false: this API does not implement WORM retention.'
+        not implement WORM retention and cannot verify a property of the storage
+
+        layer beneath it. ``legal_hold`` is true while a hold covers the pack or
+
+        its execution, which blocks payload expiry and purge inside Preloop.'
       operationId: get_flow_execution_evidence_status_api_v1_flows_executions__execution_id__evidence_status_get
       security:
       - bearerAuth: []
@@ -18351,6 +18584,105 @@ components:
       - row_count
       title: LedgerBackfillUnmatched
       description: Unpriced usage rows whose family had no ledger spend that day.
+    LegalHoldCreate:
+      properties:
+        resource_type:
+          type: string
+          title: Resource Type
+          description: One of execution, approval, evidence_pack
+        resource_id:
+          type: string
+          maxLength: 255
+          title: Resource Id
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 8
+          title: Reason
+          description: Why this record is frozen. Written to the audit log.
+      type: object
+      required:
+      - resource_type
+      - resource_id
+      - reason
+      title: LegalHoldCreate
+      description: Place a hold on one execution, approval or evidence pack.
+    LegalHoldRead:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        resource_type:
+          type: string
+          title: Resource Type
+        resource_id:
+          type: string
+          title: Resource Id
+        reason:
+          type: string
+          title: Reason
+        placed_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Placed By User Id
+        placed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Placed At
+        released_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Released By User Id
+        released_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Released At
+        release_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Release Reason
+        active:
+          type: boolean
+          title: Active
+        flagged:
+          anyOf:
+          - additionalProperties:
+              type: integer
+            type: object
+          - type: 'null'
+          title: Flagged
+      type: object
+      required:
+      - id
+      - resource_type
+      - resource_id
+      - reason
+      - active
+      title: LegalHoldRead
+      description: One hold, active or released.
+    LegalHoldRelease:
+      properties:
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 8
+          title: Reason
+          description: Why the hold is being lifted. Written to the audit log.
+      type: object
+      required:
+      - reason
+      title: LegalHoldRelease
+      description: Lift a hold. The release reason is recorded too.
     LoginRequest:
       properties:
         username:
@@ -21215,6 +21547,123 @@ components:
       - reason
       title: ResumeRequest
       description: Explicit human retry. Historical decisions stay append-only.
+    RetentionClassRead:
+      properties:
+        record_class:
+          type: string
+          title: Record Class
+        label:
+          type: string
+          title: Label
+        days:
+          type: integer
+          title: Days
+        source:
+          type: string
+          title: Source
+          description: '''account'' when this account set it, ''default'' otherwise'
+        floored:
+          type: boolean
+          title: Floored
+          description: True when the stored value was raised to meet the floor
+          default: false
+      type: object
+      required:
+      - record_class
+      - label
+      - days
+      - source
+      title: RetentionClassRead
+      description: Resolved retention for one record class.
+    RetentionPurgePreview:
+      properties:
+        account_id:
+          type: string
+          format: uuid
+          title: Account Id
+        purge_enabled:
+          type: boolean
+          title: Purge Enabled
+        classes:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Classes
+        total:
+          type: integer
+          title: Total
+      type: object
+      required:
+      - account_id
+      - purge_enabled
+      - classes
+      - total
+      title: RetentionPurgePreview
+      description: What a purge would remove right now, without removing it.
+    RetentionSettingsRead:
+      properties:
+        floor_days:
+          type: integer
+          title: Floor Days
+          description: No record class can be set below this many days
+        default_days:
+          type: integer
+          title: Default Days
+          description: Applied to any class this account has not set
+        max_days:
+          type: integer
+          title: Max Days
+        classes:
+          items:
+            $ref: '#/components/schemas/RetentionClassRead'
+          type: array
+          title: Classes
+        purge_enabled:
+          type: boolean
+          title: Purge Enabled
+          description: False when this deployment never deletes. Retention is then
+            a stated policy that nothing enforces.
+        purge_dry_run:
+          type: boolean
+          title: Purge Dry Run
+        purge_window_utc:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Purge Window Utc
+          description: Off-peak UTC hour window the purge runs in, e.g. '1-5'
+        evidence_payload_hours:
+          type: integer
+          title: Evidence Payload Hours
+          description: How long encrypted evidence payloads are kept. Separate from
+            the 'evidence' record class, which governs the record row.
+      type: object
+      required:
+      - floor_days
+      - default_days
+      - max_days
+      - classes
+      - purge_enabled
+      - purge_dry_run
+      - evidence_payload_hours
+      title: RetentionSettingsRead
+      description: Everything the console needs to render the retention panel.
+    RetentionSettingsUpdate:
+      properties:
+        classes:
+          additionalProperties:
+            anyOf:
+            - type: integer
+            - type: 'null'
+          type: object
+          title: Classes
+          description: 'Record class to days. null clears the account''s setting for
+            that class. Known classes: audit, approvals, evidence, runtime_sessions,
+            usage'
+      type: object
+      title: RetentionSettingsUpdate
+      description: Full desired state. An omitted class falls back to the default.
     RollbackRequest:
       properties:
         preview_only:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4967,7 +4967,11 @@ paths:
 
         digest over the member list, in the same shape an evidence pack manifest
 
-        uses, so one verifier covers both.'
+        uses, so one verifier covers both, plus ``signature.json``: a detached
+
+        Ed25519 signature over the manifest bytes, checkable against the account''s
+
+        published public key.'
       operationId: create_period_export_api_v1_retention_exports_post
       security:
       - bearerAuth: []
@@ -4997,6 +5001,225 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/audit/chain/status:
+    get:
+      tags:
+      - Audit chain
+      summary: Get Chain Status
+      description: Head, purge floor, sealing lag and the newest signed checkpoint.
+      operationId: get_chain_status_api_v1_audit_chain_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainStatusRead'
+      security:
+      - bearerAuth: []
+  /api/v1/audit/chain/verify:
+    get:
+      tags:
+      - Audit chain
+      summary: Verify Chain
+      description: 'Walk a range of the chain and report the first break.
+
+
+        The range matters: rows below the purge floor are gone under a stated
+
+        retention policy and rows written since the last seal are not chained
+
+        yet. Claiming to verify either would be a lie of scope.
+
+
+        The verification is itself audited. A read of the audit trail that leaves
+
+        no trace is a gap in the audit trail.'
+      operationId: verify_chain_api_v1_audit_chain_verify_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: start_seq
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+            minimum: 1
+          - type: 'null'
+          description: First sequence to check. Defaults to the purge floor.
+          title: Start Seq
+        description: First sequence to check. Defaults to the purge floor.
+      - name: end_seq
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+            minimum: 1
+          - type: 'null'
+          description: Last sequence to check. Defaults to the head.
+          title: End Seq
+        description: Last sequence to check. Defaults to the head.
+      - name: max_rows
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+            minimum: 1
+          - type: 'null'
+          description: Cut the range at this many rows and say so.
+          title: Max Rows
+        description: Cut the range at this many rows and say so.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainVerifyRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/audit/chain/segment:
+    get:
+      tags:
+      - Audit chain
+      summary: Get Chain Segment
+      description: Canonical payloads and stored hashes, for a client side walk.
+      operationId: get_chain_segment_api_v1_audit_chain_segment_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: after_seq
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Exclusive lower bound
+          default: 0
+          title: After Seq
+        description: Exclusive lower bound
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 500
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainSegmentRead'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/audit/chain/checkpoints:
+    get:
+      tags:
+      - Audit chain
+      summary: List Chain Checkpoints
+      description: 'Signed checkpoints in sequence order.
+
+
+        Worth keeping your own copies of. A checkpoint you stored last quarter is
+
+        the only thing here that a rewritten chain cannot reproduce.'
+      operationId: list_chain_checkpoints_api_v1_audit_chain_checkpoints_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: after_seq
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: After Seq
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 50
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChainCheckpointRead'
+                title: Response List Chain Checkpoints Api V1 Audit Chain Checkpoints
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/signing/keys:
+    get:
+      tags:
+      - Signing keys
+      summary: List Signing Keys
+      description: 'Public halves of every key this account has held.
+
+
+        Retired keys stay listed: every signature they made is still valid, and a
+
+        verifier holding a bundle from last year needs the key that signed it.'
+      operationId: list_signing_keys_api_v1_signing_keys_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SigningKeyListRead'
+      security:
+      - bearerAuth: []
+  /api/v1/signing/keys/rotate:
+    post:
+      tags:
+      - Signing keys
+      summary: Rotate Signing Key
+      description: 'Retire the active key and mint its replacement.
+
+
+        Signatures made by the retired key keep verifying. Rotation that
+
+        invalidated them would revoke the customer''s own evidence, which is the
+
+        opposite of the point.'
+      operationId: rotate_signing_key_api_v1_signing_keys_rotate_post
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SigningKeyRotateRead'
+      security:
+      - bearerAuth: []
   /api/v1/notification-preferences/me:
     get:
       tags:
@@ -9370,7 +9593,16 @@ paths:
 
         layer beneath it. ``legal_hold`` is true while a hold covers the pack or
 
-        its execution, which blocks payload expiry and purge inside Preloop.'
+        its execution, which blocks payload expiry and purge inside Preloop.
+
+
+        ``signature`` is the detached Ed25519 signature made when the pack was
+
+        captured, with the payload it covers, or null for a pack captured before
+
+        signing existed. ``preloop evidence verify`` checks it against the
+
+        account''s public key.'
       operationId: get_flow_execution_evidence_status_api_v1_flows_executions__execution_id__evidence_status_get
       security:
       - bearerAuth: []
@@ -14955,6 +15187,272 @@ components:
       required:
       - file
       title: Body_validate_policy_api_v1_policies_validate_post
+    ChainBreakRead:
+      properties:
+        kind:
+          type: string
+          title: Kind
+        seq:
+          type: integer
+          title: Seq
+        row_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Row Id
+        detail:
+          type: string
+          title: Detail
+      type: object
+      required:
+      - kind
+      - seq
+      - detail
+      title: ChainBreakRead
+      description: The first place the walk stopped agreeing with the chain.
+    ChainCheckpointRead:
+      properties:
+        seq:
+          type: integer
+          title: Seq
+        chain_hash:
+          type: string
+          title: Chain Hash
+          description: row_hash of the row at this sequence
+        row_count:
+          type: integer
+          title: Row Count
+        checkpointed_at:
+          type: string
+          title: Checkpointed At
+        signing_key_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Signing Key Id
+        signature:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Signature
+          description: Base64 Ed25519 signature, null when signing failed
+        signed_payload:
+          additionalProperties: true
+          type: object
+          title: Signed Payload
+          description: Canonical payload the digest was taken over
+        digest:
+          type: string
+          title: Digest
+        signature_document:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Signature Document
+          description: Detached signature document, ready to verify
+      type: object
+      required:
+      - seq
+      - chain_hash
+      - row_count
+      - checkpointed_at
+      - signed_payload
+      - digest
+      title: ChainCheckpointRead
+      description: One signed checkpoint over the chain head at a sequence.
+    ChainSegmentEntry:
+      properties:
+        seq:
+          type: integer
+          title: Seq
+        row_id:
+          type: string
+          title: Row Id
+        prev_hash:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prev Hash
+        row_hash:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Row Hash
+        payload:
+          additionalProperties: true
+          type: object
+          title: Payload
+      type: object
+      required:
+      - seq
+      - row_id
+      - payload
+      title: ChainSegmentEntry
+      description: One row's chain material, enough to recompute its hash.
+    ChainSegmentRead:
+      properties:
+        account_id:
+          type: string
+          title: Account Id
+        row_domain:
+          type: string
+          title: Row Domain
+        after_seq:
+          type: integer
+          title: After Seq
+        head_seq:
+          type: integer
+          title: Head Seq
+        pruned_below_seq:
+          type: integer
+          title: Pruned Below Seq
+        genesis_hash:
+          type: string
+          title: Genesis Hash
+        entries:
+          items:
+            $ref: '#/components/schemas/ChainSegmentEntry'
+          type: array
+          title: Entries
+        has_more:
+          type: boolean
+          title: Has More
+        note:
+          type: string
+          title: Note
+      type: object
+      required:
+      - account_id
+      - row_domain
+      - after_seq
+      - head_seq
+      - pruned_below_seq
+      - genesis_hash
+      - entries
+      - has_more
+      - note
+      title: ChainSegmentRead
+      description: Material for a client side walk. The client decides, not the server.
+    ChainStatusRead:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+        head_seq:
+          type: integer
+          title: Head Seq
+        head_hash:
+          type: string
+          title: Head Hash
+        last_sealed_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Sealed At
+        pruned_below_seq:
+          type: integer
+          title: Pruned Below Seq
+          description: Rows below this sequence were removed by the retention purge.
+            Their absence is policy, not tampering.
+        sealed_rows:
+          type: integer
+          title: Sealed Rows
+        unsealed_rows:
+          type: integer
+          title: Unsealed Rows
+          description: Written but not yet chained; sealing is a background pass
+        seal_lag_seconds:
+          type: integer
+          title: Seal Lag Seconds
+        checkpoint_interval:
+          type: integer
+          title: Checkpoint Interval
+        latest_checkpoint:
+          anyOf:
+          - $ref: '#/components/schemas/ChainCheckpointRead'
+          - type: 'null'
+        active_key_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Active Key Id
+      type: object
+      required:
+      - enabled
+      - head_seq
+      - head_hash
+      - pruned_below_seq
+      - sealed_rows
+      - unsealed_rows
+      - seal_lag_seconds
+      - checkpoint_interval
+      title: ChainStatusRead
+      description: Where this account's chain is, and how far behind sealing runs.
+    ChainVerifyRead:
+      properties:
+        account_id:
+          type: string
+          title: Account Id
+        status:
+          type: string
+          title: Status
+          description: ok, broken or empty
+        checked_rows:
+          type: integer
+          title: Checked Rows
+        start_seq:
+          type: integer
+          title: Start Seq
+        end_seq:
+          type: integer
+          title: End Seq
+        head_seq:
+          type: integer
+          title: Head Seq
+        pruned_below_seq:
+          type: integer
+          title: Pruned Below Seq
+        unsealed_rows:
+          type: integer
+          title: Unsealed Rows
+        truncated:
+          type: boolean
+          title: Truncated
+          description: True when the range was cut to the row limit
+        out_of_order_rows:
+          type: integer
+          title: Out Of Order Rows
+          description: Rows whose timestamp precedes the row before them. Concurrency,
+            not evidence of tampering on its own.
+        first_break:
+          anyOf:
+          - $ref: '#/components/schemas/ChainBreakRead'
+          - type: 'null'
+        checkpoints_verified:
+          type: integer
+          title: Checkpoints Verified
+        checkpoint_failures:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Checkpoint Failures
+      type: object
+      required:
+      - account_id
+      - status
+      - checked_rows
+      - start_seq
+      - end_seq
+      - head_seq
+      - pruned_below_seq
+      - unsealed_rows
+      - truncated
+      - out_of_order_rows
+      - checkpoints_verified
+      title: ChainVerifyRead
+      description: Verdict of a server side walk over a range of the chain.
     CommentCreate:
       properties:
         body:
@@ -23551,6 +24049,78 @@ components:
         \    threshold: Finite threshold in [0, 1] this deployment screens at.\n \
         \   primary_outcome: Optional lowercase label naming the dominant rule\n \
         \       category; omitted for benign content."
+    SigningKeyListRead:
+      properties:
+        active_key_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Active Key Id
+        signature_schema:
+          type: string
+          title: Signature Schema
+        signed_bytes_format:
+          type: string
+          title: Signed Bytes Format
+          description: Exact layout of the bytes a signature covers
+        keys:
+          items:
+            $ref: '#/components/schemas/SigningKeyRead'
+          type: array
+          title: Keys
+      type: object
+      required:
+      - signature_schema
+      - signed_bytes_format
+      - keys
+      title: SigningKeyListRead
+      description: Every key this account has held, plus which one signs today.
+    SigningKeyRead:
+      properties:
+        key_id:
+          type: string
+          title: Key Id
+        algorithm:
+          type: string
+          title: Algorithm
+        public_key:
+          type: string
+          title: Public Key
+          description: Base64 raw Ed25519 public key
+        active:
+          type: boolean
+          title: Active
+        created_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created At
+        retired_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Retired At
+      type: object
+      required:
+      - key_id
+      - algorithm
+      - public_key
+      - active
+      title: SigningKeyRead
+      description: The public half of one signing key. Never the private half.
+    SigningKeyRotateRead:
+      properties:
+        retired:
+          anyOf:
+          - $ref: '#/components/schemas/SigningKeyRead'
+          - type: 'null'
+        active:
+          $ref: '#/components/schemas/SigningKeyRead'
+      type: object
+      required:
+      - active
+      title: SigningKeyRotateRead
+      description: 'Result of a rotation: what was retired and what signs now.'
     SpeechToTextResponse:
       properties:
         text:


### PR DESCRIPTION
Closes #558.

**Branched from #559's head (`feat/retention-and-legal-hold`, `04213240`), which is open and
not merged.** The signature work is built on top of that PR's period export, not a second
export format. The first six commits in this diff belong to #559 and will disappear when it
lands; review from `480bd991` onward.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Well-designed tamper-evidence feature (audit hash chain, Ed25519 signing keys, detached signatures, client-side verification) with an honest threat model and strong test coverage; all four medium/low suggestions from the prior review are now resolved.
>
> **Overview**
> Seals audit rows into a per-account hash chain with signed checkpoints, mints per-account Ed25519 keys, signs period exports and evidence packs, and adds `preloop audit verify` / `preloop evidence verify` to recompute everything on the caller's machine. Signing is additive and off the request path; the docs state clearly what the chain does and does not prove.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 58efa2dc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->

## What this does

Audit rows are sealed into a per-account hash chain, each account gets an Ed25519 signing
key, period exports and evidence packs get detached signatures, and two CLI commands verify
all of it on the caller's machine.

### The chain

A bounded background pass seals audit rows in timestamp order: `chain_seq`, the previous
row's `row_hash` as `prev_hash`, and `row_hash` over a canonical serialisation of the record
(`sha256(b"preloop.audit.chain/v1\n" + canonical_json(payload))`). Editing a sealed row,
deleting one from the middle, or reordering two breaks every hash from that point on.

Sealing is off the request path deliberately. `model_gateway_request` writes an audit row per
gateway call; chaining inline needs a per-account lock held to commit, which would serialise
the highest-throughput path in the product on one row per account, and a chain error would
then fail the audited action. The cost is that sealing lags writes, which is why
`unsealed_rows` is in every status and verify response and in the docs.

Every `AUDIT_CHAIN_CHECKPOINT_INTERVAL` (1000) sealed rows a checkpoint over the chain head is
signed. That is the artifact a customer keeps off the platform: a server can recompute a whole
consistent chain, but not one whose old checkpoints still verify.

The retention purge from #559 raises `pruned_below_seq` as it deletes, so enforcing retention
does not read as tampering.

### The keys

`account_signing_key`: Ed25519, private half Fernet encrypted with `SECURITY__ENCRYPTION_KEY`
like every other secret, exactly one active key per account (partial unique index). Rotation
retires the old key and mints a new one; retired keys stay published and their signatures stay
valid, because invalidating them would revoke the customer's own evidence.

Signed bytes are documented and served with the keys:
`preloop.signature/v1\n<payload_type>\n<digest>\n<signed_at>`. The payload type is inside the
signature so a period export signature cannot be replayed as an evidence pack signature.

### The signatures

Period exports gain a `signature.json` member over the sha256 of `manifest.json` as packed.
It is not listed in `members`, because it cannot be: it covers the manifest that would have to
list it. Exported audit rows now carry their chain position.

Evidence packs are signed at capture, not at download, and the signature is stored beside the
record rather than inside the archive: an evidence pack is content addressed the moment it is
stored, and appending a member would change the digest the receipt already promised. The
signed payload is small and rebuildable from the bytes a downloader holds (`archive_sha256`,
`artifact_id`, `execution_id`, `size_bytes`, `created_at`).

Signing is never a precondition. An account with no usable key still gets its export with
`signature: null`, and `sign_evidence_pack` runs inside a savepoint so a signing failure rolls
back only the signature: bytes that cannot be re-captured outweigh a signature that can be
added later.

### The CLI

`preloop audit verify` does not use our verdict. It pages `/audit/chain/segment`, recomputes
every hash locally, verifies checkpoint signatures, reports the first break with its sequence
and row id, and exits non-zero. When our verdict and the local walk disagree it prints both
and says to trust the walk.

`preloop evidence verify <archive>` checks a period export or (with `--execution`) an evidence
pack. `--public-key` verifies against a key the caller kept, with no API call at all: a key
fetched at verification time only shows the bundle matches whatever key we serve today.

`cli/internal/verify/canonical.go` is a hand written encoder rather than `encoding/json`,
which escapes HTML characters, escapes U+2028 and U+2029, and spells backspace and form feed
in their six character form where Python uses the short escapes. Each would produce a wrong
digest. Its tests are pinned against bytes and a signature produced by the backend.

## What this does not do

Stated in the code, in `docs/guide/flows/evidence-storage.md` and here, because overselling it
would be worse than not shipping it:

- A compromised server can forge a record before it is signed. The signing key lives on the
  same platform that writes the records. This makes history fixed, not truthful.
- The chain proves order and non-deletion within the range it names. Rows below the purge
  floor are gone; rows not yet sealed are outside the chain.
- A signature proves origin and integrity, not that the records were true when written.
- A checkpoint kept only by us proves consistency between two things under the same control.
- None of this is WORM. An operator with database access can still delete rows; the difference
  is that now it leaves a gap the next verification names.

## Verification

- Migration `20260910_audit_chain` up, down, and up again on local Postgres 17 with pgvector.
  Tests assert the downgrade leaves audit rows intact and that the partial unique index and
  the chain walk index exist.
- Backend suite in the clone's own venv: **9617 passed, 39 failed, 53 skipped** (615 s). All
  39 failures reproduce identically on the base commit `04213240` (kill switch timing, issue
  compliance OpenAI mocks, model pricing, auth registration): pre-existing, not from this
  change.
- New backend tests: 19 chain service, 18 signing service, 15 chain API, 7 migration, 9 export
  and purge signature tests, 1 evidence capture test.
- Go: 29 tests in `internal/verify`, 16 in `internal/cmd` for the two commands. `go test ./...`
  green, `go vet` clean, `gofmt` clean on new files.
- Frontend untouched: `npx tsc --noEmit` clean, `npm run build` succeeds.

- Author: d-mo
- URL: https://github.com/preloop/preloop/pull/564
- Source Branch: feat/tamper-evident-records
- Target Branch: main