### PR TITLE
fix: release MCP database sessions and retain logs through pool outages

### DIFF
--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -8,7 +8,22 @@ to interact with the Preloop platform using FastMCP.
 import asyncio
 import logging
 import re
-from typing import Any, Optional, Dict, List, Literal
+from contextlib import ExitStack, contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from typing import (
+    Any,
+    Optional,
+    Dict,
+    List,
+    Literal,
+    Awaitable,
+    Callable,
+    ParamSpec,
+    TypeVar,
+)
+from sqlalchemy.orm import Session
 from urllib.parse import urlparse, urlunparse
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -63,6 +78,58 @@ from fastmcp.server.dependencies import get_http_request
 
 
 logger = logging.getLogger(__name__)
+
+
+_ToolParams = ParamSpec("_ToolParams")
+_ToolResult = TypeVar("_ToolResult")
+
+
+@dataclass
+class _ToolDatabase:
+    stack: ExitStack
+    session: Session | None = None
+
+
+_tool_db: ContextVar[_ToolDatabase | None] = ContextVar(
+    "native_mcp_tool_db", default=None
+)
+
+
+def _with_tool_db(
+    tool: Callable[_ToolParams, Awaitable[_ToolResult]],
+) -> Callable[_ToolParams, Awaitable[_ToolResult]]:
+    """Own the lazy database session for one native MCP tool invocation.
+
+    These functions are called by FastMCP, not FastAPI's dependency runner.
+    A bare ``next(get_db())`` does not keep the dependency generator alive;
+    queries reopen the session after its finalizer and leak the new checkout.
+    Scope ownership here guarantees cleanup on errors and cancellation too.
+    """
+
+    @wraps(tool)
+    async def wrapped(
+        *args: _ToolParams.args, **kwargs: _ToolParams.kwargs
+    ) -> _ToolResult:
+        stack = ExitStack()
+        token = _tool_db.set(_ToolDatabase(stack))
+        try:
+            return await tool(*args, **kwargs)
+        finally:
+            _tool_db.reset(token)
+            stack.close()
+
+    return wrapped
+
+
+def _get_tool_db() -> Session:
+    """Return the session owned by the current native MCP invocation."""
+    scope = _tool_db.get()
+    if scope is None:
+        raise RuntimeError("Native MCP database access requires a tool invocation")
+    if scope.session is None:
+        scope.session = scope.stack.enter_context(contextmanager(get_db)())
+        scope.stack.callback(scope.session.close)
+    return scope.session
 
 
 def _extract_assignee_name(assignee_data: Any) -> Optional[str]:
@@ -143,7 +210,7 @@ class ProcessingResult:
 
 async def _get_authenticated_user(request_headers):
     """Extract and authenticate user from request headers."""
-    db = next(get_db())
+    db = _get_tool_db()
     authorization = request_headers.get("authorization")
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Not authenticated")
@@ -473,13 +540,14 @@ def _enrich_compliance_results(db_results):
     return enriched_results
 
 
+@_with_tool_db
 async def get_issue(
     issue: str,
 ) -> GetIssueResponse:
     """
     Handles the 'get_issue' tool call.
     """
-    db = next(get_db())
+    db = _get_tool_db()
     current_user = None
     authorization = get_http_request().headers.get("authorization")
     if authorization and authorization.startswith("Bearer "):
@@ -528,6 +596,7 @@ async def get_issue(
     )
 
 
+@_with_tool_db
 async def create_issue(
     project: str,
     title: str,
@@ -541,7 +610,7 @@ async def create_issue(
     """
     Handles the 'create_issue' tool call.
     """
-    db = next(get_db())
+    db = _get_tool_db()
     current_user = None
     authorization = get_http_request().headers.get("authorization")
     if authorization and authorization.startswith("Bearer "):
@@ -618,6 +687,7 @@ async def create_issue(
         raise HTTPException(status_code=500, detail="Failed to create issue.")
 
 
+@_with_tool_db
 async def update_issue(
     issue: str,
     title: Optional[str] = None,
@@ -632,7 +702,7 @@ async def update_issue(
     """
     Handles the 'update_issue' tool call.
     """
-    db = next(get_db())
+    db = _get_tool_db()
     current_user = None
     authorization = get_http_request().headers.get("authorization")
     if authorization and authorization.startswith("Bearer "):
@@ -865,6 +935,7 @@ async def update_issue(
     )
 
 
+@_with_tool_db
 async def search(
     query: str,
     project: Optional[str] = None,
@@ -875,7 +946,7 @@ async def search(
     """
     Handles the 'search' tool call.
     """
-    db = next(get_db())
+    db = _get_tool_db()
     current_user = None
     authorization = get_http_request().headers.get("authorization")
     if authorization and authorization.startswith("Bearer "):
@@ -909,6 +980,7 @@ async def search(
         raise HTTPException(status_code=500, detail="Failed to perform search.")
 
 
+@_with_tool_db
 async def estimate_compliance(
     issues: List[str],
     compliance_metric: str = "DoR",
@@ -1112,6 +1184,7 @@ async def _process_single_issue_compliance(
         )
 
 
+@_with_tool_db
 async def improve_compliance(
     issues: List[str],
     compliance_metric: str = "DoR",
@@ -1203,6 +1276,7 @@ async def improve_compliance(
     )
 
 
+@_with_tool_db
 async def add_comment(
     target: str,
     comment: str,
@@ -1231,7 +1305,7 @@ async def add_comment(
     """
     from preloop.schemas.mcp import AddCommentResponse
 
-    db = next(get_db())
+    db = _get_tool_db()
     current_user = None
     authorization = get_http_request().headers.get("authorization")
     if authorization and authorization.startswith("Bearer "):
@@ -1331,6 +1405,8 @@ async def add_comment(
         tracker_client = await get_tracker_client(
             project_obj.organization_id, project_obj.id, db, current_user
         )
+        # Release the read transaction before the external tracker request.
+        db.close()
 
         # Determine platform from tracker if not yet known
         if platform is None:
@@ -1614,6 +1690,7 @@ async def add_comment(
             )
 
         target_id = issue_obj.key if issue_obj.key else issue_obj.external_id
+        db.close()
 
         try:
             logger.info(f"Adding comment to issue {target_id} via tracker client")
@@ -1651,6 +1728,7 @@ async def add_comment(
             )
 
 
+@_with_tool_db
 async def get_pull_request(
     pull_request: str,
     include_comments: bool = True,
@@ -1695,6 +1773,8 @@ async def get_pull_request(
     tracker_client = await get_tracker_client(
         project_obj.organization_id, project_obj.id, db, current_user
     )
+    # Client configuration is materialized; provider I/O needs no DB checkout.
+    db.close()
 
     # Determine platform from tracker if not yet known
     if platform is None:
@@ -1775,6 +1855,7 @@ async def get_pull_request(
         )
 
 
+@_with_tool_db
 async def update_pull_request(
     pull_request: str,
     title: Optional[str] = None,
@@ -1849,6 +1930,8 @@ async def update_pull_request(
     tracker_client = await get_tracker_client(
         project_obj.organization_id, project_obj.id, db, current_user
     )
+    # Client configuration is materialized; provider I/O needs no DB checkout.
+    db.close()
 
     # Determine platform from tracker if not yet known
     if platform is None:
@@ -2321,6 +2404,7 @@ def _record_opened_pr_on_execution(
         )
 
 
+@_with_tool_db
 async def create_pull_request(
     project: str,
     title: str,
@@ -2408,6 +2492,8 @@ async def create_pull_request(
     tracker_client = await get_tracker_client(
         project_obj.organization_id, project_obj.id, db, current_user
     )
+    # Client configuration is materialized; provider I/O needs no DB checkout.
+    db.close()
 
     # Determine platform from tracker if not already known
     if platform is None:
@@ -2581,6 +2667,7 @@ _EXPECTED_NOT_FOUND_MARKERS = (
 _HTTP_404_TOKEN_RE = re.compile(r"\b404\b")
 
 
+@_with_tool_db
 async def update_comment(
     target: str,
     comment_id: str,
@@ -2709,6 +2796,8 @@ async def update_comment(
     tracker_client = await get_tracker_client(
         project_obj.organization_id, project_obj.id, db, current_user
     )
+    # Client configuration is materialized; provider I/O needs no DB checkout.
+    db.close()
 
     # Determine platform from tracker if not yet known
     if platform is None:

--- a/backend/preloop/models/crud/flow_execution_log.py
+++ b/backend/preloop/models/crud/flow_execution_log.py
@@ -3,16 +3,17 @@ from datetime import datetime
 from typing import List, Optional
 
 from sqlalchemy import select, tuple_
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
-from preloop.models.models.flow_execution_log import FlowExecutionLog
+from preloop.models import models
 from preloop.utils.secret_scrubbing import scrub_secrets, scrub_structure
 from .base import CRUDBase
 
 
-class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
+class CRUDFlowExecutionLog(CRUDBase[models.FlowExecutionLog]):
     def __init__(self) -> None:
-        super().__init__(model=FlowExecutionLog)
+        super().__init__(model=models.FlowExecutionLog)
 
     def get_by_execution_id(
         self,
@@ -22,15 +23,15 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         desc: bool = False,
         skip: int = 0,
         limit: Optional[int] = None,
-    ) -> List[FlowExecutionLog]:
-        query = select(FlowExecutionLog).filter(
-            FlowExecutionLog.execution_id == execution_id,
+    ) -> List[models.FlowExecutionLog]:
+        query = select(models.FlowExecutionLog).filter(
+            models.FlowExecutionLog.execution_id == execution_id,
         )
 
         if desc:
-            query = query.order_by(FlowExecutionLog.timestamp.desc())
+            query = query.order_by(models.FlowExecutionLog.timestamp.desc())
         else:
-            query = query.order_by(FlowExecutionLog.timestamp.asc())
+            query = query.order_by(models.FlowExecutionLog.timestamp.asc())
 
         if skip > 0:
             query = query.offset(skip)
@@ -55,22 +56,23 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         *,
         after: Optional[tuple[datetime, uuid.UUID]] = None,
         limit: int = 500,
-    ) -> List[FlowExecutionLog]:
+    ) -> List[models.FlowExecutionLog]:
         """Read one bounded raw-log page, using an execution-scoped keyset cursor.
 
         Timestamp ties use row identity, so a page boundary cannot skip another
         line with the same timestamp. Derived metrics/events are never replayed.
         """
-        query = select(FlowExecutionLog).where(
-            FlowExecutionLog.execution_id == execution_id,
-            FlowExecutionLog.log_type == "agent_log_line",
+        query = select(models.FlowExecutionLog).where(
+            models.FlowExecutionLog.execution_id == execution_id,
+            models.FlowExecutionLog.log_type == "agent_log_line",
         )
         if after is not None:
             query = query.where(
-                tuple_(FlowExecutionLog.timestamp, FlowExecutionLog.id) > after
+                tuple_(models.FlowExecutionLog.timestamp, models.FlowExecutionLog.id)
+                > after
             )
         query = query.order_by(
-            FlowExecutionLog.timestamp.asc(), FlowExecutionLog.id.asc()
+            models.FlowExecutionLog.timestamp.asc(), models.FlowExecutionLog.id.asc()
         ).limit(max(1, min(limit, 1000)))
         return list(db.execute(query).scalars().all())
 
@@ -79,16 +81,45 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         db: Session,
         execution_id: uuid.UUID,
         event_id: uuid.UUID,
-    ) -> Optional[FlowExecutionLog]:
-        query = select(FlowExecutionLog).filter(
-            FlowExecutionLog.execution_id == execution_id,
-            FlowExecutionLog.id == event_id,
+    ) -> Optional[models.FlowExecutionLog]:
+        query = select(models.FlowExecutionLog).filter(
+            models.FlowExecutionLog.execution_id == execution_id,
+            models.FlowExecutionLog.id == event_id,
         )
         return db.execute(query).scalar_one_or_none()
 
+    def append_logs(self, db: Session, batch: list[tuple[str, dict]]) -> None:
+        """Insert a scrubbed batch atomically with stable IDs for safe retries.
+
+        Callers retain each entry's ``_persistence_id`` across retries, including
+        retries after an ambiguous commit failure. Conflicting IDs are already
+        persisted and must not create duplicate events.
+        """
+        if not batch:
+            return
+        rows = []
+        for execution_id, log_data in batch:
+            payload = log_data.get("payload") or {}
+            message = (
+                log_data.get("message") or payload.get("line") or payload.get("message")
+            )
+            metadata = payload or log_data.get("metadata") or log_data.get("data")
+            rows.append(
+                {
+                    "id": uuid.UUID(log_data["_persistence_id"]),
+                    "execution_id": uuid.UUID(execution_id),
+                    "log_type": log_data.get("type", "log"),
+                    "message": scrub_secrets(message),
+                    "metadata": scrub_structure(metadata) if metadata else None,
+                }
+            )
+        statement = insert(models.FlowExecutionLog.__table__).values(rows)
+        db.execute(statement.on_conflict_do_nothing(index_elements=["id"]))
+        db.commit()
+
     def append_log(
         self, db: Session, execution_id: str, log_data: dict, *, commit: bool = True
-    ) -> FlowExecutionLog:
+    ) -> models.FlowExecutionLog:
         """Append a log entry.
 
         Moved from crud_flow_execution.append_log for better grouping.
@@ -103,7 +134,7 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         )
         metadata = payload or log_data.get("metadata") or log_data.get("data")
 
-        log_entry = FlowExecutionLog(
+        log_entry = models.FlowExecutionLog(
             execution_id=execution_id,
             log_type=log_data.get("type", "log"),
             message=scrub_secrets(message),

--- a/backend/preloop/models/db/pool_diagnostics.py
+++ b/backend/preloop/models/db/pool_diagnostics.py
@@ -230,6 +230,17 @@ class PoolHoldDiagnostics:
                 }
                 for hold in holds[:MAX_REPORTED_HOLDS]
             ],
+            # The oldest holds can all predate callsite sampling. Report the
+            # oldest sampled holds separately so their evidence stays visible.
+            "oldest_attributed": [
+                {
+                    "held_seconds": round(max(0.0, now - hold.started_at), 3),
+                    "acquired_at": hold.acquired_at,
+                }
+                for hold in [hold for hold in holds if hold.acquired_at][
+                    :MAX_REPORTED_HOLDS
+                ]
+            ],
         }
 
 

--- a/backend/preloop/services/dynamic_fastmcp.py
+++ b/backend/preloop/services/dynamic_fastmcp.py
@@ -782,7 +782,8 @@ async def {internal_name}({params_str}) -> str:
 
     # Call external MCP server
     try:
-        db = next(get_db())
+        db_dependency = get_db()
+        db = next(db_dependency)
         try:
             # Use CRUD layer to get MCP server
             mcp_server = crud_mcp_server.get(db, id=server_id, account_id=account_id)
@@ -790,15 +791,19 @@ async def {internal_name}({params_str}) -> str:
             if not mcp_server:
                 return f"Error: MCP server {{server_id}} not found"
 
-            # Get client from pool
+            # Snapshot configuration before releasing the database connection.
+            # Connecting, approvals and remote tools can wait indefinitely.
+            server_name = mcp_server.name
+            client_config = {{
+                "server_id": server_id,
+                "url": mcp_server.url,
+                "auth_type": mcp_server.auth_type,
+                "auth_config": mcp_server.auth_config,
+                "transport": mcp_server.transport,
+            }}
+            db.close()
             client_pool = get_mcp_client_pool()
-            client = await client_pool.get_client(
-                server_id=server_id,
-                url=mcp_server.url,
-                auth_type=mcp_server.auth_type,
-                auth_config=mcp_server.auth_config,
-                transport=mcp_server.transport,
-            )
+            client = await client_pool.get_client(**client_config)
 
             # Approval and connection setup may outlive the initial halt check.
             denial = await self._halt_dispatch_denial(account_id)
@@ -817,7 +822,7 @@ async def {internal_name}({params_str}) -> str:
                     result,
                     account_id=account_id,
                     tool_name=tool_name,
-                    server_name=getattr(mcp_server, "name", None),
+                    server_name=server_name,
                     managed_agent_id=getattr(
                         user_context, "managed_agent_id", None
                     ),

--- a/backend/preloop/services/websocket_manager.py
+++ b/backend/preloop/services/websocket_manager.py
@@ -4,6 +4,7 @@ import logging
 import threading
 import time
 import uuid
+from contextlib import closing
 from typing import Dict, List, Optional, Set, Tuple
 
 from fastapi import WebSocket
@@ -25,16 +26,22 @@ logger = logging.getLogger(__name__)
 
 # Dictionary to hold loop-specific queues to prevent test runner cross-loop panics
 _log_queues: dict[asyncio.AbstractEventLoop, asyncio.Queue] = {}
+_log_batches: dict[asyncio.AbstractEventLoop, list[tuple[str, dict]]] = {}
 
-# Background log persistence must never starve request-serving connections.
+# Limit the connections used by background log persistence.
 # Only this many threads may hold a pooled DB connection for log writes at a
 # time, so a burst of NATS logs cannot consume the whole QueuePool.
 LOG_PERSIST_MAX_CONCURRENCY = 1
 _log_persist_semaphore = threading.BoundedSemaphore(LOG_PERSIST_MAX_CONCURRENCY)
 
-# Bounded retry for transient pool/connection failures before dropping data.
+# Bound each synchronous retry cycle; the async worker retains failed batches.
 LOG_PERSIST_MAX_ATTEMPTS = 3
 LOG_PERSIST_BASE_BACKOFF_SECONDS = 0.5
+LOG_PERSIST_RETRY_SECONDS = 5.0
+LOG_QUEUE_MAX_SIZE = 10_000
+LOG_BATCH_MAX_SIZE = 500
+LOG_BATCH_WAIT_SECONDS = 0.05
+LOG_SHUTDOWN_DRAIN_SECONDS = 10.0
 
 # Transient errors worth retrying: pool checkout timeouts (QueuePool limit
 # reached) and dropped/failed connections. Anything else is a real bug and is
@@ -66,11 +73,13 @@ def _strip_orphaned_logs(
     from preloop.models.crud import crud_flow_execution
 
     ids = {execution_id for execution_id, _ in batch}
-    db = next(get_db())
-    try:
-        existing = crud_flow_execution.existing_ids(db, list(ids))
-    finally:
-        db.close()
+    # Keep the generator alive until the operation finishes.
+    with closing(get_db()) as sessions:
+        db = next(sessions)
+        try:
+            existing = crud_flow_execution.existing_ids(db, list(ids))
+        finally:
+            db.close()
 
     surviving: List[Tuple[str, dict]] = []
     orphaned: Dict[str, int] = {}
@@ -86,7 +95,7 @@ def get_log_queue() -> asyncio.Queue:
     """Returns the logging queue associated with the current running event loop."""
     loop = asyncio.get_running_loop()
     if loop not in _log_queues:
-        _log_queues[loop] = asyncio.Queue()
+        _log_queues[loop] = asyncio.Queue(maxsize=LOG_QUEUE_MAX_SIZE)
     return _log_queues[loop]
 
 
@@ -96,24 +105,22 @@ def _write_log_batch(batch: List[Tuple[str, dict]]) -> None:
     Raises whatever the database layer raises; retry policy lives in the
     caller. DB access stays behind ``preloop.models.crud``.
     """
-    from preloop.models.crud import crud_flow_execution
+    from preloop.models.crud import crud_flow_execution_log
 
-    db = next(get_db())
-    try:
-        for execution_id, log_data in batch:
-            crud_flow_execution.append_log(
-                db, execution_id=execution_id, log_data=log_data, commit=False
-            )
-        db.commit()
-    except Exception:
-        # Never leave a half-applied transaction on a pooled connection.
+    with closing(get_db()) as sessions:
+        db = next(sessions)
         try:
-            db.rollback()
-        except Exception:  # pragma: no cover - rollback failure is best-effort
-            logger.warning("Rollback failed while aborting log batch", exc_info=True)
-        raise
-    finally:
-        db.close()
+            crud_flow_execution_log.append_logs(db, batch)
+        except Exception:
+            try:
+                db.rollback()
+            except Exception:  # pragma: no cover - rollback is best-effort
+                logger.warning(
+                    "Rollback failed while aborting log batch", exc_info=True
+                )
+            raise
+        finally:
+            db.close()
 
 
 def _sync_batch_insert_logs(batch: list) -> bool:
@@ -122,7 +129,8 @@ def _sync_batch_insert_logs(batch: list) -> bool:
     Pool exhaustion (``QueuePool limit ... reached``) and dropped connections
     are transient: the previous implementation dropped the whole batch on the
     first error, silently losing execution logs during load spikes. We now
-    retry with exponential backoff and only drop as a last resort.
+    retry with exponential backoff, then return control to the async worker
+    without discarding the batch.
 
     A semaphore bounds how many threads may hold a pooled connection for log
     persistence, so background writes cannot exhaust the pool that serves user
@@ -135,9 +143,18 @@ def _sync_batch_insert_logs(batch: list) -> bool:
         True if the batch was persisted (entries for since-deleted executions
         are dropped by design and still count as handled), False if data was
         dropped due to an unexpected error.
+
+    Raises:
+        SQLAlchemyTimeoutError: Pool exhaustion persists after this retry cycle.
+        OperationalError: The database remains unavailable after this retry cycle.
     """
     if not batch:
         return True
+
+    # Stable IDs make a retry safe even if COMMIT succeeded before the
+    # connection failed. Keep them in the retained batch across retry cycles.
+    for _, log_data in batch:
+        log_data.setdefault("_persistence_id", str(uuid.uuid4()))
 
     last_error: Optional[BaseException] = None
     attempts_made = 0
@@ -213,7 +230,10 @@ def _sync_batch_insert_logs(batch: list) -> bool:
                 )
                 break
 
-    # Exhausted retries (or hit a non-retryable error): drop, but loudly.
+    if isinstance(last_error, _RETRYABLE_DB_ERRORS):
+        raise last_error
+
+    # Non-retryable errors are dropped and reported.
     logger.error(
         "Dropping batch of %d logs after %d attempt(s): %s",
         len(batch),
@@ -235,53 +255,92 @@ def _sync_batch_insert_logs(batch: list) -> bool:
     return False
 
 
-async def _log_writer_worker():
-    """
-    Background worker that continuously drains the log queue and writes to the DB in batches.
-    """
-    while True:
-        try:
-            queue = get_log_queue()
-            # Wait for at least one item
-            item = await queue.get()
-            batch = [item]
-
-            # Greedily drain up to 500 items instantly
-            while len(batch) < 500:
+async def _log_writer_worker() -> None:
+    """Persist coalesced batches, retaining them throughout transient outages."""
+    queue = get_log_queue()
+    try:
+        while True:
+            loop = asyncio.get_running_loop()
+            batch = _log_batches.get(loop)
+            if batch is None:
+                batch = [await queue.get()]
+                _log_batches[loop] = batch
+            # Coalesce logs arriving on separate loop ticks without checking out a
+            # connection. Busy streams fill the batch immediately.
+            deadline = asyncio.get_running_loop().time() + LOG_BATCH_WAIT_SECONDS
+            while len(batch) < LOG_BATCH_MAX_SIZE:
                 try:
                     batch.append(queue.get_nowait())
                 except asyncio.QueueEmpty:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        break
+                    try:
+                        batch.append(await asyncio.wait_for(queue.get(), remaining))
+                    except asyncio.TimeoutError:
+                        break
+
+            while True:
+                try:
+                    write_task = asyncio.create_task(
+                        asyncio.to_thread(_sync_batch_insert_logs, batch)
+                    )
+                    try:
+                        await asyncio.shield(write_task)
+                    except asyncio.CancelledError:
+                        # Cancelling to_thread does not stop its transaction. Join
+                        # it before letting shutdown finish or another writer start.
+                        try:
+                            while not write_task.done():
+                                try:
+                                    await asyncio.shield(write_task)
+                                except asyncio.CancelledError:
+                                    # A second shutdown cancellation still must
+                                    # not abandon the database worker thread.
+                                    continue
+                            write_task.result()
+                        except _RETRYABLE_DB_ERRORS:
+                            logger.error(
+                                "Shutdown interrupted persistence; %d logs remain unpersisted",
+                                len(batch),
+                            )
+                        else:
+                            for _ in batch:
+                                queue.task_done()
+                            _log_batches.pop(loop, None)
+                        raise
                     break
-
-            # Dispatch the bulk insert to an isolated thread
-            await asyncio.to_thread(_sync_batch_insert_logs, batch)
-
-            # Mark all dequeued task objects as done
+                except _RETRYABLE_DB_ERRORS as exc:
+                    logger.warning(
+                        "Log persistence delayed; retaining %d logs (%d queued), "
+                        "retrying in %.1fs: %s",
+                        len(batch),
+                        queue.qsize(),
+                        LOG_PERSIST_RETRY_SECONDS,
+                        exc,
+                    )
+                    # No worker thread or database connection is held while waiting.
+                    await asyncio.sleep(LOG_PERSIST_RETRY_SECONDS)
             for _ in batch:
                 queue.task_done()
+            _log_batches.pop(loop, None)
+    except asyncio.CancelledError:
+        pending = _log_batches.get(asyncio.get_running_loop(), [])
+        if pending:
+            logger.warning(
+                "Log writer stopped with %d in-flight and %d queued logs; "
+                "retained for restart on this event loop, lost if the process exits",
+                len(pending),
+                queue.qsize(),
+            )
+        raise
 
-        except asyncio.CancelledError:
-            break
-        except Exception as e:
-            logger.error(f"Error in log writer worker: {e}", exc_info=True)
-            await asyncio.sleep(1)
 
-
-async def persist_execution_log(execution_id: str, log_data: dict):
-    """
-    Asynchronously queues a log entry for persistence to execution_logs array in the database.
-
-    Args:
-        execution_id: ID of the flow execution
-        log_data: Log message data to append
-    """
-    try:
-        # Puts the item into the queue without blocking the NATS consumer event loop
-        get_log_queue().put_nowait((execution_id, log_data))
-    except Exception as e:
-        logger.error(
-            f"Failed to queue log for execution {execution_id}: {e}", exc_info=True
-        )
+async def persist_execution_log(execution_id: str, log_data: dict) -> None:
+    """Queue a log, applying backpressure when the in-memory backlog is full."""
+    await get_log_queue().put(
+        (execution_id, {**log_data, "_persistence_id": str(uuid.uuid4())})
+    )
 
 
 class WebSocketManager:
@@ -604,47 +663,50 @@ async def nats_consumer(manager: "WebSocketManager"):
         except Exception as e:
             logger.error(f"Error persisting log: {e}")
 
+    subscriptions = []
+    log_worker_task = asyncio.create_task(_log_writer_worker())
     try:
-        # Subscribe to a wildcard subject to receive all flow updates
-        await nats_client.subscribe("flow-updates.*", cb=message_handler)
-        logger.info("Subscribed to NATS subject 'flow-updates.*'")
-
-        # Persist logs with a queue group so only one instance writes them to DB
-        await nats_client.subscribe(
-            "flow-updates.*", queue="log-persisters", cb=persistence_handler
-        )
-        logger.info(
-            "Subscribed to NATS subject 'flow-updates.*' with queue group 'log-persisters'"
-        )
-
-        await nats_client.subscribe("account-updates.*", cb=message_handler)
-        logger.info("Subscribed to NATS subject 'account-updates.*'")
-
-        # Subscribe to approval updates
-        await nats_client.subscribe("approval-updates", cb=message_handler)
-        logger.info("Subscribed to NATS subject 'approval-updates'")
-
-        # Subscribe to admin activity updates (for admin dashboard)
-        await nats_client.subscribe("admin.activity", cb=message_handler)
-        logger.info("Subscribed to NATS subject 'admin.activity'")
-
-        # Start the background log writer worker task
-        log_worker_task = asyncio.create_task(_log_writer_worker())
-
+        # Every process broadcasts locally. A queue group assigns each log to
+        # one persister; this is Core NATS and has no durable acknowledgement.
+        for subject, queue_group, handler in (
+            ("flow-updates.*", "", message_handler),
+            ("flow-updates.*", "log-persisters", persistence_handler),
+            ("account-updates.*", "", message_handler),
+            ("approval-updates", "", message_handler),
+            ("admin.activity", "", message_handler),
+        ):
+            subscriptions.append(
+                await nats_client.subscribe(subject, queue=queue_group, cb=handler)
+            )
+            logger.info("Subscribed to NATS subject %s queue=%s", subject, queue_group)
+        while True:
+            await asyncio.sleep(1)
+    except Exception as exc:
+        logger.error("NATS consumer failed: %s", exc)
+    finally:
+        # Stop accepting messages before draining already accepted logs.
+        for subscription in subscriptions:
+            if subscription is not None:
+                try:
+                    await subscription.unsubscribe()
+                except Exception:
+                    logger.warning("Failed to unsubscribe NATS consumer", exc_info=True)
+        queue = get_log_queue()
         try:
-            # Keep the consumer running
-            while True:
-                await asyncio.sleep(1)
+            await asyncio.wait_for(queue.join(), LOG_SHUTDOWN_DRAIN_SECONDS)
+        except asyncio.TimeoutError:
+            logger.error(
+                "Log shutdown drain timed out; %d queued and %d in-flight logs "
+                "may be lost on process exit because Core NATS cannot redeliver them",
+                queue.qsize(),
+                len(_log_batches.get(asyncio.get_running_loop(), [])),
+            )
         finally:
             log_worker_task.cancel()
             try:
                 await log_worker_task
             except asyncio.CancelledError:
-                # Background log writer was cancelled during consumer shutdown.
                 pass
-
-    except Exception as e:
-        logger.error(f"NATS consumer failed: {e}")
 
 
 # Create a single instance of the manager to be used across the application

--- a/backend/preloop/services/websocket_manager.py
+++ b/backend/preloop/services/websocket_manager.py
@@ -337,7 +337,11 @@ async def _log_writer_worker() -> None:
 
 
 async def persist_execution_log(execution_id: str, log_data: dict) -> None:
-    """Queue a log, applying backpressure when the in-memory backlog is full."""
+    """Queue a log, applying backpressure when the in-memory backlog is full.
+
+    NATS runs each subscription's callbacks in its own worker. Waiting here
+    pauses only the persister, not the client reader or realtime subscriptions.
+    """
     await get_log_queue().put(
         (execution_id, {**log_data, "_persistence_id": str(uuid.uuid4())})
     )

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -4,6 +4,7 @@ Tests for the MCP API endpoints.
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any, Generator
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
@@ -233,6 +234,8 @@ async def test_mcp_update_issue_success(db_session: Session, test_user: User):
     assert isinstance(response, GetIssueResponse)
     assert response.title == "Updated Title"
     mock_tracker_client.update_issue.assert_called_once()
+    # The tool owns and closes its session; reattach before checking persistence.
+    db_session.add(issue)
     db_session.refresh(issue)
     assert issue.title == "Updated Title"
 
@@ -2140,7 +2143,11 @@ async def test_update_comment_not_found_maps_to_404_with_warning_log(
 
         from fastapi import HTTPException
 
-        with caplog.at_level(logging.WARNING):
+        # Application loggers do not propagate to pytest's root handler.
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(mcp.logger, "handlers", [caplog.handler]),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await mcp.update_comment(
                     target="owner/repo#123",
@@ -2236,7 +2243,11 @@ async def test_update_comment_genuine_api_failure_maps_to_502_with_error_log(
 
         from fastapi import HTTPException
 
-        with caplog.at_level(logging.ERROR):
+        # Application loggers do not propagate to pytest's root handler.
+        with (
+            caplog.at_level(logging.ERROR),
+            patch.object(mcp.logger, "handlers", [caplog.handler]),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await mcp.update_comment(
                     target="owner/repo#123",
@@ -2326,7 +2337,11 @@ async def test_update_comment_404_substring_is_not_misclassified_as_not_found(
 
         from fastapi import HTTPException
 
-        with caplog.at_level(logging.ERROR):
+        # Application loggers do not propagate to pytest's root handler.
+        with (
+            caplog.at_level(logging.ERROR),
+            patch.object(mcp.logger, "handlers", [caplog.handler]),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await mcp.update_comment(
                     target="owner/repo#123",
@@ -3614,3 +3629,110 @@ async def test_update_pull_request_remove_absent_reaction_is_success(
     assert response.status == "updated"
     assert "FAILED" not in response.message
     assert "already absent" in response.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["read", "create"])
+async def test_pr_provider_uses_hydrated_config_after_session_close(
+    operation: str,
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real tracker/project ORM state is consumed before external provider I/O."""
+    from types import SimpleNamespace
+
+    from sqlalchemy import inspect
+
+    from preloop.api import common
+    from preloop.models import models
+    from preloop.models.crud import crud_project
+
+    tracker = models.Tracker(
+        name="example",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+        auth_type="api_token",
+    )
+    db_session.add(tracker)
+    db_session.flush()
+    organization = models.Organization(
+        name="example", identifier="example", tracker_id=tracker.id
+    )
+    db_session.add(organization)
+    db_session.flush()
+    project = models.Project(
+        name="repo",
+        identifier="example/repo",
+        slug="example/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.add(
+        models.TrackerScopeRule(
+            tracker_id=tracker.id,
+            scope_type="ORGANIZATION",
+            rule_type="INCLUDE",
+            identifier="example",
+        )
+    )
+    db_session.commit()
+    project_id = project.id
+    tracker_id = str(tracker.id)
+    account_id = test_user.account_id
+    recorded = False
+
+    async def provider(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        assert not db_session.in_transaction()
+        assert inspect(project).detached
+        assert inspect(test_user).detached
+        return {
+            "id": "123",
+            "number": 123,
+            "title": "Example",
+            "state": "open",
+            "url": "https://github.com/example/repo/pull/123",
+        }
+
+    async def create_client(**kwargs: Any) -> SimpleNamespace:
+        assert kwargs["tracker_id"] == tracker_id
+        assert kwargs["api_key"] == "test_key"
+        assert kwargs["connection_details"]["owner"] == "example"
+        assert kwargs["connection_details"]["repo"] == "repo"
+        return SimpleNamespace(
+            tracker_type="github",
+            get_pull_request=provider,
+            create_pull_request=provider,
+        )
+
+    def record_opened(db: Session, **kwargs: Any) -> None:
+        nonlocal recorded
+        # The invocation can reopen the same session for persistence after I/O.
+        assert crud_project.get(db, id=project_id, account_id=account_id).name == "repo"
+        recorded = True
+
+    def dependency() -> Generator[Session, None, None]:
+        yield db_session
+
+    monkeypatch.setattr(mcp, "get_db", dependency)
+    monkeypatch.setattr(
+        mcp,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"authorization": "Bearer test"}),
+    )
+    monkeypatch.setattr(
+        mcp, "get_user_from_token_if_valid", AsyncMock(return_value=test_user)
+    )
+    monkeypatch.setattr(common, "create_tracker_client", create_client)
+    monkeypatch.setattr(mcp, "_record_opened_pr_on_execution", record_opened)
+    if operation == "read":
+        result = await mcp.get_pull_request("https://github.com/example/repo/pull/123")
+    else:
+        result = await mcp.create_pull_request(
+            "example/repo", "Example", "feature", "main"
+        )
+        assert recorded
+    assert result.number == 123
+    assert not db_session.in_transaction()

--- a/backend/tests/endpoints/test_mcp_session_lifecycle.py
+++ b/backend/tests/endpoints/test_mcp_session_lifecycle.py
@@ -1,0 +1,256 @@
+"""Native MCP tools must not retain database connections between calls."""
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from typing import Any, Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import QueuePool
+
+from preloop.api.endpoints import mcp
+
+
+@pytest.fixture
+def tool_pool(monkeypatch: pytest.MonkeyPatch) -> Generator[Any, None, None]:
+    """Use a real single-connection pool, without external database services."""
+    engine = create_engine(
+        "sqlite://", poolclass=QueuePool, pool_size=1, max_overflow=0, pool_timeout=0.01
+    )
+    sessions: list[Session] = []
+
+    def get_db() -> Generator[Session, None, None]:
+        db = Session(engine)
+        sessions.append(db)  # Do not let garbage collection hide missing cleanup.
+        try:
+            yield db
+        finally:
+            db.close()
+
+    monkeypatch.setattr(mcp, "get_db", get_db)
+    monkeypatch.setattr(
+        mcp,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"authorization": "Bearer test"}),
+    )
+    try:
+        yield engine.pool
+    finally:
+        for db in sessions:
+            db.close()
+        engine.dispose()
+
+
+TOOL_NAMES = (
+    "get_issue",
+    "create_issue",
+    "update_issue",
+    "search",
+    "estimate_compliance",
+    "improve_compliance",
+    "add_comment",
+    "get_pull_request",
+    "update_pull_request",
+    "create_pull_request",
+    "update_comment",
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", TOOL_NAMES)
+async def test_all_native_tools_release_connection_on_auth_failure(
+    tool_name: str, tool_pool: QueuePool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def invalid_token(token: str, db: Session) -> None:
+        db.execute(text("SELECT 1"))
+        return None
+
+    monkeypatch.setattr(mcp, "get_user_from_token_if_valid", invalid_token)
+    tool = getattr(mcp, tool_name)
+    arguments = {
+        name: ["EX-1"] if name == "issues" else "example"
+        for name, parameter in inspect.signature(tool).parameters.items()
+        if parameter.default is inspect.Parameter.empty
+    }
+    # Repeated denied calls must not exhaust even a minimal pool.
+    for _ in range(3):
+        with pytest.raises(HTTPException) as error:
+            await tool(**arguments)
+        assert error.value.status_code == 401
+        assert tool_pool.checkedout() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "error", "cancel"])
+async def test_concurrent_pr_reads_release_pool_before_provider_wait(
+    outcome: str, tool_pool: QueuePool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    count = 30
+    entered = 0
+    all_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def valid_token(token: str, db: Session) -> Any:
+        db.execute(text("SELECT 1"))
+        return SimpleNamespace(account_id="account")
+
+    async def get_pr(number: int) -> dict[str, Any]:
+        nonlocal entered
+        entered += 1
+        if entered == count:
+            all_entered.set()
+        await release.wait()
+        if outcome == "error":
+            raise RuntimeError("Provider unavailable")
+        return {
+            "id": "1",
+            "number": number,
+            "title": "Example",
+            "state": "open",
+            "url": "https://github.com/example/repo/pull/1",
+        }
+
+    monkeypatch.setattr(mcp, "get_user_from_token_if_valid", valid_token)
+    monkeypatch.setattr(
+        mcp,
+        "_find_pr_project",
+        lambda *args, **kwargs: SimpleNamespace(
+            id="project", organization_id="organization"
+        ),
+    )
+    monkeypatch.setattr(
+        mcp,
+        "get_tracker_client",
+        AsyncMock(
+            return_value=SimpleNamespace(tracker_type="github", get_pull_request=get_pr)
+        ),
+    )
+    tasks = [
+        asyncio.create_task(
+            mcp.get_pull_request("https://github.com/example/repo/pull/1")
+        )
+        for _ in range(count)
+    ]
+    try:
+        await asyncio.wait_for(all_entered.wait(), timeout=2)
+        assert tool_pool.checkedout() == 0
+        if outcome == "cancel":
+            for task in tasks:
+                task.cancel()
+        release.set()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        if outcome == "success":
+            assert all(not isinstance(result, BaseException) for result in results)
+        elif outcome == "error":
+            assert all(
+                isinstance(result, HTTPException) and result.status_code == 502
+                for result in results
+            )
+        else:
+            assert all(isinstance(result, asyncio.CancelledError) for result in results)
+        assert tool_pool.checkedout() == 0
+    finally:
+        release.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait_stage", ["connect", "call"])
+async def test_external_mcp_waits_do_not_hold_database_connections(
+    wait_stage: str, tool_pool: QueuePool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from preloop.services import approval_helper, dynamic_fastmcp
+
+    count = 30
+    entered = 0
+    all_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_at_provider() -> None:
+        nonlocal entered
+        entered += 1
+        if entered == count:
+            all_entered.set()
+        await release.wait()
+
+    async def call_tool(*args: Any) -> list[Any]:
+        if wait_stage == "call":
+            await wait_at_provider()
+        return []
+
+    async def get_client(**kwargs: Any) -> Any:
+        if wait_stage == "connect":
+            await wait_at_provider()
+        return SimpleNamespace(call_tool=call_tool)
+
+    def get_server(db: Session, **kwargs: Any) -> Any:
+        db.execute(text("SELECT 1"))
+        return SimpleNamespace(
+            name="Example",
+            url="https://example.com/mcp",
+            auth_type="none",
+            auth_config={},
+            transport="http",
+        )
+
+    server = dynamic_fastmcp.DynamicFastMCP("pool-test")
+    server.set_user_context_provider(
+        lambda: SimpleNamespace(account_id="account", username="example")
+    )
+    monkeypatch.setattr(dynamic_fastmcp, "get_db", mcp.get_db)
+    monkeypatch.setattr(dynamic_fastmcp.crud_mcp_server, "get", get_server)
+    monkeypatch.setattr(
+        dynamic_fastmcp,
+        "get_mcp_client_pool",
+        lambda: SimpleNamespace(get_client=get_client),
+    )
+    monkeypatch.setattr(
+        approval_helper, "require_approval", AsyncMock(return_value=(True, None))
+    )
+    monkeypatch.setattr(server, "_halt_dispatch_denial", AsyncMock(return_value=None))
+    wrapper = server._create_proxied_tool_wrapper(
+        "example", "server", "account", "Example", {"properties": {}}
+    )
+    tasks = [asyncio.create_task(wrapper()) for _ in range(count)]
+    try:
+        await asyncio.wait_for(all_entered.wait(), timeout=2)
+        assert tool_pool.checkedout() == 0
+        for task in tasks:
+            task.cancel()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(isinstance(result, asyncio.CancelledError) for result in results)
+        assert tool_pool.checkedout() == 0
+    finally:
+        release.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_native_tool_cancellation_during_auth_releases_connection(
+    tool_pool: QueuePool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    entered = asyncio.Event()
+
+    async def authenticate(token: str, db: Session) -> None:
+        db.execute(text("SELECT 1"))
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(mcp, "get_user_from_token_if_valid", authenticate)
+    task = asyncio.create_task(
+        mcp.get_pull_request("https://github.com/example/repo/pull/1")
+    )
+    await entered.wait()
+    assert tool_pool.checkedout() == 1
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert tool_pool.checkedout() == 0

--- a/backend/tests/endpoints/test_mcp_session_lifecycle.py
+++ b/backend/tests/endpoints/test_mcp_session_lifecycle.py
@@ -251,6 +251,6 @@ async def test_native_tool_cancellation_during_auth_releases_connection(
     await entered.wait()
     assert tool_pool.checkedout() == 1
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    cancelled = await asyncio.gather(task, return_exceptions=True)
+    assert isinstance(cancelled[0], asyncio.CancelledError)
     assert tool_pool.checkedout() == 0

--- a/backend/tests/services/test_db_pool_hold_diagnostics.py
+++ b/backend/tests/services/test_db_pool_hold_diagnostics.py
@@ -333,6 +333,47 @@ def test_should_capture_callsite_at_half_of_size_and_overflow() -> None:
     assert diagnostics._should_capture_callsite(pool)
 
 
+def test_oldest_unsampled_holds_do_not_hide_sampled_acquisitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full pool reports attribution even when its oldest holds predate pressure."""
+    monkeypatch.delenv("DB_POOL_HOLD_DIAGNOSTICS", raising=False)
+    pool_engine = create_engine(
+        "sqlite://", poolclass=QueuePool, pool_size=16, max_overflow=0
+    )
+    diagnostics.install_pool_hold_diagnostics(pool_engine)
+    namespace: dict[str, Any] = {"engine": pool_engine}
+    exec(
+        compile(
+            "def acquire():\n    return engine.connect()\n",
+            str(Path(diagnostics._PACKAGE_ROOT) / "services" / "sample_provider.py"),
+            "exec",
+        ),
+        namespace,
+    )
+    connections = []
+    try:
+        connections = [namespace["acquire"]() for _ in range(16)]
+        snapshot = diagnostics.collect_pool_holds(pool_engine)
+        assert len(snapshot["oldest"]) == diagnostics.MAX_REPORTED_HOLDS
+        assert all(not hold["acquired_at"] for hold in snapshot["oldest"])
+        attributed = snapshot["oldest_attributed"]
+        assert len(attributed) == diagnostics.MAX_REPORTED_HOLDS
+        assert all(
+            "services/sample_provider.py:acquire:2" in hold["acquired_at"]
+            for hold in attributed
+        )
+        assert all(
+            first["held_seconds"] >= second["held_seconds"]
+            for first, second in zip(attributed, attributed[1:], strict=False)
+        )
+    finally:
+        for connection in connections:
+            connection.close()
+        pool_engine.dispose()
+    assert diagnostics.collect_pool_holds(pool_engine)["oldest_attributed"] == []
+
+
 def test_dispose_during_capture_cannot_reinsert_old_hold(engine: Engine) -> None:
     tracker = getattr(engine, diagnostics._ATTRIBUTE)
     old_record = object()

--- a/backend/tests/services/test_log_persistence_backpressure.py
+++ b/backend/tests/services/test_log_persistence_backpressure.py
@@ -1,12 +1,19 @@
 """Exercise batching, pool saturation and retry safety against a local DB."""
 
 import asyncio
+import json
 import threading
 import uuid
 from collections.abc import Generator
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from nats.aio.client import Client
+from nats.aio.msg import Msg
+from nats.aio.subscription import Subscription
+from nats.errors import SlowConsumerError
+from collections.abc import Awaitable, Callable
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError, TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session
@@ -201,8 +208,8 @@ async def test_worker_cancellation_waits_for_in_flight_transaction(monkeypatch) 
         await asyncio.sleep(0.01)
         assert not worker.done()
         release.set()
-        with pytest.raises(asyncio.CancelledError):
-            await worker
+        cancelled = await asyncio.gather(worker, return_exceptions=True)
+        assert isinstance(cancelled[0], asyncio.CancelledError)
         await asyncio.wait_for(queue.join(), 2)
     finally:
         release.set()
@@ -238,8 +245,8 @@ async def test_worker_restart_recovers_dequeued_batch(phase, monkeypatch) -> Non
         # Allow the worker to enter its async backoff after the thread finishes.
         await asyncio.sleep(0.01)
         worker.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await worker
+        cancelled = await asyncio.gather(worker, return_exceptions=True)
+        assert isinstance(cancelled[0], asyncio.CancelledError)
         assert len(logs._log_batches[loop]) == 1
         monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0)
         monkeypatch.setattr(
@@ -255,3 +262,133 @@ async def test_worker_restart_recovers_dequeued_batch(phase, monkeypatch) -> Non
         await asyncio.gather(worker, return_exceptions=True)
         logs._log_queues.pop(loop, None)
         logs._log_batches.pop(loop, None)
+
+
+@pytest.mark.asyncio
+async def test_blocked_persister_does_not_stall_other_nats_subscriptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the real NATS parser and per-subscription callback workers."""
+    client = Client()
+    client._status = Client.CONNECTED
+    errors = AsyncMock()
+    client._error_cb = errors
+    # Replace only the socket writes: subscribe, parser dispatch and callback
+    # workers are the installed nats-py implementation used in production.
+    monkeypatch.setattr(client, "_send_subscribe", AsyncMock())
+    monkeypatch.setattr(client, "_send_unsubscribe", AsyncMock())
+    subscribe = client.subscribe
+    subscriptions: dict[tuple[str, str], Subscription] = {}
+
+    async def bounded_subscribe(
+        subject: str, *, queue: str, cb: Callable[[Msg], Awaitable[None]]
+    ) -> Subscription:
+        options = {"pending_msgs_limit": 2} if queue == "log-persisters" else {}
+        sub = await subscribe(subject, queue=queue, cb=cb, **options)
+        subscriptions[(subject, queue)] = sub
+        return sub
+
+    monkeypatch.setattr(client, "subscribe", bounded_subscribe)
+    monkeypatch.setattr(
+        logs, "get_task_publisher", AsyncMock(return_value=SimpleNamespace(nc=client))
+    )
+    monkeypatch.setattr(logs, "LOG_QUEUE_MAX_SIZE", 1)
+    monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0)
+    release_writer = asyncio.Event()
+    writer = logs._log_writer_worker
+    persisted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        logs, "_sync_batch_insert_logs", lambda batch: persisted.extend(batch)
+    )
+
+    async def gated_writer() -> None:
+        await release_writer.wait()
+        await writer()
+
+    monkeypatch.setattr(logs, "_log_writer_worker", gated_writer)
+    queue = logs.get_log_queue()
+    await logs.persist_execution_log("execution", {"message": "already queued"})
+    persister_entered = asyncio.Event()
+    callback_tasks: set[asyncio.Task] = set()
+    persist = logs.persist_execution_log
+
+    async def observe_persistence(execution_id: str, log_data: dict) -> None:
+        callback_tasks.add(asyncio.current_task())
+        persister_entered.set()
+        await persist(execution_id, log_data)
+
+    monkeypatch.setattr(logs, "persist_execution_log", observe_persistence)
+    manager = logs.WebSocketManager()
+    monkeypatch.setattr(manager, "broadcast_json", AsyncMock())
+    consumer = asyncio.create_task(logs.nats_consumer(manager))
+
+    async def dispatch(sub: Subscription, message_type: str) -> None:
+        # Feed actual wire frames through the shared client parser. A server
+        # already resolves wildcards and delivers the matching subscription ID.
+        payload = json.dumps(
+            {"execution_id": "execution", "account_id": "account", "type": message_type}
+        ).encode()
+        subject = sub.subject.replace("*", "example")
+        frame = f"MSG {subject} {sub._id} {len(payload)}\r\n".encode()
+        await client._ps.parse(frame + payload + b"\r\n")
+
+    try:
+        async with asyncio.timeout(2):
+            while len(subscriptions) < 5:
+                await asyncio.sleep(0)
+        persister = subscriptions[("flow-updates.*", "log-persisters")]
+        await dispatch(persister, "agent_log_line")
+        await asyncio.wait_for(persister_entered.wait(), 2)
+        tasks_before_burst = asyncio.all_tasks()
+        realtime = [
+            (subscriptions[("flow-updates.*", "")], "agent_log_line"),
+            (subscriptions[("account-updates.*", "")], "activity_update"),
+            (subscriptions[("approval-updates", "")], "approval_update"),
+            (subscriptions[("admin.activity", "")], "admin_activity"),
+        ]
+        async with asyncio.timeout(2):
+            for _ in range(20):
+                await dispatch(persister, "agent_log_line")
+                for sub, message_type in realtime:
+                    await dispatch(sub, message_type)
+            for sub, _ in realtime:
+                await sub._pending_queue.join()
+
+        assert manager.broadcast_json.await_count == 80
+        for _, message_type in realtime:
+            assert (
+                sum(
+                    call.args[0]["type"] == message_type
+                    for call in manager.broadcast_json.await_args_list
+                )
+                == 20
+            )
+        assert queue.qsize() == 1
+        assert persister.pending_msgs == 2
+        assert errors.await_count == 18
+        assert all(
+            isinstance(call.args[0], SlowConsumerError)
+            and call.args[0].sub is persister
+            for call in errors.await_args_list
+        )
+        assert callback_tasks == {persister._wait_for_msgs_task}
+        assert asyncio.all_tasks() == tasks_before_burst
+
+        release_writer.set()
+        async with asyncio.timeout(2):
+            await persister._pending_queue.join()
+            await queue.join()
+        assert len(persisted) == 4
+        assert callback_tasks == {persister._wait_for_msgs_task}
+    finally:
+        release_writer.set()
+        consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        for sub in subscriptions.values():
+            sub._stop_processing()
+        await asyncio.gather(
+            *(sub._wait_for_msgs_task for sub in subscriptions.values()),
+            return_exceptions=True,
+        )
+        logs._log_queues.pop(asyncio.get_running_loop(), None)
+        logs._log_batches.pop(asyncio.get_running_loop(), None)

--- a/backend/tests/services/test_log_persistence_backpressure.py
+++ b/backend/tests/services/test_log_persistence_backpressure.py
@@ -1,0 +1,257 @@
+"""Exercise batching, pool saturation and retry safety against a local DB."""
+
+import asyncio
+import threading
+import uuid
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError, TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import QueuePool
+
+from preloop.services import websocket_manager as logs
+
+
+@pytest.fixture
+def log_database(tmp_path, monkeypatch):
+    """Use a deliberately tiny local pool, never a configured deployment DB."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'logs.sqlite'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.01,
+        connect_args={"check_same_thread": False},
+    )
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE flow_execution_log (id CHAR(32) PRIMARY KEY, "
+                "execution_id CHAR(32), timestamp DATETIME, log_type VARCHAR(50), "
+                "message TEXT, metadata JSON, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+            )
+        )
+
+    def sessions() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    monkeypatch.setattr(logs, "get_db", sessions)
+    monkeypatch.setattr(logs, "LOG_PERSIST_BASE_BACKOFF_SECONDS", 0.001)
+    monkeypatch.setattr(logs, "LOG_PERSIST_RETRY_SECONDS", 0.001)
+    monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0.01)
+    with patch.object(logs, "notify_admins") as notify:
+        yield engine, notify
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_saturated_pool_retains_logs_and_backpressures_producers(
+    log_database, monkeypatch
+) -> None:
+    engine, notify = log_database
+    monkeypatch.setattr(logs, "LOG_QUEUE_MAX_SIZE", 32)
+    monkeypatch.setattr(logs, "LOG_BATCH_MAX_SIZE", 16)
+    queue = logs.get_log_queue()
+    exhausted_cycle = threading.Event()
+    original_insert = logs._sync_batch_insert_logs
+    batch_sizes: list[int] = []
+
+    def insert(batch: list) -> bool:
+        batch_sizes.append(len(batch))
+        try:
+            return original_insert(batch)
+        except SQLAlchemyTimeoutError:
+            exhausted_cycle.set()
+            raise
+
+    monkeypatch.setattr(logs, "_sync_batch_insert_logs", insert)
+    connections = [engine.connect()]
+    worker = asyncio.create_task(logs._log_writer_worker())
+    execution_ids = [str(uuid.uuid4()) for _ in range(40)]
+
+    async def producer(execution_id: str) -> None:
+        for line in range(100):
+            await logs.persist_execution_log(
+                execution_id, {"type": "agent_log_line", "message": str(line)}
+            )
+
+    producers = [
+        asyncio.create_task(producer(execution_id)) for execution_id in execution_ids
+    ]
+    try:
+        async with asyncio.timeout(5):
+            while not exhausted_cycle.is_set():
+                await asyncio.sleep(0.005)
+        assert queue.qsize() == 32
+        assert not all(task.done() for task in producers)
+        assert engine.pool.checkedout() == 1
+        for connection in connections:
+            connection.close()
+        connections.clear()
+        await asyncio.wait_for(asyncio.gather(*producers), 10)
+        await asyncio.wait_for(queue.join(), 10)
+        with engine.connect() as connection:
+            count = connection.scalar(text("SELECT COUNT(*) FROM flow_execution_log"))
+            executions = connection.scalar(
+                text("SELECT COUNT(DISTINCT execution_id) FROM flow_execution_log")
+            )
+        assert count == 4000
+        assert executions == 40
+        assert max(batch_sizes) <= 16
+        assert engine.pool.checkedout() == 0
+        notify.assert_not_called()
+    finally:
+        for connection in connections:
+            connection.close()
+        for task in producers:
+            task.cancel()
+        await asyncio.gather(*producers, return_exceptions=True)
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        logs._log_queues.pop(asyncio.get_running_loop(), None)
+
+
+def test_retry_after_ambiguous_commit_does_not_duplicate_logs(
+    log_database, monkeypatch
+) -> None:
+    engine, notify = log_database
+    original_commit = Session.commit
+    commits = 0
+
+    def commit(session: Session) -> None:
+        nonlocal commits
+        original_commit(session)
+        commits += 1
+        if commits == 1:
+            raise OperationalError("COMMIT", {}, Exception("connection dropped"))
+
+    monkeypatch.setattr(Session, "commit", commit)
+    secret = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    batch = [
+        (str(uuid.uuid4()), {"message": f"https://{secret}@example.com/repository"}),
+        (str(uuid.uuid4()), {"type": "agent_log_line", "payload": {"line": "ok"}}),
+    ]
+    assert logs._sync_batch_insert_logs(batch)
+    with engine.connect() as connection:
+        rows = (
+            connection.execute(
+                text("SELECT message FROM flow_execution_log ORDER BY message")
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    assert "ok" in rows
+    assert all(secret not in message for message in rows)
+    assert commits == 2
+    assert engine.pool.checkedout() == 0
+    notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coalesces_lines_from_separate_event_loop_ticks(monkeypatch) -> None:
+    monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0.05)
+    batches = []
+    monkeypatch.setattr(
+        logs, "_sync_batch_insert_logs", lambda batch: batches.append(batch)
+    )
+    worker = asyncio.create_task(logs._log_writer_worker())
+    queue = logs.get_log_queue()
+    try:
+        for index in range(10):
+            await logs.persist_execution_log("execution", {"message": str(index)})
+            await asyncio.sleep(0.001)
+        await asyncio.wait_for(queue.join(), 2)
+        assert len(batches) == 1
+        assert len(batches[0]) == 10
+    finally:
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        logs._log_queues.pop(asyncio.get_running_loop(), None)
+
+
+@pytest.mark.asyncio
+async def test_worker_cancellation_waits_for_in_flight_transaction(monkeypatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0)
+
+    def insert(batch: list) -> bool:
+        started.set()
+        assert release.wait(5)
+        return True
+
+    monkeypatch.setattr(logs, "_sync_batch_insert_logs", insert)
+    queue = logs.get_log_queue()
+    await logs.persist_execution_log("execution", {"message": "in flight"})
+    worker = asyncio.create_task(logs._log_writer_worker())
+    try:
+        async with asyncio.timeout(2):
+            while not started.is_set():
+                await asyncio.sleep(0.001)
+        worker.cancel()
+        await asyncio.sleep(0.01)
+        assert not worker.done()
+        worker.cancel()
+        await asyncio.sleep(0.01)
+        assert not worker.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await worker
+        await asyncio.wait_for(queue.join(), 2)
+    finally:
+        release.set()
+        await asyncio.gather(worker, return_exceptions=True)
+        logs._log_queues.pop(asyncio.get_running_loop(), None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["coalescing", "retry_backoff"])
+async def test_worker_restart_recovers_dequeued_batch(phase, monkeypatch) -> None:
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(
+        logs, "LOG_BATCH_WAIT_SECONDS", 60 if phase == "coalescing" else 0
+    )
+    monkeypatch.setattr(logs, "LOG_PERSIST_RETRY_SECONDS", 60)
+    failed = threading.Event()
+    written: list[tuple[str, dict]] = []
+
+    def unavailable(batch: list) -> bool:
+        failed.set()
+        raise SQLAlchemyTimeoutError("pool exhausted")
+
+    monkeypatch.setattr(logs, "_sync_batch_insert_logs", unavailable)
+    queue = logs.get_log_queue()
+    await logs.persist_execution_log("execution", {"message": "retained"})
+    worker = asyncio.create_task(logs._log_writer_worker())
+    try:
+        async with asyncio.timeout(2):
+            while not logs._log_batches.get(loop) or (
+                phase == "retry_backoff" and not failed.is_set()
+            ):
+                await asyncio.sleep(0.001)
+        # Allow the worker to enter its async backoff after the thread finishes.
+        await asyncio.sleep(0.01)
+        worker.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await worker
+        assert len(logs._log_batches[loop]) == 1
+        monkeypatch.setattr(logs, "LOG_BATCH_WAIT_SECONDS", 0)
+        monkeypatch.setattr(
+            logs, "_sync_batch_insert_logs", lambda batch: written.extend(batch)
+        )
+        worker = asyncio.create_task(logs._log_writer_worker())
+        await asyncio.wait_for(queue.join(), 2)
+        assert len(written) == 1
+        assert written[0][1]["message"] == "retained"
+        assert loop not in logs._log_batches
+    finally:
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        logs._log_queues.pop(loop, None)
+        logs._log_batches.pop(loop, None)

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -46,15 +46,20 @@ class TestPersistExecutionLog:
         log_data = {"message": "Step completed", "level": "INFO"}
 
         mock_queue = MagicMock()
+        mock_queue.put = AsyncMock()
         mock_get_queue.return_value = mock_queue
 
         await persist_execution_log(execution_id, log_data)
 
         # Verify queue was called
-        mock_queue.put_nowait.assert_called_once_with((execution_id, log_data))
+        mock_queue.put.assert_awaited_once()
+        queued_id, queued_data = mock_queue.put.call_args.args[0]
+        assert queued_id == execution_id
+        assert queued_data["message"] == log_data["message"]
+        assert uuid.UUID(queued_data["_persistence_id"])
 
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_sync_batch_insert_logs_success(self, mock_append, mock_get_db):
         """Test the synchronous batch insertion function."""
         execution_id = "exec_123"
@@ -63,19 +68,16 @@ class TestPersistExecutionLog:
 
         # Mock database session
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.return_value = (db for db in [mock_db])
 
         _sync_batch_insert_logs(batch)
 
-        # Verify CRUD append_log was called with commit=False
-        mock_append.assert_called_once_with(
-            mock_db, execution_id=execution_id, log_data=log_data, commit=False
-        )
-        assert mock_db.commit.called
+        # Verify the whole batch is delegated to one CRUD transaction.
+        mock_append.assert_called_once_with(mock_db, batch)
         assert mock_db.close.called
 
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_sync_batch_insert_logs_with_complex_data(self, mock_append, mock_get_db):
         """Test batch persisting execution log with complex data."""
         execution_id = "exec_456"
@@ -87,21 +89,18 @@ class TestPersistExecutionLog:
         batch = [(execution_id, log_data)]
 
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.return_value = (db for db in [mock_db])
 
         _sync_batch_insert_logs(batch)
 
         # Verify CRUD was called with the complex data dict
-        mock_append.assert_called_once_with(
-            mock_db, execution_id=execution_id, log_data=log_data, commit=False
-        )
-        assert mock_db.commit.called
+        mock_append.assert_called_once_with(mock_db, batch)
         assert mock_db.close.called
 
     @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.services.websocket_manager.logger")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_sync_batch_insert_logs_database_error(
         self, mock_append, mock_logger, mock_get_db, mock_notify
     ):
@@ -117,7 +116,7 @@ class TestPersistExecutionLog:
 
         # Mock CRUD to raise exception
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.return_value = (db for db in [mock_db])
         mock_append.side_effect = Exception("Database error")
 
         _sync_batch_insert_logs(batch)
@@ -134,10 +133,10 @@ class TestPersistExecutionLog:
     def test_sync_batch_insert_logs_closes_db_on_success(self, mock_get_db):
         """Test that database is closed even on success."""
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.return_value = (db for db in [mock_db])
         batch = [("exec_id", {"message": "test"})]
 
-        with patch("preloop.models.crud.crud_flow_execution.append_log"):
+        with patch("preloop.models.crud.crud_flow_execution_log.append_logs"):
             _sync_batch_insert_logs(batch)
 
         assert mock_db.close.called
@@ -157,11 +156,11 @@ class TestSyncBatchInsertLogsRetry:
             yield sleep
 
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_retries_pool_timeout_then_succeeds(self, mock_append, mock_get_db):
         """A transient QueuePool timeout is retried and the batch is saved."""
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         # Fail once with the exact error seen in production, then succeed.
         mock_append.side_effect = [
             SQLAlchemyTimeoutError("QueuePool limit of size 3 overflow 7 reached"),
@@ -170,32 +169,31 @@ class TestSyncBatchInsertLogsRetry:
 
         assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is True
         assert mock_append.call_count == 2
-        assert mock_db.commit.called
 
     @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
-    def test_drops_only_after_max_attempts(
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
+    def test_transient_failure_returns_to_worker_after_max_attempts(
         self, mock_append, mock_get_db, mock_notify, _no_sleep
     ):
-        """Persistent failure drops the batch, but only after all attempts."""
+        """Persistent failure is retained by the worker, without a loss alert."""
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = SQLAlchemyTimeoutError("QueuePool limit reached")
 
-        assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is False
+        with pytest.raises(SQLAlchemyTimeoutError):
+            _sync_batch_insert_logs([("exec_1", {"message": "hi"})])
         assert mock_append.call_count == LOG_PERSIST_MAX_ATTEMPTS
-        # Operator is still told about real data loss.
-        assert mock_notify.called
+        mock_notify.assert_not_called()
         # Exponential backoff between attempts: 0.5s then 1.0s.
         assert [c.args[0] for c in _no_sleep.call_args_list] == [0.5, 1.0]
 
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_retries_operational_error(self, mock_append, mock_get_db):
         """Dropped connections (OperationalError) are also transient."""
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = [
             OperationalError("SELECT 1", {}, Exception("server closed connection")),
             None,
@@ -206,13 +204,13 @@ class TestSyncBatchInsertLogsRetry:
 
     @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_non_retryable_error_fails_fast(
         self, mock_append, mock_get_db, mock_notify, _no_sleep
     ):
         """Programming errors are not retried - no point hammering the DB."""
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = ValueError("bad log payload")
 
         assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is False
@@ -221,11 +219,11 @@ class TestSyncBatchInsertLogsRetry:
         assert mock_notify.called
 
     @patch("preloop.services.websocket_manager.get_db")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_failed_attempt_rolls_back(self, mock_append, mock_get_db):
         """A failed batch must not leave a dirty transaction on the pool."""
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = [SQLAlchemyTimeoutError("pool"), None]
 
         _sync_batch_insert_logs([("exec_1", {"message": "hi"})])
@@ -243,7 +241,7 @@ class TestSyncBatchInsertLogsRetry:
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.services.websocket_manager.logger")
     @patch("preloop.models.crud.crud_flow_execution.existing_ids")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_fk_violation_for_deleted_execution_drops_quietly(
         self, mock_append, mock_existing, mock_logger, mock_get_db, mock_notify
     ):
@@ -257,7 +255,7 @@ class TestSyncBatchInsertLogsRetry:
         """
         execution_id = str(uuid.uuid4())
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = _fk_violation()
         mock_existing.return_value = set()  # execution row is gone
 
@@ -284,7 +282,7 @@ class TestSyncBatchInsertLogsRetry:
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.services.websocket_manager.logger")
     @patch("preloop.models.crud.crud_flow_execution.existing_ids")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_fk_violation_mixed_batch_persists_survivors(
         self, mock_append, mock_existing, mock_logger, mock_get_db, mock_notify
     ):
@@ -292,7 +290,7 @@ class TestSyncBatchInsertLogsRetry:
         live_id = str(uuid.uuid4())
         orphan_id = str(uuid.uuid4())
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         # First write attempt fails on the orphan; retry succeeds.
         mock_append.side_effect = [_fk_violation(), None]
         mock_existing.return_value = {live_id}
@@ -307,8 +305,8 @@ class TestSyncBatchInsertLogsRetry:
         assert result is True
         # Retry only wrote the surviving entry.
         last_call = mock_append.call_args_list[-1]
-        assert last_call.kwargs["execution_id"] == live_id
-        assert mock_db.commit.called
+        assert last_call.args[1][0][0] == live_id
+        assert len(last_call.args[1]) == 1
         # Single warning for the orphan, no alert.
         assert mock_logger.warning.call_count == 1
         assert not mock_notify.called
@@ -317,14 +315,14 @@ class TestSyncBatchInsertLogsRetry:
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.services.websocket_manager.logger")
     @patch("preloop.models.crud.crud_flow_execution.existing_ids")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_fk_violation_with_live_executions_is_loud(
         self, mock_append, mock_existing, mock_logger, mock_get_db, mock_notify
     ):
         """An FK violation while every execution exists is NOT the orphan case."""
         execution_id = str(uuid.uuid4())
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         mock_append.side_effect = _fk_violation()
         mock_existing.return_value = {execution_id}  # rows all exist
 
@@ -339,7 +337,7 @@ class TestSyncBatchInsertLogsRetry:
     @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.models.crud.crud_flow_execution.existing_ids")
-    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    @patch("preloop.models.crud.crud_flow_execution_log.append_logs")
     def test_fk_violation_existence_checked_only_once(
         self, mock_append, mock_existing, mock_get_db, mock_notify
     ):
@@ -347,7 +345,7 @@ class TestSyncBatchInsertLogsRetry:
         live_id = str(uuid.uuid4())
         orphan_id = str(uuid.uuid4())
         mock_db = MagicMock()
-        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_get_db.side_effect = lambda: (db for db in [mock_db])
         # Survivor hits an FK violation again on the retry.
         mock_append.side_effect = [_fk_violation(), _fk_violation()]
         mock_existing.return_value = {live_id}

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -132,6 +132,9 @@ including SQLAlchemy greenlet parents for async callers.
 
 The existing pool monitor warning includes the five oldest active holds with
 monotonic durations and sanitized package-relative file/function/line identities.
+Callsites are sampled only from half capacity onward. The separate
+`oldest_attributed` list includes up to five sampled active holds, so early
+unsampled acquisitions cannot hide the available callsite evidence.
 At most 128 active holds are retained per engine. No SQL, parameters, source lines,
 locals, credentials, account identifiers, frame objects or DBAPI connections are
 captured. Metadata is removed on checkin, invalidation, close and detach; engine

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -43,6 +43,22 @@ FastMCP's `@mcp.tool()` decorator, then filtered at runtime based on user contex
 - Full compatibility with FastMCP's StreamableHTTP implementation
 - Backward compatible with existing authentication infrastructure
 
+## Database session lifetime
+
+Native MCP tool functions own a lazy database session per invocation through
+`_with_tool_db`. The dependency generator remains alive until the tool finishes,
+and the session closes on success, error, or cancellation. FastMCP invokes these
+functions directly, so FastAPI does not manage their database dependencies.
+
+Pull request and comment tools resolve tracker configuration and identifiers,
+then close their read transaction before awaiting external tracker operations.
+The tracker factory currently constructs clients without network I/O. Proxied
+MCP tools likewise snapshot server configuration and release the database session
+before connecting or calling a remote tool. Database writes after a provider
+response can reopen the invocation's session and are still covered by final
+cleanup. Concurrent provider waits therefore do not each reserve a database
+connection on these paths.
+
 ## MCP Flow (Integrated HTTP)
 1.  **MCP Client Request:** An MCP client (e.g., Claude Code) sends a tool request using streamable HTTP transport to the MCP server (e.g., `/mcp/v1`). The request includes the standard MCP payload and an `Authorization: Bearer <token>` header.
 2.  **Preloop API Server:**

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -31,6 +31,16 @@ and one active batch of at most 500 entries. Producers await queue capacity;
 these bounds count entries, not payload bytes. A short coalescing window gathers
 logs arriving on separate event-loop ticks into one database transaction.
 
+The pinned nats-py client dispatches messages into each subscription's bounded
+pending queue without awaiting that subscription's callback. One worker per
+subscription invokes its callbacks serially. Waiting for log queue capacity
+therefore pauses the `log-persisters` worker while the separate flow, account,
+approval and admin realtime subscriptions continue processing. No per-message
+producer tasks are created. If the persister's NATS pending buffer also fills,
+the NATS client reports a slow-consumer error and drops that subscription's overflowing
+messages; it cannot provide durable backpressure to publishers. This transport
+limit is separate from retention of logs already accepted into the writer queue.
+
 Database sessions exist only during a write attempt. The CRUD layer scrubs each
 batch and inserts it with stable row IDs, so retrying after an ambiguous commit
 response cannot duplicate the same accepted event. Pool checkout timeouts and

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -21,3 +21,30 @@ Single WebSocket connection per client with pub/sub message routing:
 - Clear separation of concerns
 
 > **Enterprise Features**: Preloop Cloud and Preloop Enterprise add RBAC and approval workflows with quorum, escalations and AI gates. Contact sales@preloop.ai for more information.
+
+## Execution log persistence
+
+Each API process receives realtime flow updates through Core NATS. A separate
+`log-persisters` queue subscription assigns each log to one process for database
+persistence. Each process has one writer with a bounded queue of 10,000 entries
+and one active batch of at most 500 entries. Producers await queue capacity;
+these bounds count entries, not payload bytes. A short coalescing window gathers
+logs arriving on separate event-loop ticks into one database transaction.
+
+Database sessions exist only during a write attempt. The CRUD layer scrubs each
+batch and inserts it with stable row IDs, so retrying after an ambiguous commit
+response cannot duplicate the same accepted event. Pool checkout timeouts and
+connection failures trigger bounded synchronous retry cycles followed by an
+asynchronous delay. The writer retains the batch until the database recovers;
+exhausting one retry cycle does not drop it. Known logs for deleted executions
+are discarded, while non-retryable data errors still produce a loss alert.
+
+Shutdown stops subscriptions and allows accepted logs to drain. Cancellation
+joins an active database write and retains unfinished batches for a writer
+restart on the same event loop. A drain timeout reports both queued and active
+counts. The queue and retained batch are process memory: a process exit, an
+extended outage that exceeds Core NATS client buffering, or a failed publish can
+still lose logs. Core NATS provides no durable acknowledgement or redelivery.
+Restart-safe delivery requires a separate durable transport change. Limiting
+writer concurrency reduces pool pressure but does not reserve capacity away
+from API requests.


### PR DESCRIPTION
Concurrent MCP reviewer calls can exhaust the API database pool because native tools open sessions outside FastAPI's dependency lifecycle and leave connections checked out. Pool saturation then blocks sign-in and causes execution log batches to be discarded after three retries.

Give every native MCP invocation explicit session ownership and close it on success, failure, or cancellation. Release read transactions before pull-request/comment provider waits and before remote MCP connection/tool waits. Retain log batches across transient database failures, bound queue growth, coalesce writes, and use stable IDs to make ambiguous-commit retries idempotent. Pool diagnostics now show sampled holders even when the oldest acquisitions were unsampled.

Validation includes real one-connection pool regressions for 30 concurrent native and proxied MCP calls, and recovery of 4,000 logs from 40 producers through pool exhaustion. Cancellation, repeated cancellation, same-loop writer restart, duplicate prevention and scrubbing are covered. After rebasing onto current main (`b4c9c025`), the combined MCP, log, diagnostics and health suite passes all 236 tests. Final changed-file pre-commit checks, including OpenAPI generation, pass with no schema change.

Logs still use Core NATS and an in-memory queue. Process exit or exhausted upstream buffering can lose data; durable transport remains a separate change. Pool size and readiness status behavior are unchanged.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-tested fix for MCP session leaks and log persistence. The prior concern about blocking backpressure stalling NATS realtime broadcasts was resolved by a regression test proving nats-py isolates subscription callbacks per worker.
>
> **Overview**
> Gives native MCP tools explicit session ownership, releases read transactions before provider waits, and rewrites log persistence to retain batches across transient DB failures with stable idempotent IDs. Extensive pool-concurrency, cancellation, and backpressure regression tests cover the change.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit b9ed69c5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->