### PR TITLE
Add a disposable capacity lab with simulated agents and providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Enterprise licensing: sales@preloop.ai.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+The [disposable capacity lab](scripts/capacity/README.md) measures authenticated MCP,
+model-gateway and execution-log workloads using local simulated providers.
+
 ## License
 
 [Apache License 2.0](LICENSE). Copyright (c) 2026 Spacecode AI Inc.

--- a/scripts/capacity/.gitignore
+++ b/scripts/capacity/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/scripts/capacity/README.md
+++ b/scripts/capacity/README.md
@@ -1,0 +1,83 @@
+# Disposable Preloop capacity lab
+
+This lab sends authenticated traffic through Preloop, PostgreSQL and NATS using a deterministic local model and MCP server. Each simulated agent connects to Preloop's MCP endpoint, discovers and calls the proxied `capacity_echo` tool, then consumes a streaming response through the separate model gateway. Independent probes exercise sign-in, authenticated control reads and liveness. The optional log lane publishes known-count execution logs through the real NATS `log-persisters` path.
+
+It measures a particular checkout and workload. It does not run actual CLI agent processes, Kubernetes jobs, tracker PR reviews, human approvals or paid models. A synthetic agent's concurrency is therefore not a supported production agent count.
+
+## Disposable VM quickstart
+
+Use a new Linux VM with Docker Engine, Compose v2 and Python 3.11+. The example resource limits are in `compose.yaml`; a small VM starting point is 2 vCPU and 4 GiB RAM. The container memory ceilings total roughly 3.5 GiB while the load driver runs, leaving little OS headroom. Watch host pressure and lower ceilings or use a larger VM as needed. A local image build can need more memory and disk than the running lab: build on another machine of the same architecture and `docker save`/`docker load` the image if necessary. No VM is provisioned by these scripts.
+
+From a checkout of the revision to test, the wrapper handles resource capture,
+resolved Compose configuration, image records and service logs:
+
+```bash
+scripts/capacity/lab.sh up
+scripts/capacity/lab.sh run --levels 1,2,4,8 --seconds 30 --logs-per-second 100
+scripts/capacity/lab.sh down
+```
+
+The equivalent individual commands are:
+
+```bash
+export PRELOOP_DISABLE_TELEMETRY=true
+export CAPACITY_REVISION=$(git rev-parse HEAD)
+docker compose -f scripts/capacity/compose.yaml build
+# Use --wait so database migrations and service health pass before setup.
+docker compose -f scripts/capacity/compose.yaml up -d --wait api gateway fake
+mkdir -p scripts/capacity/artifacts
+python3 scripts/capacity/collect.py --seconds 600 \
+  --output scripts/capacity/artifacts/resources.jsonl &
+collector_pid=$!
+docker compose -f scripts/capacity/compose.yaml run --rm load \
+  python -m scripts.capacity.run --levels 1,2,4,8,16,32 \
+  --seconds 30 --logs-per-second 100 --cooldown-seconds 15
+kill "$collector_pid" 2>/dev/null || true
+docker compose -f scripts/capacity/compose.yaml logs --no-color \
+  > scripts/capacity/artifacts/services.log
+```
+
+The run prints each stage's summary and creates a timestamped artifact directory. Exit 0 means the tested stages stayed inside the configured thresholds; exit 2 means a threshold was exceeded. An exception/setup failure is a harness failure, not a measured capacity limit. Keep the service logs when diagnosing either outcome. The bounded resource collector can finish by itself if a shell exits before killing it.
+
+The Compose network is **internal**, has no published ports and cannot reach paid providers or public services. All credentials are disposable placeholders or randomly created local account keys. Do not attach this network to production services. The driver rejects external endpoint URLs, ignores proxy environment variables, and verifies the fixture identity. `collect.py` requires a local Unix-socket Docker context and the `preloop-capacity` project. Builds/pulls need Internet access; workload services do not. Nothing invokes a VM provider or deploys to staging/production.
+
+To test a prebuilt application image, set `CAPACITY_IMAGE` to that image **only if it includes this checkout's `scripts/capacity` directory**, and skip `build`. The repository Dockerfile copies `scripts/` into the application image. Record the application commit and image digest; an image tag alone can move. Apply the harness patch to another checkout to compare versions; do not silently carry application fixes between candidates.
+
+## Workloads and bounds
+
+- `--levels 1,2,4,8` runs closed-loop concurrency steps. Connections are established per stage. Each actor waits for its tool and model response before the next operation. Setup latency is reported separately as `mcp_connect`.
+- `--levels 16 --seconds 1800` is a soak. `--max-requests` and `--max-logs` bound retained evidence and offered work. A cap reached before the duration is a truncated observation, not a completed soak. Increase the caps deliberately and budget disk/memory.
+- `--tool-delay-ms 1000` and `--think-ms 100` control tool hold time and actor pacing. Set `FAKE_MODEL_DELAY_MS`, `FAKE_TOKEN_DELAY_MS` and `FAKE_OUTPUT_TOKENS` before `up --force-recreate fake` to control time to first token, stream duration and response size. Model payloads are deterministic, and their token usage is synthetic.
+- `--cancel-every 10` intentionally closes every tenth model stream after content begins. These count separately and do not count as completed model requests or dilute completion latency percentiles.
+- `FAKE_ERROR_EVERY=10` injects fixture HTTP 503 responses. This is an error-recovery scenario; its threshold crossing is not a server capacity result. Set it back to zero before a capacity sweep.
+- `--logs-per-second 100` enables a separate paced log lane, spread over `--log-executions 8`. The fixture helper uses models and CRUD to create a disabled flow and already-terminal executions in the newly registered account. No execution is queued, and no agent worker is enabled. Each line has a stage and sequence marker. The publisher reports offered and achieved rate; it never emits an unbounded catch-up burst. NATS flush confirms submission, not database persistence.
+- `--cooldown-seconds 15` observes recovery after the producers stop. Separate recovery sign-in/control/ping samples and pool/queue snapshots remain in the artifacts. With logs enabled, bounded CRUD keyset pages reconcile submitted versus uniquely persisted rows and duplicates. Missing rows at the end of this window may still be delayed; inspect the recovery history or rerun with a longer window before calling them permanently lost.
+
+Defaults stop at the first configured error-rate or p95 breach. `--continue-after-failure` continues only the explicitly bounded levels. Thresholds are `--max-error-rate` and `--max-p95-ms`; defaults are starting criteria, not product SLOs. A level with no successful tool or complete model samples also fails. A log persistence deficit, a recovery probe error/p95 breach, or missing successful recovery sign-in/ping samples also fails the stage. Recovery is unmeasured when its window is zero.
+
+## Evidence and interpretation
+
+`config.json` records workload settings, source revision and driver platform. `requests.jsonl` records operation, duration, status/error category and model time to first content, without tokens, request bodies or response payloads. `summary.json` reports stage throughput, successful full-request p50/p95/p99, all-attempt p99, error categories and first threshold crossing. It records attempted and completed throughput separately. Failed requests remain in error counts even if their latency is absent from successful-request percentiles.
+
+`telemetry.jsonl` contains API/gateway health bodies (request pool occupancy and usage writer queue), NATS counters, recovery log counts and driver event-loop timer lag. Ping latency is an **indirect** signal of target event-loop responsiveness, not an instrumented server event-loop-delay gauge. Correlate it with driver lag and CPU saturation before blaming the target. Missing/erroring telemetry is evidence missing, never evidence of health. Health HTTP 200 alone does not establish available request-pool capacity.
+
+`resources.jsonl` samples each lab container's Docker CPU, memory, process count and state, plus PostgreSQL connection/wait categories. Include the fake service and load driver: if either is saturated, the experiment has reached an injector/fixture limit. Service logs provide pool holder warnings, NATS write failures and restart diagnostics. The native smoke and unit tests validate behavior; they are not VM capacity benchmarks.
+
+To identify what broke first, align timestamps around the first stage breach, check whether fixture errors were intentionally enabled, compare driver/fake resources with API/gateway resources, inspect PostgreSQL waits and request-pool occupancy, then check recovery sign-in and log reconciliation. A first failing step brackets a limit between the previous passing step and this step **for this workload**. Repeat narrower steps and multiple runs. Closed-loop traffic self-throttles when latency rises; it does not represent an unlimited open-loop arrival rate and cannot by itself establish a production capacity SLA.
+
+Tune one variable at a time: application CPU/memory ceilings, request pool/overflow/timeouts (`CAPACITY_POOL_SIZE`, `CAPACITY_MAX_OVERFLOW`, `CAPACITY_POOL_TIMEOUT`), provider delay, log rate, or topology. Pool counts are per process/engine; keep the aggregate within PostgreSQL's connection budget. Increasing pool size cannot repair held connections. Capture resolved Compose configuration and image digests with the artifacts, then compare the same workload and thresholds.
+
+## Cleanup
+
+Stop collection, save artifacts, then remove only the lab project and its disposable database:
+
+```bash
+docker compose -f scripts/capacity/compose.yaml down --volumes --remove-orphans
+```
+
+The artifact directory remains on the host. Every run creates a new account, so recreate the volume for a clean baseline between comparisons. The lab does not modify application backend behavior. Local unit/protocol checks use the existing development environment:
+
+```bash
+PRELOOP_DISABLE_TELEMETRY=true PYTHONPATH=.:backend \
+  python -m pytest scripts/capacity/tests -q
+```

--- a/scripts/capacity/collect.py
+++ b/scripts/capacity/collect.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Record Docker resource and PostgreSQL wait evidence from the local fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+COMPOSE = ["docker", "compose", "-f", str(Path(__file__).with_name("compose.yaml"))]
+
+
+def command(arguments: list[str], timeout: float = 10) -> str:
+    return subprocess.run(
+        arguments, check=True, capture_output=True, text=True, timeout=timeout
+    ).stdout
+
+
+def sample() -> dict[str, Any]:
+    """Only inspect containers belonging to the dedicated Compose project."""
+    ids = command([*COMPOSE, "ps", "-aq"]).split()
+    if not ids:
+        return {"error": "no_capacity_containers"}
+    for row in json.loads(command(["docker", "inspect", *ids])):
+        if (
+            row.get("Config", {}).get("Labels", {}).get("com.docker.compose.project")
+            != "preloop-capacity"
+        ):
+            raise ValueError("Unexpected Compose project")
+    stats = [
+        json.loads(line)
+        for line in command(
+            ["docker", "stats", "--no-stream", "--format", "{{json .}}", *ids]
+        ).splitlines()
+    ]
+    states = [
+        json.loads(line)
+        for line in command(
+            ["docker", "inspect", "--format", "{{json .State}}", *ids]
+        ).splitlines()
+    ]
+    pg = command(
+        [
+            *COMPOSE,
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-U",
+            "capacity",
+            "-d",
+            "capacity",
+            "-At",
+            "-c",
+            "SELECT COALESCE(state, 'background'), COALESCE(wait_event_type, 'none'), count(*) FROM pg_stat_activity WHERE datname = current_database() GROUP BY 1, 2;",
+        ]
+    )
+    return {"containers": stats, "states": states, "postgres_activity": pg.splitlines()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--seconds", type=float, default=600)
+    parser.add_argument("--interval", type=float, default=5)
+    args = parser.parse_args()
+    if not 0 < args.seconds <= 86400 or not 1 <= args.interval <= 60:
+        parser.error("Use positive bounded collection duration and interval")
+    context = json.loads(command(["docker", "context", "inspect"]))[0]
+    if not context["Endpoints"]["docker"]["Host"].startswith("unix://") or os.getenv(
+        "DOCKER_HOST"
+    ):
+        parser.error("Collector requires a local Unix-socket Docker context")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    with args.output.open("x") as output:
+        output.write(
+            json.dumps(
+                {
+                    "type": "host",
+                    "platform": platform.platform(),
+                    "logical_cpus": os.cpu_count(),
+                    "revision": command(["git", "rev-parse", "HEAD"]).strip(),
+                }
+            )
+            + "\n"
+        )
+        while time.monotonic() - started < args.seconds:
+            before = time.monotonic()
+            try:
+                row = sample()
+            except Exception as exc:
+                row = {"error": type(exc).__name__}
+            output.write(json.dumps({"timestamp": time.time(), **row}) + "\n")
+            output.flush()
+            time.sleep(max(0, args.interval - (time.monotonic() - before)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capacity/compose.yaml
+++ b/scripts/capacity/compose.yaml
@@ -1,5 +1,10 @@
 name: preloop-capacity
 
+# Placeholder credentials (SECRET_KEY, POSTGRES_PASSWORD, DATABASE_URL) are
+# disposable and internal-only. This project uses an isolated Compose network
+# (internal: true, no published ports) and a throwaway database volume. Do not
+# reuse these values outside this lab or attach the network to other stacks.
+
 x-environment: &environment
   PRELOOP_DISABLE_TELEMETRY: "true"
   DATABASE_URL: postgresql+psycopg://capacity:capacity@postgres/capacity

--- a/scripts/capacity/compose.yaml
+++ b/scripts/capacity/compose.yaml
@@ -1,0 +1,115 @@
+name: preloop-capacity
+
+x-environment: &environment
+  PRELOOP_DISABLE_TELEMETRY: "true"
+  DATABASE_URL: postgresql+psycopg://capacity:capacity@postgres/capacity
+  NATS_URL: nats://nats:4222
+  SECRET_KEY: change-this-capacity-local-secret
+  PRELOOP_URL: http://api:8000
+  HOST: 0.0.0.0
+  PORT: "8000"
+  REGISTRATION_ENABLED: "true"
+  FLOW_EXECUTION_WORKER_ENABLED: "false"
+  DATABASE_POOL_SIZE: ${CAPACITY_POOL_SIZE:-4}
+  DATABASE_MAX_OVERFLOW: ${CAPACITY_MAX_OVERFLOW:-4}
+  DATABASE_POOL_TIMEOUT: ${CAPACITY_POOL_TIMEOUT:-2}
+  DB_MONITORING_INTERVAL: "2"
+  DB_POOL_HOLD_STACKS: "true"
+  LOG_LEVEL: WARNING
+
+x-app: &app
+  image: ${CAPACITY_IMAGE:-preloop-capacity:local}
+  build:
+    context: ../..
+  networks: [isolated]
+  environment: *environment
+  restart: "no"
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    networks: [isolated]
+    environment:
+      POSTGRES_USER: capacity
+      POSTGRES_PASSWORD: capacity
+      POSTGRES_DB: capacity
+    command: [postgres, -c, max_connections=100, -c, shared_buffers=128MB]
+    mem_limit: ${CAPACITY_POSTGRES_MEMORY:-512m}
+    volumes: ["database:/var/lib/postgresql/data"]
+    healthcheck:
+      test: [CMD-SHELL, pg_isready -U capacity -d capacity]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+  nats:
+    image: nats:2.11-alpine
+    networks: [isolated]
+    command: [-js, -m, "8222"]
+    mem_limit: 128m
+  fake:
+    <<: *app
+    command: python -m uvicorn scripts.capacity.fake:app --host 0.0.0.0 --port 9000 --no-access-log
+    environment:
+      PRELOOP_DISABLE_TELEMETRY: "true"
+      FAKE_MODEL_DELAY_MS: ${FAKE_MODEL_DELAY_MS:-100}
+      FAKE_TOKEN_DELAY_MS: ${FAKE_TOKEN_DELAY_MS:-5}
+      FAKE_OUTPUT_TOKENS: ${FAKE_OUTPUT_TOKENS:-16}
+      FAKE_ERROR_EVERY: ${FAKE_ERROR_EVERY:-0}
+    mem_limit: 384m
+    healthcheck:
+      test: [CMD, python, -c, "import urllib.request; urllib.request.urlopen('http://localhost:9000/capacity/identity')"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+  migrate:
+    <<: *app
+    depends_on:
+      postgres: {condition: service_healthy}
+    command: python scripts/init_db.py --force
+  api:
+    <<: *app
+    depends_on:
+      migrate: {condition: service_completed_successfully}
+      nats: {condition: service_started}
+      fake: {condition: service_started}
+    command: python -m preloop.server
+    mem_limit: ${CAPACITY_API_MEMORY:-1024m}
+    cpus: ${CAPACITY_API_CPUS:-1.0}
+    healthcheck: &api-health
+      test: [CMD, python, -c, "import urllib.request,json; assert json.load(urllib.request.urlopen('http://localhost:8000/api/v1/health'))['database'] == 'connected'"]
+      interval: 3s
+      timeout: 3s
+      retries: 60
+    environment:
+      <<: *environment
+      PRELOOP_SERVICE_ROLE: api
+  gateway:
+    <<: *app
+    depends_on:
+      migrate: {condition: service_completed_successfully}
+      nats: {condition: service_started}
+    command: python -m preloop.server
+    mem_limit: ${CAPACITY_GATEWAY_MEMORY:-1024m}
+    cpus: ${CAPACITY_GATEWAY_CPUS:-1.0}
+    healthcheck: *api-health
+    environment:
+      <<: *environment
+      PRELOOP_SERVICE_ROLE: gateway
+  load:
+    <<: *app
+    profiles: [load]
+    command: python -m scripts.capacity.run
+    mem_limit: 512m
+    volumes: ["./artifacts:/artifacts"]
+    environment:
+      PRELOOP_DISABLE_TELEMETRY: "true"
+      CAPACITY_REVISION: ${CAPACITY_REVISION:-unknown}
+      DATABASE_URL: postgresql+psycopg://capacity:capacity@postgres/capacity
+      NATS_URL: nats://nats:4222
+      SECRET_KEY: change-this-capacity-local-secret
+
+networks:
+  isolated:
+    internal: true
+volumes:
+  database:

--- a/scripts/capacity/fake.py
+++ b/scripts/capacity/fake.py
@@ -1,0 +1,145 @@
+"""Deterministic, local-only OpenAI and MCP substitutes for capacity tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from fastmcp import FastMCP
+
+mcp = FastMCP("capacity-fixture")
+counts = {"model": 0, "tool": 0}
+
+
+def setting(name: str, default: int, maximum: int) -> int:
+    """Read a bounded deterministic fixture setting."""
+    return max(0, min(maximum, int(os.getenv(name, str(default)))))
+
+
+@mcp.tool
+async def capacity_echo(sequence: int, delay_ms: int = 100) -> dict[str, int]:
+    """Echo a sequence after a bounded provider wait, with no external I/O."""
+    if not 0 <= delay_ms <= 60_000:
+        raise ValueError("delay_ms must be between 0 and 60000")
+    counts["tool"] += 1
+    await asyncio.sleep(delay_ms / 1000)
+    return {"sequence": sequence}
+
+
+mcp_app = mcp.http_app(path="/mcp", stateless_http=True)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async with mcp_app.lifespan(app):
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+app.mount("/tools", mcp_app)
+
+
+@app.get("/capacity/identity")
+async def identity() -> dict[str, Any]:
+    return {
+        "fixture": "preloop-capacity-v1",
+        "requests": dict(counts),
+        "error_every": setting("FAKE_ERROR_EVERY", 0, 1_000_000),
+        "model_delay_ms": setting("FAKE_MODEL_DELAY_MS", 100, 60_000),
+        "token_delay_ms": setting("FAKE_TOKEN_DELAY_MS", 5, 10_000),
+        "output_tokens": setting("FAKE_OUTPUT_TOKENS", 16, 4096),
+    }
+
+
+@app.get("/v1/models")
+async def models() -> dict[str, Any]:
+    return {"object": "list", "data": [{"id": "capacity-model", "object": "model"}]}
+
+
+@app.post("/v1/chat/completions")
+async def completion(request: Request) -> Any:
+    body = await request.json()
+    counts["model"] += 1
+    sequence = counts["model"]
+    error_every = setting("FAKE_ERROR_EVERY", 0, 1_000_000)
+    if error_every and sequence % error_every == 0:
+        raise HTTPException(status_code=503, detail="Injected capacity-fixture failure")
+    await asyncio.sleep(setting("FAKE_MODEL_DELAY_MS", 100, 60_000) / 1000)
+    tokens = setting("FAKE_OUTPUT_TOKENS", 16, 4096)
+    usage = {
+        "prompt_tokens": 16,
+        "completion_tokens": tokens,
+        "total_tokens": 16 + tokens,
+    }
+    base = {
+        "id": f"chatcmpl-capacity-{sequence}",
+        "created": int(time.time()),
+        "model": body.get("model", "capacity-model"),
+    }
+    if not body.get("stream"):
+        return {
+            **base,
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok " * tokens},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": usage,
+        }
+
+    async def stream() -> AsyncIterator[str]:
+        for index in range(tokens):
+            await asyncio.sleep(setting("FAKE_TOKEN_DELAY_MS", 5, 10_000) / 1000)
+            delta = {"content": "ok "}
+            if index == 0:
+                delta["role"] = "assistant"
+            yield (
+                "data: "
+                + json.dumps(
+                    {
+                        **base,
+                        "object": "chat.completion.chunk",
+                        "choices": [
+                            {"index": 0, "delta": delta, "finish_reason": None}
+                        ],
+                    }
+                )
+                + "\n\n"
+            )
+        yield (
+            "data: "
+            + json.dumps(
+                {
+                    **base,
+                    "object": "chat.completion.chunk",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+            )
+            + "\n\n"
+        )
+        yield (
+            "data: "
+            + json.dumps(
+                {
+                    **base,
+                    "object": "chat.completion.chunk",
+                    "choices": [],
+                    "usage": usage,
+                }
+            )
+            + "\n\n"
+        )
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(stream(), media_type="text/event-stream")

--- a/scripts/capacity/lab.sh
+++ b/scripts/capacity/lab.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Manage only the disposable local capacity Compose project.
+set -euo pipefail
+export PRELOOP_DISABLE_TELEMETRY=true
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$repo_root"
+if [[ -n "${DOCKER_HOST:-}" ]]; then
+  echo 'Use a local Unix-socket Docker context without DOCKER_HOST.' >&2
+  exit 1
+fi
+docker context inspect | python3 -c 'import json,sys; endpoint=json.load(sys.stdin)[0]["Endpoints"]["docker"]["Host"]; assert endpoint.startswith("unix://"), "Local Docker required"'
+export CAPACITY_REVISION=${CAPACITY_REVISION:-$(git rev-parse HEAD)}
+compose=(docker compose -f scripts/capacity/compose.yaml)
+action=${1:-help}
+if [[ $# -gt 0 ]]; then shift; fi
+case "$action" in
+  up)
+    if [[ -z "${CAPACITY_IMAGE:-}" ]]; then "${compose[@]}" build; fi
+    "${compose[@]}" up -d --wait api gateway fake
+    ;;
+  run)
+    run_id=$(date -u +%Y%m%dT%H%M%SZ)-$$
+    artifact_dir="scripts/capacity/artifacts/$run_id"
+    mkdir -p "$artifact_dir"
+    "${compose[@]}" config > "$artifact_dir/compose.yaml"
+    "${compose[@]}" images --format json > "$artifact_dir/images.json"
+    python3 scripts/capacity/collect.py --seconds 86400 --output "$artifact_dir/resources.jsonl" &
+    collector_pid=$!
+    finish() {
+      kill "$collector_pid" 2>/dev/null || true
+      wait "$collector_pid" 2>/dev/null || true
+      "${compose[@]}" logs --no-color > "$artifact_dir/services.log" 2>&1 || true
+      echo "Artifacts: $artifact_dir"
+    }
+    trap finish EXIT
+    "${compose[@]}" run --rm load python -m scripts.capacity.run "$@" --output "/artifacts/$run_id/run"
+    ;;
+  down)
+    "${compose[@]}" down --volumes --remove-orphans
+    ;;
+  *)
+    echo 'Usage: scripts/capacity/lab.sh up | run [driver arguments] | down'
+    ;;
+esac

--- a/scripts/capacity/logs.py
+++ b/scripts/capacity/logs.py
@@ -1,0 +1,140 @@
+"""Optional inert execution fixtures and real NATS log-persistence accounting."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+from uuid import UUID
+
+os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+
+
+class LogFixture:
+    """Seed through CRUD only; never enqueue or launch an agent execution."""
+
+    def __init__(self, account_id: str, count: int) -> None:
+        from loguru import logger
+
+        logger.disable("preloop.models.db.session")
+        from preloop.models import models, schemas
+        from preloop.models.crud import crud_flow, crud_flow_execution
+        from preloop.models.db.session import get_db_session
+
+        database = urlparse(os.environ.get("DATABASE_URL", ""))
+        if database.hostname not in {
+            "postgres",
+            "localhost",
+            "127.0.0.1",
+        } or not database.path.lstrip("/").startswith("capacity"):
+            raise ValueError(
+                "Log fixtures require a local disposable capacity database"
+            )
+        self.ids: list[UUID] = []
+        self.cursors: dict[UUID, Any] = {}
+        self.seen: dict[int, set[int]] = {}
+        self.rows: dict[int, int] = {}
+        with closing(get_db_session()) as sessions:
+            db = next(sessions)
+            flow: models.Flow = crud_flow.create(
+                db,
+                account_id=account_id,
+                flow_in=schemas.FlowCreate(
+                    name="Capacity inert log fixture",
+                    prompt_template="Never execute this disabled fixture",
+                    agent_type="custom",
+                    agent_config={},
+                    is_enabled=False,
+                ),
+            )
+            for _ in range(count):
+                execution = crud_flow_execution.create(
+                    db,
+                    schemas.FlowExecutionCreate(
+                        flow_id=flow.id,
+                        status="SUCCEEDED",
+                        start_time=datetime.now(UTC),
+                        end_time=datetime.now(UTC),
+                    ),
+                )
+                self.ids.append(execution.id)
+            db.commit()
+
+    def reconcile(self, stage: int) -> dict[str, Any]:
+        """Read at most one keyset page per execution per sample, without SQL."""
+        from preloop.models.crud import crud_flow_execution_log
+        from preloop.models.db.session import get_db_session
+
+        self.seen = {stage: self.seen.get(stage, set())}
+        self.rows = {stage: self.rows.get(stage, 0)}
+        with closing(get_db_session()) as sessions:
+            db = next(sessions)
+            for execution_id in self.ids:
+                rows = crud_flow_execution_log.get_agent_log_page(
+                    db, execution_id, after=self.cursors.get(execution_id), limit=1000
+                )
+                for row in rows:
+                    prefix, row_stage, sequence = (row.message or "").split(":")
+                    if prefix != "capacity":
+                        raise ValueError("Unexpected fixture log")
+                    if int(row_stage) == stage:
+                        self.seen[stage].add(int(sequence))
+                        self.rows[stage] += 1
+                if rows:
+                    self.cursors[execution_id] = (rows[-1].timestamp, rows[-1].id)
+        return {
+            str(stage): {
+                "unique_persisted": len(values),
+                "rows": self.rows[stage],
+                "duplicates": self.rows[stage] - len(values),
+            }
+            for stage, values in self.seen.items()
+        }
+
+    async def publish(
+        self, account_id: str, stage: int, rate: float, seconds: float, maximum: int
+    ) -> dict[str, Any]:
+        """Offer a paced stream; never catch up with an unbounded burst."""
+        import nats
+
+        address = os.environ.get("NATS_URL", "nats://nats:4222")
+        parsed = urlparse(address)
+        if parsed.hostname not in {"nats", "localhost", "127.0.0.1"}:
+            raise ValueError("Log publisher requires local NATS")
+        client = await nats.connect(
+            address, connect_timeout=5, max_reconnect_attempts=0
+        )
+        submitted = 0
+        start = time.monotonic()
+        try:
+            while time.monotonic() - start < seconds and submitted < maximum:
+                execution_id = str(self.ids[submitted % len(self.ids)])
+                payload = {
+                    "type": "agent_log_line",
+                    "execution_id": execution_id,
+                    "account_id": account_id,
+                    "payload": {"line": f"capacity:{stage}:{submitted}"},
+                }
+                await client.publish(
+                    "flow-updates." + execution_id, json.dumps(payload).encode()
+                )
+                submitted += 1
+                if submitted % 100 == 0:
+                    await client.flush(timeout=5)
+                await asyncio.sleep(max(0, 1 / rate))
+            await client.flush(timeout=5)
+        finally:
+            await client.close()
+        elapsed = time.monotonic() - start
+        return {
+            "submitted": submitted,
+            "elapsed_seconds": elapsed,
+            "observed_logs_per_second": submitted / elapsed,
+            "requested_logs_per_second": rate,
+            "maximum_reached": submitted >= maximum,
+        }

--- a/scripts/capacity/logs.py
+++ b/scripts/capacity/logs.py
@@ -79,11 +79,17 @@ class LogFixture:
                     db, execution_id, after=self.cursors.get(execution_id), limit=1000
                 )
                 for row in rows:
-                    prefix, row_stage, sequence = (row.message or "").split(":")
-                    if prefix != "capacity":
+                    parts = (row.message or "").split(":")
+                    if (
+                        len(parts) != 3
+                        or parts[0] != "capacity"
+                        or not parts[1].isdigit()
+                        or not parts[2].isdigit()
+                    ):
                         raise ValueError("Unexpected fixture log")
-                    if int(row_stage) == stage:
-                        self.seen[stage].add(int(sequence))
+                    row_stage, sequence = int(parts[1]), int(parts[2])
+                    if row_stage == stage:
+                        self.seen[stage].add(sequence)
                         self.rows[stage] += 1
                 if rows:
                     self.cursors[execution_id] = (rows[-1].timestamp, rows[-1].id)

--- a/scripts/capacity/run.py
+++ b/scripts/capacity/run.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""Bounded authenticated capacity workloads for the disposable Compose stack."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import os
+import platform
+import secrets
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, TextIO
+from urllib.parse import urlparse
+
+os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+
+import httpx
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+
+class WorkloadError(Exception):
+    """A stable, payload-free workload failure category."""
+
+
+def error_kind(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"http_{exc.response.status_code}"
+    return str(exc) if isinstance(exc, WorkloadError) else type(exc).__name__
+
+
+def mcp_http_client(**kwargs: Any) -> httpx.AsyncClient:
+    """Keep MCP traffic independent of ambient proxies and remote redirects."""
+    return httpx.AsyncClient(
+        **{**kwargs, "trust_env": False, "follow_redirects": False}
+    )
+
+
+def local_url(value: str) -> str:
+    """Keep the driver restricted to this stack or local smoke servers."""
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname
+        not in {"api", "gateway", "fake", "nats", "127.0.0.1", "localhost"}
+        or parsed.username
+        or parsed.password
+    ):
+        raise ValueError("Capacity endpoints must be local HTTP stack services")
+    return value.rstrip("/")
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    """Nearest-rank percentile; return no value for an empty sample."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    return round(ordered[max(0, math.ceil(quantile * len(ordered)) - 1)], 3)
+
+
+def summarize(samples: list[dict[str, Any]], elapsed: float) -> dict[str, Any]:
+    """Summarize attempts, including failed-request latency separately."""
+    operations = {}
+    for operation in sorted({sample["operation"] for sample in samples}):
+        selected = [sample for sample in samples if sample["operation"] == operation]
+        success = [
+            sample["ms"]
+            for sample in selected
+            if sample["ok"] and not sample.get("cancelled")
+        ]
+        operations[operation] = {
+            "attempts": len(selected),
+            "successes": len(success),
+            "errors": sum(not sample["ok"] for sample in selected),
+            "errors_by_kind": dict(
+                Counter(sample["error"] for sample in selected if not sample["ok"])
+            ),
+            "cancelled_streams": sum(
+                sample.get("cancelled", False) for sample in selected
+            ),
+            "attempts_per_second": round(len(selected) / elapsed, 3),
+            "successes_per_second": round(len(success) / elapsed, 3),
+            "error_rate": sum(not sample["ok"] for sample in selected) / len(selected),
+            "p50_ms": percentile(success, 0.50),
+            "p95_ms": percentile(success, 0.95),
+            "p99_ms": percentile(success, 0.99),
+            "all_attempts_p99_ms": percentile([s["ms"] for s in selected], 0.99),
+            "ttft_p95_ms": percentile(
+                [s["ttft_ms"] for s in selected if s.get("ttft_ms") is not None], 0.95
+            ),
+        }
+    return {"elapsed_seconds": round(elapsed, 3), "operations": operations}
+
+
+def breaches(
+    summary: dict[str, Any], max_error_rate: float, max_p95_ms: float
+) -> list[str]:
+    failures = []
+    for name, stats in summary["operations"].items():
+        if stats["error_rate"] > max_error_rate:
+            failures.append(f"{name}:error_rate")
+        if stats["p95_ms"] is not None and stats["p95_ms"] > max_p95_ms:
+            failures.append(f"{name}:p95")
+    return failures
+
+
+class Recorder:
+    """Bound in-memory samples per stage while preserving every attempt on disk."""
+
+    def __init__(
+        self, output: TextIO, stage: int, maximum: int, phase: str = "load"
+    ) -> None:
+        self.output = output
+        self.stage = stage
+        self.phase = phase
+        self.maximum = maximum
+        self.started = 0
+        self.samples: list[dict[str, Any]] = []
+
+    def reserve(self) -> bool:
+        if self.started >= self.maximum:
+            return False
+        self.started += 1
+        return True
+
+    def record(
+        self, operation: str, started: float, error: str | None = None, **extra: Any
+    ) -> None:
+        sample = {
+            "stage": self.stage,
+            "phase": self.phase,
+            "timestamp": time.time(),
+            "operation": operation,
+            "ms": round((time.perf_counter() - started) * 1000, 3),
+            "ok": error is None,
+            "error": error,
+            **extra,
+        }
+        self.samples.append(sample)
+        self.output.write(json.dumps(sample) + "\n")
+
+
+async def checked(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs: Any
+) -> Any:
+    response = await client.request(method, url, **kwargs)
+    response.raise_for_status()
+    return response.json()
+
+
+async def bootstrap(
+    client: httpx.AsyncClient, api: str, fake: str
+) -> tuple[str, dict[str, str], str]:
+    """Create a new isolated account using the same API as an actual client."""
+    marker = await checked(client, "GET", fake + "/capacity/identity")
+    if marker.get("fixture") != "preloop-capacity-v1":
+        raise ValueError("Deterministic fixture identity check failed")
+    username = "capacity" + secrets.token_hex(6)
+    login = {"username": username, "password": secrets.token_urlsafe(24)}
+    user = await checked(
+        client,
+        "POST",
+        api + "/api/v1/auth/register",
+        json={
+            **login,
+            "email": username + "@example.com",
+            "full_name": "Capacity Fixture",
+        },
+    )
+    auth = await checked(client, "POST", api + "/api/v1/auth/token/json", json=login)
+    headers = {"Authorization": "Bearer " + auth["access_token"]}
+    key = await checked(
+        client,
+        "POST",
+        api + "/api/v1/auth/api-keys",
+        headers=headers,
+        json={"name": "capacity-driver"},
+    )
+    await checked(
+        client,
+        "POST",
+        api + "/api/v1/ai-models",
+        headers=headers,
+        json={
+            "name": "Capacity fixture",
+            "provider_name": "openai",
+            "model_identifier": "capacity-model",
+            "api_endpoint": fake + "/v1",
+            "api_key": "example-key-capacity-fixture",
+            "is_default": True,
+            "meta_data": {
+                "gateway": {"enabled": True, "model_alias": "openai/capacity-model"}
+            },
+        },
+    )
+    server = await checked(
+        client,
+        "POST",
+        api + "/api/v1/mcp-servers",
+        headers=headers,
+        json={
+            "name": "capacity-fixture",
+            "url": fake + "/tools/mcp",
+            "transport": "http-streaming",
+            "auth_type": "none",
+        },
+    )
+    if server.get("status") != "active":
+        raise RuntimeError("Fixture MCP discovery failed; inspect local API logs")
+    return key["key"], login, user["account_id"]
+
+
+async def model_call(
+    client: httpx.AsyncClient, url: str, headers: dict[str, str], cancel: bool
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    first = None
+    done = False
+    content = False
+    async with client.stream(
+        "POST",
+        url + "/openai/v1/chat/completions",
+        headers=headers,
+        json={
+            "model": "openai/capacity-model",
+            "messages": [
+                {"role": "user", "content": "Return the deterministic fixture reply."}
+            ],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "max_tokens": 64,
+        },
+    ) as response:
+        response.raise_for_status()
+        async for line in response.aiter_lines():
+            if not line.startswith("data: "):
+                continue
+            data = line[6:]
+            if data == "[DONE]":
+                done = True
+                break
+            chunk = json.loads(data)
+            if "error" in chunk:
+                raise WorkloadError("upstream_stream_error")
+            if any(
+                choice.get("delta", {}).get("content")
+                for choice in chunk.get("choices", [])
+            ):
+                content = True
+                if first is None:
+                    first = round((time.perf_counter() - started) * 1000, 3)
+                if cancel:
+                    return {"ttft_ms": first, "cancelled": True}
+    if not done or not content:
+        raise WorkloadError("incomplete_stream")
+    return {"ttft_ms": first, "cancelled": False}
+
+
+async def actor(
+    index: int, args: argparse.Namespace, token: str, recorder: Recorder, stop: float
+) -> None:
+    headers = {
+        "Authorization": "Bearer " + token,
+        "X-Preloop-Session-Id": f"capacity-{recorder.stage}-{index}",
+    }
+    client = Client(
+        StreamableHttpTransport(
+            args.api + "/mcp/v1", headers=headers, httpx_client_factory=mcp_http_client
+        ),
+        timeout=args.timeout,
+    )
+    setup = time.perf_counter()
+    connected = False
+    if not recorder.reserve():
+        return
+    try:
+        async with (
+            client,
+            httpx.AsyncClient(timeout=args.timeout, trust_env=False) as http,
+        ):
+            listed = await client.list_tools()
+            tool = next(
+                (item.name for item in listed if item.name.endswith("capacity_echo")),
+                None,
+            )
+            if tool is None:
+                raise WorkloadError("fixture_tool_not_discovered")
+            recorder.record("mcp_connect", setup)
+            connected = True
+            sequence = 0
+            while time.monotonic() < stop:
+                for operation in ("mcp_tool", "gateway_stream"):
+                    if time.monotonic() >= stop or not recorder.reserve():
+                        return
+                    started = time.perf_counter()
+                    extra: dict[str, Any] = {}
+                    error = None
+                    try:
+                        async with asyncio.timeout(args.timeout):
+                            if operation == "mcp_tool":
+                                result = await client.call_tool(
+                                    tool,
+                                    {
+                                        "sequence": sequence,
+                                        "delay_ms": args.tool_delay_ms,
+                                    },
+                                )
+                                if result.is_error:
+                                    raise WorkloadError("mcp_tool_error")
+                            else:
+                                extra = await model_call(
+                                    http,
+                                    args.gateway,
+                                    headers,
+                                    bool(
+                                        args.cancel_every
+                                        and sequence % args.cancel_every == 0
+                                    ),
+                                )
+                    except Exception as exc:
+                        error = error_kind(exc)
+                    recorder.record(operation, started, error, **extra)
+                sequence += 1
+                if args.think_ms:
+                    await asyncio.sleep(args.think_ms / 1000)
+    except Exception as exc:
+        recorder.record(
+            "mcp_teardown" if connected else "mcp_connect", setup, error_kind(exc)
+        )
+
+
+async def observe(
+    args: argparse.Namespace,
+    token: str,
+    login: dict[str, str],
+    recorder: Recorder,
+    stop: asyncio.Event,
+    output: TextIO,
+) -> None:
+    headers = {"Authorization": "Bearer " + token}
+    async with httpx.AsyncClient(timeout=args.timeout, trust_env=False) as client:
+        tick = 0
+        while not stop.is_set() and recorder.started < recorder.maximum:
+            timestamp = time.time()
+            snapshots: dict[str, Any] = {
+                "stage": recorder.stage,
+                "phase": recorder.phase,
+                "timestamp": timestamp,
+            }
+            for name, url in (("api", args.api), ("gateway", args.gateway)):
+                started = time.perf_counter()
+                if not recorder.reserve():
+                    break
+                error = None
+                try:
+                    async with asyncio.timeout(args.timeout):
+                        await checked(client, "GET", url + "/api/v1/ping")
+                except Exception as exc:
+                    error = error_kind(exc)
+                recorder.record(name + "_ping", started, error)
+                try:
+                    snapshots[name] = await checked(
+                        client, "GET", url + "/api/v1/health"
+                    )
+                except Exception as exc:
+                    snapshots[name] = {"error": type(exc).__name__}
+            if recorder.reserve():
+                started = time.perf_counter()
+                error = None
+                try:
+                    if tick % 5 == 0:
+                        await checked(
+                            client,
+                            "POST",
+                            args.api + "/api/v1/auth/token/json",
+                            json=login,
+                        )
+                    else:
+                        await checked(
+                            client,
+                            "GET",
+                            args.api + "/api/v1/auth/users/me",
+                            headers=headers,
+                        )
+                except Exception as exc:
+                    error = error_kind(exc)
+                recorder.record(
+                    "signin" if tick % 5 == 0 else "control", started, error
+                )
+            try:
+                snapshots["nats"] = await checked(client, "GET", args.nats + "/varz")
+            except Exception as exc:
+                snapshots["nats"] = {"error": type(exc).__name__}
+            output.write(json.dumps(snapshots) + "\n")
+            output.flush()
+            tick += 1
+            before = time.monotonic()
+            try:
+                await asyncio.wait_for(stop.wait(), args.sample_seconds)
+            except asyncio.TimeoutError:
+                output.write(
+                    json.dumps(
+                        {
+                            "stage": recorder.stage,
+                            "phase": recorder.phase,
+                            "timestamp": time.time(),
+                            "driver_loop_lag_ms": max(
+                                0,
+                                (time.monotonic() - before - args.sample_seconds)
+                                * 1000,
+                            ),
+                        }
+                    )
+                    + "\n"
+                )
+
+
+async def run(args: argparse.Namespace) -> int:
+    args.output.mkdir(parents=True, exist_ok=False)
+    metadata = {
+        **vars(args),
+        "output": str(args.output),
+        "revision": os.getenv("CAPACITY_REVISION", "unknown"),
+        "platform": platform.platform(),
+        "telemetry_disabled": True,
+        "workload": "closed-loop simulated agents, one proxied tool then one streaming gateway call",
+    }
+    (args.output / "config.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    report: dict[str, Any] = {
+        "stages": [],
+        "first_failure_concurrency": None,
+        "status": "starting",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=60, trust_env=False) as client:
+            token, login, account_id = await bootstrap(client, args.api, args.fake)
+            metadata["fixture"] = await checked(
+                client, "GET", args.fake + "/capacity/identity"
+            )
+            (args.output / "config.json").write_text(
+                json.dumps(metadata, indent=2) + "\n"
+            )
+        fixture = None
+        if args.logs_per_second:
+            from scripts.capacity.logs import LogFixture
+
+            fixture = await asyncio.to_thread(
+                LogFixture, account_id, args.log_executions
+            )
+        with (
+            (args.output / "requests.jsonl").open("w") as requests,
+            (args.output / "telemetry.jsonl").open("w") as telemetry,
+        ):
+            for stage, concurrency in enumerate(args.levels):
+                recorder = Recorder(requests, stage, args.max_requests)
+                started = time.monotonic()
+                stop = asyncio.Event()
+                monitor = asyncio.create_task(
+                    observe(args, token, login, recorder, stop, telemetry)
+                )
+                publisher = (
+                    asyncio.create_task(
+                        fixture.publish(
+                            account_id,
+                            stage,
+                            args.logs_per_second,
+                            args.seconds,
+                            args.max_logs,
+                        )
+                    )
+                    if fixture
+                    else None
+                )
+                try:
+                    await asyncio.gather(
+                        *(
+                            actor(i, args, token, recorder, started + args.seconds)
+                            for i in range(concurrency)
+                        )
+                    )
+                finally:
+                    stop.set()
+                    await monitor
+                log_result = await publisher if publisher else None
+                summary = {
+                    "concurrency": concurrency,
+                    **summarize(recorder.samples, time.monotonic() - started),
+                    "request_cap_reached": recorder.started >= args.max_requests,
+                }
+                # Recovery has its own recorder so cooldown does not dilute load latency.
+                recovery = Recorder(requests, stage, args.max_requests, "recovery")
+                recovery_started = time.monotonic()
+                recovery_stop = asyncio.Event()
+                recovery_monitor = asyncio.create_task(
+                    observe(args, token, login, recovery, recovery_stop, telemetry)
+                )
+                persisted = {}
+                try:
+                    while time.monotonic() - recovery_started < args.cooldown_seconds:
+                        if fixture:
+                            persisted = await asyncio.to_thread(
+                                fixture.reconcile, stage
+                            )
+                            telemetry.write(
+                                json.dumps(
+                                    {
+                                        "stage": stage,
+                                        "timestamp": time.time(),
+                                        "recovery_log_counts": persisted,
+                                    }
+                                )
+                                + "\n"
+                            )
+                        await asyncio.sleep(min(1, args.cooldown_seconds))
+                finally:
+                    recovery_stop.set()
+                    await recovery_monitor
+                if fixture:
+                    persisted = await asyncio.to_thread(fixture.reconcile, stage)
+                    log_result.update(
+                        persisted.get(
+                            str(stage),
+                            {"unique_persisted": 0, "rows": 0, "duplicates": 0},
+                        )
+                    )
+                    log_result["missing_after_recovery"] = (
+                        log_result["submitted"] - log_result["unique_persisted"]
+                    )
+                    summary["logs"] = log_result
+                summary["recovery"] = summarize(
+                    recovery.samples, max(0.001, time.monotonic() - recovery_started)
+                )
+                failures = breaches(summary, args.max_error_rate, args.max_p95_ms)
+                if args.cooldown_seconds > 0:
+                    failures.extend(
+                        "recovery:" + breach
+                        for breach in breaches(
+                            summary["recovery"], args.max_error_rate, args.max_p95_ms
+                        )
+                    )
+                    for required_probe in ("signin", "api_ping", "gateway_ping"):
+                        if (
+                            summary["recovery"]["operations"]
+                            .get(required_probe, {})
+                            .get("successes", 0)
+                            == 0
+                        ):
+                            failures.append(
+                                "recovery:" + required_probe + ":no_successful_samples"
+                            )
+                if log_result and log_result["missing_after_recovery"]:
+                    failures.append("logs:missing_after_recovery")
+                for required in ("mcp_tool", "gateway_stream"):
+                    if summary["operations"].get(required, {}).get("successes", 0) == 0:
+                        failures.append(required + ":no_successful_samples")
+                summary["threshold_breaches"] = failures
+                invalid = any(
+                    kind
+                    in {
+                        "http_401",
+                        "http_403",
+                        "http_404",
+                        "http_422",
+                        "fixture_tool_not_discovered",
+                    }
+                    for stats in summary["operations"].values()
+                    for kind in stats["errors_by_kind"]
+                )
+                summary["classification"] = (
+                    "setup_or_configuration_failure"
+                    if invalid
+                    else "fixture_fault_injection"
+                    if metadata["fixture"].get("error_every")
+                    else "slo_breach"
+                    if failures
+                    else "within_thresholds"
+                )
+                report["stages"].append(summary)
+                print(json.dumps(summary), flush=True)
+                requests.flush()
+                if failures and report["first_failure_concurrency"] is None:
+                    report["first_failure_concurrency"] = concurrency
+                    report["first_failure_kind"] = summary["classification"]
+                if failures and not args.continue_after_failure:
+                    break
+
+        report["status"] = (
+            "threshold_exceeded" if report["first_failure_concurrency"] else "completed"
+        )
+    except Exception as exc:
+        report["status"] = "harness_error"
+        report["error_type"] = type(exc).__name__
+        raise
+    finally:
+        (args.output / "summary.json").write_text(json.dumps(report, indent=2) + "\n")
+    return 2 if report["first_failure_concurrency"] else 0
+
+
+def arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--levels",
+        default="1,2,4,8,16,32,64,128",
+        help="Concurrency steps; repeat a value for repeated measurements",
+    )
+    parser.add_argument(
+        "--seconds",
+        type=float,
+        default=30,
+        help="Seconds per step; use one level for a soak",
+    )
+    parser.add_argument("--timeout", type=float, default=15)
+    parser.add_argument("--tool-delay-ms", type=int, default=100)
+    parser.add_argument("--think-ms", type=int, default=0)
+    parser.add_argument("--cancel-every", type=int, default=0)
+    parser.add_argument("--sample-seconds", type=float, default=2)
+    parser.add_argument("--cooldown-seconds", type=float, default=5)
+    parser.add_argument(
+        "--logs-per-second",
+        type=float,
+        default=0,
+        help="Optional paced Core NATS log lane",
+    )
+    parser.add_argument("--log-executions", type=int, default=8)
+    parser.add_argument("--max-logs", type=int, default=100_000)
+    parser.add_argument("--max-requests", type=int, default=100_000)
+    parser.add_argument("--max-error-rate", type=float, default=0.01)
+    parser.add_argument("--max-p95-ms", type=float, default=5000)
+    parser.add_argument("--continue-after-failure", action="store_true")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("/artifacts") / time.strftime("%Y%m%d-%H%M%S"),
+    )
+    for name, default in (
+        ("api", "http://api:8000"),
+        ("gateway", "http://gateway:8000"),
+        ("fake", "http://fake:9000"),
+        ("nats", "http://nats:8222"),
+    ):
+        parser.add_argument("--" + name, type=local_url, default=default)
+    args = parser.parse_args()
+    args.levels = [int(level) for level in args.levels.split(",")]
+    if (
+        not args.levels
+        or len(args.levels) > 32
+        or not all(1 <= n <= 512 for n in args.levels)
+    ):
+        parser.error("Use at most 32 concurrency levels, each between 1 and 512")
+    if (
+        not 0 < args.seconds <= 3600
+        or not 0 < args.timeout <= 120
+        or not 0 <= args.max_error_rate <= 1
+        or not 0 < args.max_p95_ms
+    ):
+        parser.error("Invalid duration, timeout or threshold")
+    if (
+        not 1 <= args.max_requests <= 1_000_000
+        or not 0 <= args.tool_delay_ms <= 60000
+        or not 0 <= args.think_ms <= 60000
+        or args.cancel_every < 0
+        or args.sample_seconds < 0.1
+        or not 0 <= args.cooldown_seconds <= 60
+    ):
+        parser.error("Invalid workload bound")
+    if (
+        not 0 <= args.logs_per_second <= 10000
+        or not 1 <= args.log_executions <= 64
+        or not 1 <= args.max_logs <= 1_000_000
+    ):
+        parser.error("Invalid log workload bound")
+    return args
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(run(arguments())))

--- a/scripts/capacity/tests/test_capacity.py
+++ b/scripts/capacity/tests/test_capacity.py
@@ -1,0 +1,238 @@
+"""Local protocol and measurement checks; never contact a paid provider."""
+
+import io
+import json
+import os
+
+os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from fastmcp import Client
+
+from scripts.capacity import fake, run
+
+
+def test_nearest_rank_percentile_and_empty_samples() -> None:
+    assert run.percentile([], 0.95) is None
+    assert run.percentile([40, 10, 30, 20], 0.50) == 20
+    assert run.percentile([40, 10, 30, 20], 0.95) == 40
+
+
+def test_cancellations_do_not_inflate_completion_throughput_or_latency() -> None:
+    samples = [
+        {"operation": "gateway_stream", "ms": 100, "ok": True},
+        {"operation": "gateway_stream", "ms": 1, "ok": True, "cancelled": True},
+        {"operation": "gateway_stream", "ms": 200, "ok": False, "error": "http_503"},
+    ]
+    summary = run.summarize(samples, 2)
+    stats = summary["operations"]["gateway_stream"]
+    assert stats["successes"] == 1
+    assert stats["successes_per_second"] == 0.5
+    assert stats["cancelled_streams"] == 1
+    assert stats["p95_ms"] == 100
+    assert stats["errors"] == 1
+    assert stats["error_rate"] == pytest.approx(1 / 3)
+    assert run.breaches(summary, 0.01, 50) == [
+        "gateway_stream:error_rate",
+        "gateway_stream:p95",
+    ]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://staging.example.com",
+        "http://example.com",
+        "http://user:pass@localhost",
+        "file:///tmp/a",
+        "https://api.openai.com",
+    ],
+)
+def test_driver_rejects_external_endpoints(url: str) -> None:
+    with pytest.raises(ValueError):
+        run.local_url(url)
+
+
+def test_recorder_bounds_reservations_and_writes_payload_free_samples() -> None:
+    output = io.StringIO()
+    recorder = run.Recorder(output, 1, 2)
+    assert recorder.reserve()
+    assert recorder.reserve()
+    assert not recorder.reserve()
+    recorder.record("mcp_tool", 0, "mcp_tool_error")
+    row = json.loads(output.getvalue())
+    assert row["operation"] == "mcp_tool"
+    assert row["ok"] is False
+    assert "headers" not in row
+
+
+def test_fake_stream_has_content_usage_and_terminal_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_MODEL_DELAY_MS", "0")
+    monkeypatch.setenv("FAKE_TOKEN_DELAY_MS", "0")
+    monkeypatch.setenv("FAKE_OUTPUT_TOKENS", "3")
+    with TestClient(fake.app) as client:
+        response = client.post("/v1/chat/completions", json={"stream": True})
+    chunks = [
+        line[6:] for line in response.text.splitlines() if line.startswith("data: ")
+    ]
+    assert chunks[-1] == "[DONE]"
+    assert json.loads(chunks[-2])["usage"]["completion_tokens"] == 3
+    assert (
+        sum(
+            bool(
+                json.loads(chunk)["choices"]
+                and json.loads(chunk)["choices"][0].get("delta", {}).get("content")
+            )
+            for chunk in chunks[:-1]
+        )
+        == 3
+    )
+
+
+def test_fake_error_injection_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAKE_ERROR_EVERY", "1")
+    with TestClient(fake.app) as client:
+        response = client.post("/v1/chat/completions", json={})
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_mcp_fixture_executes_real_tool_protocol() -> None:
+    async with Client(fake.mcp) as client:
+        tools = await client.list_tools()
+        assert [tool.name for tool in tools] == ["capacity_echo"]
+        result = await client.call_tool(
+            "capacity_echo", {"sequence": 12, "delay_ms": 0}
+        )
+        assert not result.is_error
+        assert result.data == {"sequence": 12}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ("data: [DONE]\n\n", "incomplete_stream"),
+        ('data: {"error": "unavailable"}\n\n', "upstream_stream_error"),
+    ],
+)
+async def test_http_200_does_not_hide_broken_model_stream(
+    payload: str, expected: str
+) -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, text=payload))
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(run.WorkloadError, match=expected):
+            await run.model_call(client, "http://gateway", {}, False)
+
+
+@pytest.mark.asyncio
+async def test_intentional_stream_cancellation_requires_content() -> None:
+    payload = 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, text=payload))
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await run.model_call(client, "http://gateway", {}, True)
+    assert result["cancelled"] is True
+    assert result["ttft_ms"] is not None
+
+
+def test_log_reconciliation_deduplicates_and_releases_previous_stage_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+    from uuid import uuid4
+    from unittest.mock import MagicMock
+
+    from preloop.models import crud
+    from preloop.models.db import session
+    from scripts.capacity.logs import LogFixture
+
+    fixture = object.__new__(LogFixture)
+    execution_id = uuid4()
+    fixture.ids = [execution_id]
+    fixture.cursors = {}
+    fixture.seen = {0: {1, 2}}
+    fixture.rows = {0: 2}
+    rows = [
+        SimpleNamespace(message=message, timestamp=datetime.now(UTC), id=uuid4())
+        for message in ["capacity:0:3", "capacity:1:0", "capacity:1:0", "capacity:1:1"]
+    ]
+
+    def sessions():
+        yield MagicMock()
+
+    monkeypatch.setattr(session, "get_db_session", sessions)
+    monkeypatch.setattr(
+        crud.crud_flow_execution_log, "get_agent_log_page", lambda *a, **k: rows
+    )
+    result = fixture.reconcile(1)
+    assert result == {"1": {"unique_persisted": 2, "rows": 3, "duplicates": 1}}
+    assert fixture.cursors[execution_id] == (rows[-1].timestamp, rows[-1].id)
+    assert 0 not in fixture.seen
+
+
+@pytest.mark.asyncio
+async def test_recovery_signin_failure_fails_an_otherwise_passing_run(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import argparse
+    import time
+    from unittest.mock import AsyncMock
+
+    args = argparse.Namespace(
+        output=tmp_path / "run",
+        api="http://api",
+        fake="http://fake",
+        levels=[1],
+        logs_per_second=0,
+        max_requests=100,
+        seconds=0.01,
+        cooldown_seconds=0.01,
+        max_error_rate=0.01,
+        max_p95_ms=5000,
+        continue_after_failure=False,
+    )
+    monkeypatch.setattr(
+        run, "bootstrap", AsyncMock(return_value=("local", {}, "account"))
+    )
+    monkeypatch.setattr(
+        run, "checked", AsyncMock(return_value={"fixture": "preloop-capacity-v1"})
+    )
+
+    async def actor(index, args, token, recorder, stop):
+        for operation in ("mcp_tool", "gateway_stream"):
+            recorder.record(operation, time.perf_counter())
+
+    async def observe(args, token, login, recorder, stop, output):
+        for operation in ("api_ping", "gateway_ping", "signin"):
+            recorder.record(
+                operation,
+                time.perf_counter(),
+                "http_503"
+                if recorder.phase == "recovery" and operation == "signin"
+                else None,
+            )
+
+    monkeypatch.setattr(run, "actor", actor)
+    monkeypatch.setattr(run, "observe", observe)
+    assert await run.run(args) == 2
+    summary = json.loads((args.output / "summary.json").read_text())
+    assert "recovery:signin:error_rate" in summary["stages"][0]["threshold_breaches"]
+    assert (
+        "recovery:signin:no_successful_samples"
+        in summary["stages"][0]["threshold_breaches"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_transport_disables_ambient_proxy_and_redirects() -> None:
+    async with run.mcp_http_client(
+        headers={"x-capacity": "test"}, follow_redirects=True
+    ) as client:
+        assert client.trust_env is False
+        assert client.follow_redirects is False
+        assert client.headers["x-capacity"] == "test"

--- a/scripts/capacity/tests/test_capacity.py
+++ b/scripts/capacity/tests/test_capacity.py
@@ -4,6 +4,9 @@ import io
 import json
 import os
 
+from collections.abc import Callable
+from typing import Any
+
 os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
 
 import httpx
@@ -175,6 +178,40 @@ def test_log_reconciliation_deduplicates_and_releases_previous_stage_state(
     assert 0 not in fixture.seen
 
 
+@pytest.mark.parametrize(
+    "message",
+    ["not-a-log", "capacity:1", "capacity:1:0:extra", "capacity:x:0", ""],
+)
+def test_log_reconciliation_rejects_malformed_lines_as_unexpected_fixture_logs(
+    message: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+    from uuid import uuid4
+    from unittest.mock import MagicMock
+
+    from preloop.models import crud
+    from preloop.models.db import session
+    from scripts.capacity.logs import LogFixture
+
+    fixture = object.__new__(LogFixture)
+    fixture.ids = [uuid4()]
+    fixture.cursors = {}
+    fixture.seen = {}
+    fixture.rows = {}
+    rows = [SimpleNamespace(message=message, timestamp=datetime.now(UTC), id=uuid4())]
+
+    def sessions():
+        yield MagicMock()
+
+    monkeypatch.setattr(session, "get_db_session", sessions)
+    monkeypatch.setattr(
+        crud.crud_flow_execution_log, "get_agent_log_page", lambda *a, **k: rows
+    )
+    with pytest.raises(ValueError, match="Unexpected fixture log"):
+        fixture.reconcile(1)
+
+
 @pytest.mark.asyncio
 async def test_recovery_signin_failure_fails_an_otherwise_passing_run(
     tmp_path, monkeypatch: pytest.MonkeyPatch
@@ -236,3 +273,258 @@ async def test_mcp_transport_disables_ambient_proxy_and_redirects() -> None:
         assert client.trust_env is False
         assert client.follow_redirects is False
         assert client.headers["x-capacity"] == "test"
+
+
+ACCOUNT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+STREAM_BODY = (
+    'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+    'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+    "data: [DONE]\n\n"
+)
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _json_body(request: httpx.Request) -> dict[str, object]:
+    return json.loads(request.content) if request.content else {}
+
+
+def _async_client_with_handler(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> Callable[..., httpx.AsyncClient]:
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return _REAL_ASYNC_CLIENT(*args, **kwargs)
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_follows_register_token_key_model_mcp_contract() -> None:
+    from uuid import uuid4
+
+    from preloop.models.schemas.mcp_server import MCPServerCreate
+    from preloop.schemas.ai_model import AIModelCreate
+    from preloop.schemas.auth import ApiKeyCreate, AuthUserCreate, LoginRequest
+
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        seen.append((request.method, f"{request.url.host}{path}"))
+        if request.method == "GET" and path == "/capacity/identity":
+            assert request.url.host == "fake"
+            return httpx.Response(200, json={"fixture": "preloop-capacity-v1"})
+        body = _json_body(request)
+        if path == "/api/v1/auth/register":
+            AuthUserCreate.model_validate(body)
+            assert body["email"].endswith("@example.com")
+            return httpx.Response(201, json={"account_id": ACCOUNT_ID})
+        if path == "/api/v1/auth/token/json":
+            LoginRequest.model_validate(body)
+            return httpx.Response(200, json={"access_token": "capacity-token"})
+        assert request.headers.get("authorization") == "Bearer capacity-token"
+        if path == "/api/v1/auth/api-keys":
+            ApiKeyCreate.model_validate(body)
+            assert body["name"] == "capacity-driver"
+            return httpx.Response(201, json={"key": "capacity-key"})
+        if path == "/api/v1/ai-models":
+            AIModelCreate.model_validate(body)
+            assert body["api_endpoint"] == "http://fake/v1"
+            assert (
+                body["meta_data"]["gateway"]["model_alias"] == "openai/capacity-model"
+            )
+            return httpx.Response(201, json={"id": str(uuid4())})
+        if path == "/api/v1/mcp-servers":
+            MCPServerCreate.model_validate(body)
+            assert body["url"] == "http://fake/tools/mcp"
+            assert body["transport"] == "http-streaming"
+            assert body["auth_type"] == "none"
+            return httpx.Response(201, json={"status": "active"})
+        raise AssertionError(f"unexpected {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        key, login, account_id = await run.bootstrap(
+            client, "http://api", "http://fake"
+        )
+    assert key == "capacity-key"
+    assert account_id == ACCOUNT_ID
+    assert login["username"].startswith("capacity")
+    assert seen == [
+        ("GET", "fake/capacity/identity"),
+        ("POST", "api/api/v1/auth/register"),
+        ("POST", "api/api/v1/auth/token/json"),
+        ("POST", "api/api/v1/auth/api-keys"),
+        ("POST", "api/api/v1/ai-models"),
+        ("POST", "api/api/v1/mcp-servers"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_a_non_fixture_identity() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"fixture": "other"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(ValueError, match="identity check failed"):
+            await run.bootstrap(client, "http://api", "http://fake")
+
+
+@pytest.mark.asyncio
+async def test_actor_alternates_tool_then_gateway_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import argparse
+    import time
+
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    gateway_requests: list[httpx.Request] = []
+
+    def gateway(request: httpx.Request) -> httpx.Response:
+        gateway_requests.append(request)
+        assert request.url.path == "/openai/v1/chat/completions"
+        body = _json_body(request)
+        assert body["model"] == "openai/capacity-model"
+        assert body["stream"] is True
+        assert body["stream_options"]["include_usage"] is True
+        assert request.headers["authorization"] == "Bearer capacity-token"
+        assert request.headers["x-preloop-session-id"] == "capacity-0-3"
+        return httpx.Response(200, text=STREAM_BODY)
+
+    def fake_client(transport, timeout=None):
+        assert isinstance(transport, StreamableHttpTransport)
+        assert transport.url == "http://127.0.0.1/mcp/v1"
+        assert transport.headers["Authorization"] == "Bearer capacity-token"
+        assert transport.httpx_client_factory is run.mcp_http_client
+        return Client(fake.mcp, timeout=timeout)
+
+    monkeypatch.setattr(run, "Client", fake_client)
+    monkeypatch.setattr(run.httpx, "AsyncClient", _async_client_with_handler(gateway))
+    output = io.StringIO()
+    recorder = run.Recorder(output, 0, 8)
+    args = argparse.Namespace(
+        api="http://127.0.0.1",
+        gateway="http://127.0.0.1:8001",
+        timeout=5,
+        tool_delay_ms=0,
+        think_ms=0,
+        cancel_every=0,
+    )
+    await run.actor(3, args, "capacity-token", recorder, time.monotonic() + 0.4)
+    operations = [sample["operation"] for sample in recorder.samples]
+    assert operations[0] == "mcp_connect"
+    pairs = [op for op in operations[1:] if op in {"mcp_tool", "gateway_stream"}]
+    assert pairs[:2] == ["mcp_tool", "gateway_stream"]
+    assert all(pairs[i] != pairs[i + 1] for i in range(len(pairs) - 1))
+    assert "mcp_tool" in operations
+    assert "gateway_stream" in operations
+    assert all(sample["ok"] for sample in recorder.samples)
+    assert gateway_requests
+
+
+@pytest.mark.asyncio
+async def test_observe_probes_ping_health_signin_control_and_nats_varz(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import argparse
+    import asyncio
+
+    from preloop.schemas.auth import LoginRequest
+
+    seen: list[tuple[str, str]] = []
+    login = {"username": "capacityuser", "password": "capacity-password-ok"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        seen.append((request.method, f"{request.url.host}{path}"))
+        if path == "/api/v1/ping":
+            return httpx.Response(200, json={"status": "pong"})
+        if path == "/api/v1/health":
+            return httpx.Response(200, json={"database": "connected"})
+        if path == "/api/v1/auth/token/json":
+            LoginRequest.model_validate(_json_body(request))
+            return httpx.Response(200, json={"access_token": "capacity-token"})
+        if path == "/api/v1/auth/users/me":
+            assert request.headers.get("authorization") == "Bearer capacity-token"
+            return httpx.Response(200, json={"username": "capacityuser"})
+        if path == "/varz":
+            assert request.url.host == "nats"
+            return httpx.Response(200, json={"connections": 1})
+        raise AssertionError(f"unexpected {request.method} {request.url}")
+
+    monkeypatch.setattr(run.httpx, "AsyncClient", _async_client_with_handler(handler))
+    output = io.StringIO()
+    recorder = run.Recorder(output, 0, 6)
+    args = argparse.Namespace(
+        timeout=2,
+        api="http://api",
+        gateway="http://gateway",
+        nats="http://nats",
+        sample_seconds=0.05,
+    )
+    stop = asyncio.Event()
+    await run.observe(args, "capacity-token", login, recorder, stop, output)
+    assert seen[:6] == [
+        ("GET", "api/api/v1/ping"),
+        ("GET", "api/api/v1/health"),
+        ("GET", "gateway/api/v1/ping"),
+        ("GET", "gateway/api/v1/health"),
+        ("POST", "api/api/v1/auth/token/json"),
+        ("GET", "nats/varz"),
+    ]
+    assert ("GET", "api/api/v1/auth/users/me") in seen
+    operations = [sample["operation"] for sample in recorder.samples]
+    assert "api_ping" in operations
+    assert "gateway_ping" in operations
+    assert "signin" in operations
+    assert "control" in operations
+    assert all(sample["ok"] for sample in recorder.samples)
+
+
+@pytest.mark.asyncio
+async def test_log_publish_uses_flow_updates_subject_and_agent_log_line_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from uuid import uuid4
+
+    import nats
+
+    from scripts.capacity.logs import LogFixture
+
+    execution_id = uuid4()
+    published: list[tuple[str, dict]] = []
+
+    class FakeNats:
+        async def publish(self, subject: str, payload: bytes) -> None:
+            published.append((subject, json.loads(payload)))
+
+        async def flush(self, timeout: float = 5) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    async def connect(address, connect_timeout=5, max_reconnect_attempts=0):
+        assert address == "nats://127.0.0.1:4222"
+        assert connect_timeout == 5
+        assert max_reconnect_attempts == 0
+        return FakeNats()
+
+    monkeypatch.setenv("NATS_URL", "nats://127.0.0.1:4222")
+    monkeypatch.setattr(nats, "connect", connect)
+    fixture = object.__new__(LogFixture)
+    fixture.ids = [execution_id]
+    result = await fixture.publish("account-1", 2, rate=1000, seconds=1, maximum=2)
+    assert result["submitted"] == 2
+    assert result["maximum_reached"] is True
+    assert [subject for subject, _ in published] == [
+        "flow-updates." + str(execution_id)
+    ] * 2
+    for index, (_, payload) in enumerate(published):
+        assert payload["type"] == "agent_log_line"
+        assert payload["execution_id"] == str(execution_id)
+        assert payload["account_id"] == "account-1"
+        assert payload["payload"] == {"line": f"capacity:2:{index}"}


### PR DESCRIPTION
Add a disposable capacity lab that drives authenticated MCP tool calls, streaming model-gateway requests, sign-in/control probes and optional NATS execution-log persistence against Preloop, PostgreSQL and deterministic local providers. A private Compose network blocks external provider traffic, and disabled inert flow fixtures never launch agents.

Configurable concurrency steps, bounded soaks, delays, intentional stream cancellation and log rates produce raw request/telemetry artifacts, throughput/latency/error summaries, recovery checks and submitted-versus-persisted log accounting. The local wrapper captures resource, PostgreSQL wait, image/configuration and service-log evidence. Documentation explains closed-loop workload limits and how to distinguish injector/provider limits from target failures.

Validation: 17 unit/protocol tests; native full-stack smoke with a fresh local PostgreSQL database, separate NATS/API/gateway/fake processes, real registration and authenticated tool/model requests; full and deliberately cancelled streams; exact log reconciliation. Changed-file hooks, Compose configuration, shell syntax and scoped secret scan pass. Docker runtime and VM resource measurements remain untested because the workstation Docker daemon is unavailable. No VM capacity claim is made.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Self-contained benchmark harness with no production-code changes, strong network isolation, and well-tested measurement logic; no security or correctness concerns requiring a fix.
>
> **Overview**
> Adds a disposable capacity lab under `scripts/capacity/` that drives authenticated MCP tool calls, streaming gateway requests, and optional NATS log persistence against an internal-only Compose stack. The integration glue (`bootstrap`/`actor`/`observe`/`publish`) is now covered by protocol tests, and the previously flagged robustness and placeholder cleanups are addressed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit cc312964. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->