### PR TITLE
Align inventory cost totals and refresh reviewed model pricing

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -563,7 +563,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 exc_info=True,
             )
 
-    yield
+    # All roles, including a dedicated gateway, need the same current prices.
+    from preloop.services.reviewed_model_price_refresh import (
+        start_reviewed_price_refresh,
+    )
+
+    price_refresher = start_reviewed_price_refresh()
+    try:
+        yield
+    finally:
+        if price_refresher is not None:
+            await price_refresher.stop()
 
     # Shutdown logic
 

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -477,6 +477,23 @@ class Settings(BaseSettings):
             "day so repeated traffic never re-triggers lookups."
         ),
     )
+    model_price_refresh_url: str = Field(
+        "",
+        description=(
+            "Trusted HTTPS URL of a reviewed price feed; empty disables refresh. "
+            "Refreshes supported current estimates in every API/gateway/worker "
+            "process without an application deployment. Never re-prices history."
+        ),
+    )
+    model_price_refresh_allowed_models: list[str] = Field(
+        default_factory=list,
+        description="Exact catalog keys the reviewed feed may update; required when enabled.",
+    )
+    model_price_refresh_interval_seconds: int = Field(
+        21600,
+        ge=60,
+        description="Reviewed price feed polling interval (default six hours).",
+    )
     model_catalog_sync_scheduled_enabled: bool = Field(
         False,
         description=(

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1417,10 +1417,13 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         runtime_principal_id: Optional[str] = None,
-        limit: int = 20,
+        limit: Optional[int] = 20,
     ) -> List[Dict[str, Any]]:
-        """Group gateway usage by flow."""
-        from ..models.flow import Flow
+        """Group gateway usage by flow.
+
+        Pass ``limit=None`` for complete account totals; the default only
+        returns the busiest flows and is appropriate for top-flow lists.
+        """
 
         base_query = (
             db.query(

--- a/backend/preloop/schemas/ai_model_pricing.py
+++ b/backend/preloop/schemas/ai_model_pricing.py
@@ -8,7 +8,7 @@ conversion happens here, once, rather than in each client.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -63,6 +63,10 @@ class AIModelPricingResponse(BaseModel):
     override_id: Optional[str] = None
     effective_from: Optional[datetime] = None
     effective_until: Optional[datetime] = None
+    catalog_provenance: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Published-price provenance and schedule estimation assumptions.",
+    )
     catalog_key: Optional[str] = Field(
         default=None,
         description="The price list entry that matched, when the source is the catalog.",

--- a/backend/preloop/services/ai_model_pricing.py
+++ b/backend/preloop/services/ai_model_pricing.py
@@ -23,7 +23,7 @@ from preloop.schemas.ai_model_pricing import (
     AIModelPriceQuote,
     AIModelPricingResponse,
 )
-from preloop.services import model_price_catalog
+from preloop.services import deepseek_pricing, model_price_catalog
 from preloop.services.model_pricing import (
     _get_configured_pricing,
     _iter_litellm_model_candidates,
@@ -37,8 +37,8 @@ logger = logging.getLogger(__name__)
 
 #: Providers that publish machine-readable prices Preloop can read back.
 #: OpenRouter's ``GET /api/v1/models`` carries a ``pricing`` block per model;
-#: no other supported provider serves prices from its API, so the console
-#: offers the fetch to these and disables it, by name, for the rest.
+#: this is the set of implemented adapters, not an assertion that other
+#: providers have no machine-readable retail catalogs.
 PRICE_FETCH_PROVIDERS = {"openrouter"}
 
 #: Shown when a provider does not publish prices.
@@ -247,6 +247,21 @@ def _pricing_response(
                 currency=str(configured.get("currency") or "USD"),
             )
 
+    tariff = deepseek_pricing.native_tariff(ai_model)
+    if tariff is not None:
+        return AIModelPricingResponse(
+            **base,
+            source="catalog",
+            price=AIModelPrice(
+                input_per_1m=tariff.input_per_1m,
+                output_per_1m=tariff.output_per_1m,
+                cached_input_per_1m=tariff.cached_input_per_1m,
+            ),
+            catalog_key=f"deepseek/{tariff.model}",
+            effective_from=tariff.effective_from,
+            catalog_provenance=tariff.metadata(),
+        )
+
     catalog = _catalog_entry(ai_model)
     if catalog:
         catalog_key, entry = catalog
@@ -255,6 +270,7 @@ def _pricing_response(
             source="catalog",
             price=_price_from_catalog_entry(entry),
             catalog_key=catalog_key,
+            catalog_provenance=entry.get("preloop_price_provenance"),
         )
 
     return AIModelPricingResponse(**base, source="none")

--- a/backend/preloop/services/deepseek_pricing.py
+++ b/backend/preloop/services/deepseek_pricing.py
@@ -1,0 +1,255 @@
+"""Dated native DeepSeek USD tariffs, with explicit estimation provenance.
+
+These rates apply only to api.deepseek.com. Marketplace and cloud sellers
+set their own tariffs. Public-holiday exemptions are not precisely specified
+by the provider, so weekday peak estimates conservatively omit that exemption.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+from typing import Any
+from urllib.parse import urlsplit
+
+from preloop.models import models
+
+PRICING_URL = "https://api-docs.deepseek.com/quick_start/pricing"
+AUGUST_START = datetime(2026, 8, 16, 16, tzinfo=timezone.utc)
+SEPTEMBER_START = datetime(2026, 9, 10, 4, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class DeepSeekTariff:
+    """The selected dated tariff; prices are USD per million tokens."""
+
+    model: str
+    observed_at: datetime
+    effective_from: datetime
+    band: str
+    input_per_1m: float
+    output_per_1m: float
+    cached_input_per_1m: float
+    weekday_schedule: bool
+    reviewed_provenance: dict[str, Any] | None = None
+
+    def metadata(self) -> dict[str, Any]:
+        """Return immutable calculation inputs for a usage-row snapshot."""
+        snapshot = {
+            "provider": "deepseek",
+            "model": self.model,
+            "currency": "USD",
+            "policy_version": "deepseek-native-2026-09-12",
+            "source_url": (
+                "https://api-docs.deepseek.com/img/v4_260813_price_en.png"
+                if self.effective_from < SEPTEMBER_START
+                else PRICING_URL
+            ),
+            "source_verified_at": "2026-09-12T17:12:53+00:00",
+            "effective_from": self.effective_from.isoformat(),
+            "observed_at": self.observed_at.isoformat(),
+            "rate_band": self.band,
+            "input_per_1m": self.input_per_1m,
+            "output_per_1m": self.output_per_1m,
+            "cached_input_per_1m": self.cached_input_per_1m,
+            "peak_hours_utc": [[1, 4], [6, 10]],
+            "peak_weekdays": [0, 1, 2, 3, 4]
+            if self.weekday_schedule
+            else [0, 1, 2, 3, 4, 5, 6],
+            "estimate_limitations": [
+                "Provider public-holiday calendar is unspecified; weekday peak "
+                "rates may overestimate exempt holidays."
+            ]
+            if self.weekday_schedule
+            else [],
+        }
+        if self.model == "deepseek-v4-pro" and self.weekday_schedule:
+            snapshot["estimate_limitations"].append(
+                "The current shared pricing page specifies weekday peaks; its "
+                "historical effective instant for Pro is not explicitly stated. "
+                "This estimate applies the September 10 schedule transition."
+            )
+        if self.reviewed_provenance:
+            snapshot.update(
+                source_url=self.reviewed_provenance.get("source_url"),
+                source_verified_at=self.reviewed_provenance.get("verified_at"),
+                policy_version=self.reviewed_provenance.get("revision"),
+                reviewed_feed=self.reviewed_provenance,
+            )
+        return snapshot
+
+    def estimate(
+        self,
+        *,
+        prompt_tokens: int,
+        completion_tokens: int,
+        usage_details: dict[str, Any] | None,
+    ) -> float:
+        """Price reported cache reads separately, conservatively if absent."""
+        details = usage_details or {}
+        nested = details.get("prompt_tokens_details")
+        nested = nested if isinstance(nested, dict) else {}
+        cached = nested.get("cached_tokens")
+        if cached is None:
+            cached = details.get("prompt_cache_hit_tokens")
+        if cached is None:
+            cached = details.get("cache_read_input_tokens")
+        try:
+            reads = min(max(int(cached or 0), 0), max(prompt_tokens, 0))
+        except (TypeError, ValueError, OverflowError):
+            reads = 0
+        return round(
+            (
+                (max(prompt_tokens, 0) - reads) * self.input_per_1m
+                + reads * self.cached_input_per_1m
+                + max(completion_tokens, 0) * self.output_per_1m
+            )
+            / 1_000_000,
+            12,
+        )
+
+
+def native_tariff(
+    ai_model: models.AIModel, *, observed_at: datetime | None = None
+) -> DeepSeekTariff | None:
+    """Select a native tariff by actual endpoint, model and request time.
+
+    Earlier periods and unknown model identifiers retain the existing catalog
+    fallback. The September Pro retirement was rescinded; Pro stays Pro.
+    """
+    endpoint = (ai_model.api_endpoint or "").strip()
+    provider = (ai_model.provider_name or "").strip().lower()
+    if endpoint:
+        try:
+            host = urlsplit(endpoint).hostname
+        except ValueError:
+            return None
+        if host != "api.deepseek.com":
+            return None
+    elif provider != "deepseek":
+        return None
+    identifier = (ai_model.model_identifier or "").strip().lower()
+    for prefix in ("preloop/", "deepseek/"):
+        if identifier.startswith(prefix):
+            identifier = identifier[len(prefix) :]
+    moment = observed_at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    moment = moment.astimezone(timezone.utc)
+    if moment < AUGUST_START:
+        return None
+    september = moment >= SEPTEMBER_START
+    if identifier == "deepseek-v4-pro":
+        canonical, rates = "deepseek-v4-pro", (0.044, 1.32, 3.96)
+    elif identifier in {"deepseek-v4-flash", "deepseek-v4-flash-vision-exp"}:
+        canonical = "deepseek-flash" if september else identifier
+        rates = (0.006, 0.30, 1.20) if september else (0.014, 0.44, 1.32)
+    elif identifier == "deepseek-flash" and september:
+        canonical, rates = "deepseek-flash", (0.006, 0.30, 1.20)
+    else:
+        return None
+    peak_hour = 1 <= moment.hour < 4 or 6 <= moment.hour < 10
+    peak = peak_hour and (not september or moment.weekday() < 5)
+    multiplier = 1 if peak else 0.5
+    baseline = DeepSeekTariff(
+        model=canonical,
+        observed_at=moment,
+        effective_from=SEPTEMBER_START if september else AUGUST_START,
+        band="peak" if peak else "off_peak",
+        input_per_1m=rates[1] * multiplier,
+        output_per_1m=rates[2] * multiplier,
+        cached_input_per_1m=rates[0] * multiplier,
+        weekday_schedule=september,
+    )
+
+    return _reviewed_tariff(identifier, baseline) or baseline
+
+
+def _reviewed_tariff(
+    identifier: str, baseline: DeepSeekTariff
+) -> DeepSeekTariff | None:
+    """Read a validated reviewed policy while keeping historical built-in rates.
+
+    Validation is repeated defensively for the small supported policy shape;
+    arbitrary LiteLLM/source fields must not silently become billing policies.
+    """
+    import litellm
+
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    keys = dict.fromkeys(
+        (
+            f"deepseek/{baseline.model}",
+            baseline.model,
+            f"deepseek/{identifier}",
+            identifier,
+        )
+    )
+    if baseline.model == "deepseek-flash":
+        # Existing catalogs still use the retired native Flash identifiers.
+        # They are one serving tariff after the September alias transition.
+        for alias in ("deepseek-v4-flash", "deepseek-v4-flash-vision-exp"):
+            keys.setdefault(f"deepseek/{alias}", None)
+            keys.setdefault(alias, None)
+    for key in keys:
+        entry = litellm.model_cost.get(key)
+        if not isinstance(entry, dict):
+            continue
+        policy = entry.get("preloop_price_policy")
+        provenance = entry.get("preloop_price_provenance")
+        if isinstance(policy, dict) and isinstance(provenance, dict):
+            candidates.append((policy, provenance))
+        history = entry.get("preloop_price_policy_history")
+        if isinstance(history, list):
+            for version in history:
+                if (
+                    isinstance(version, dict)
+                    and isinstance(version.get("policy"), dict)
+                    and isinstance(version.get("provenance"), dict)
+                ):
+                    candidates.append((version["policy"], version["provenance"]))
+    selected: DeepSeekTariff | None = None
+    for policy, provenance in candidates:
+        if (
+            policy.get("kind") != "deepseek_utc_bands"
+            or policy.get("peak_hours_utc") != [[1, 4], [6, 10]]
+            or policy.get("peak_weekdays") != [0, 1, 2, 3, 4]
+            or policy.get("public_holidays") != "unspecified"
+        ):
+            continue
+        try:
+            effective = datetime.fromisoformat(policy["effective_from"])
+            if effective.tzinfo is None:
+                continue
+            effective = effective.astimezone(timezone.utc)
+            if effective < SEPTEMBER_START or baseline.observed_at < effective:
+                continue
+            band = policy[baseline.band]
+            rates = [
+                band[field]
+                for field in ("cached_input_per_1m", "input_per_1m", "output_per_1m")
+            ]
+            if not all(
+                isinstance(rate, (float, int))
+                and not isinstance(rate, bool)
+                and math.isfinite(rate)
+                and rate >= 0
+                for rate in rates
+            ):
+                continue
+        except (KeyError, TypeError, ValueError):
+            continue
+        if selected is not None and selected.effective_from >= effective:
+            continue
+        selected = DeepSeekTariff(
+            model=baseline.model,
+            observed_at=baseline.observed_at,
+            effective_from=effective,
+            band=baseline.band,
+            cached_input_per_1m=rates[0],
+            input_per_1m=rates[1],
+            output_per_1m=rates[2],
+            weekday_schedule=True,
+            reviewed_provenance=dict(provenance),
+        )
+    return selected

--- a/backend/preloop/services/model_gateway_usage.py
+++ b/backend/preloop/services/model_gateway_usage.py
@@ -104,6 +104,9 @@ class ModelGatewayUsageService:
                 start_date=start_date,
                 end_date=end_date,
                 runtime_principal_id=runtime_principal_id,
+                # These are full per-flow totals for Cost and Inventory,
+                # including flows outside the recent-session/top-flow lists.
+                limit=None,
             )
             usage_by_session = crud_api_usage.get_gateway_usage_by_session(
                 self.db,
@@ -111,9 +114,8 @@ class ModelGatewayUsageService:
                 start_date=start_date,
                 end_date=end_date,
                 runtime_principal_id=runtime_principal_id,
-                # Cover all agents' sessions for the cost-view breakdown tabs;
-                # the default of 20 truncates to the most-recent sessions and
-                # drops agents whose traffic isn't in that window.
+                # Recent session detail stays bounded. Flow totals above must
+                # not be reconstructed by summing this truncated activity list.
                 limit=250,
             )
             usage_by_tool = ToolUsageStatsService(self.db).get_account_usage_by_tool(

--- a/backend/preloop/services/model_price_catalog.py
+++ b/backend/preloop/services/model_price_catalog.py
@@ -479,7 +479,10 @@ def lookup_model_price_now(candidates: List[str]) -> Optional[str]:
             try:
                 import litellm
 
-                litellm.register_model({candidate: entry})
+                with _lock:
+                    existing = litellm.model_cost.get(candidate, {})
+                    if not existing.get("preloop_price_provenance"):
+                        litellm.register_model({candidate: entry})
                 matched_key = candidate
                 logger.info(
                     "Live price lookup registered %s from upstream map",

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, Iterable, Optional
 
 import litellm
 
 from preloop.models.models.ai_model import AIModel
-from preloop.services import alibaba_pricing
+from preloop.services import alibaba_pricing, deepseek_pricing
 from preloop.services.litellm_routing import PROVIDER_PREFIX as _PROVIDER_PREFIX
 
 logger = logging.getLogger(__name__)
@@ -200,6 +201,7 @@ class CostEstimate:
 
     cost: Optional[float]
     source: str
+    pricing_snapshot: Optional[Dict[str, Any]] = None
 
 
 def provider_reported_cost(
@@ -302,6 +304,7 @@ def estimate_ai_model_usage_cost(
     total_tokens: int,
     usage_details: Optional[Dict[str, Any]] = None,
     pricing_override: Optional[Dict[str, Any]] = None,
+    observed_at: Optional[datetime] = None,
 ) -> Optional[float]:
     """Estimate usage cost using manual pricing overrides or LiteLLM pricing."""
     return estimate_ai_model_usage_cost_detailed(
@@ -311,6 +314,7 @@ def estimate_ai_model_usage_cost(
         total_tokens=total_tokens,
         usage_details=usage_details,
         pricing_override=pricing_override,
+        observed_at=observed_at,
     ).cost
 
 
@@ -322,6 +326,7 @@ def estimate_ai_model_usage_cost_detailed(
     total_tokens: int,
     usage_details: Optional[Dict[str, Any]] = None,
     pricing_override: Optional[Dict[str, Any]] = None,
+    observed_at: Optional[datetime] = None,
 ) -> CostEstimate:
     """Estimate usage cost and report which pricing source produced it.
 
@@ -361,6 +366,23 @@ def estimate_ai_model_usage_cost_detailed(
 
     if prompt_tokens <= 0 and completion_tokens <= 0:
         return CostEstimate(cost=None, source="unpriced")
+
+    tariff = deepseek_pricing.native_tariff(ai_model, observed_at=observed_at)
+    if tariff is not None:
+        native_cost = tariff.estimate(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            usage_details=usage_details,
+        )
+        if pricing_override:
+            native_cost = _apply_pricing_adjustments(
+                native_cost, pricing_override, total_tokens=total_tokens
+            )
+        return CostEstimate(
+            cost=native_cost,
+            source="override" if pricing_override else "catalog",
+            pricing_snapshot=tariff.metadata(),
+        )
 
     list_cost = _estimate_litellm_cost(
         ai_model,

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -8522,6 +8522,11 @@ class OpenAIGatewayService:
             ai_model=ai_model,
             model_alias=model_alias,
         )
+        # Estimate the request's start from the measured duration so crossing
+        # a tariff boundary during a stream does not select completion-time rates.
+        pricing_observed_at = datetime.now(timezone.utc) - timedelta(
+            seconds=max(duration, 0.0)
+        )
         cost_estimate = estimate_ai_model_usage_cost_detailed(
             ai_model,
             prompt_tokens=prompt_tokens,
@@ -8529,6 +8534,7 @@ class OpenAIGatewayService:
             total_tokens=total_tokens or 0,
             usage_details=usage_details,
             pricing_override=pricing_override,
+            observed_at=pricing_observed_at,
         )
         estimated_cost = cost_estimate.cost
         cost_source = cost_estimate.source
@@ -8618,6 +8624,12 @@ class OpenAIGatewayService:
                 if upstream_response
                 else None,
                 "usage_details": usage_details or None,
+                "pricing_snapshot": {
+                    **cost_estimate.pricing_snapshot,
+                    "timestamp_basis": "request_start_estimated_from_duration",
+                }
+                if cost_estimate.pricing_snapshot
+                else None,
                 "pricing_override_id": pricing_override.get("id")
                 if pricing_override
                 else None,

--- a/backend/preloop/services/reviewed_model_price_refresh.py
+++ b/backend/preloop/services/reviewed_model_price_refresh.py
@@ -1,0 +1,411 @@
+"""Refresh current estimates from an operator-controlled, reviewed price feed.
+
+This service never discovers providers, changes account overrides, or writes usage
+rows. Every serving process polls independently; one dictionary replacement makes
+the validated price set visible together. Published pages are evidence, not an
+executable scraping policy. Only flat token rates and the known native DeepSeek UTC-band policy are
+supported; new policy structures need estimator support before publication.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+logger = logging.getLogger(__name__)
+MAX_FEED_BYTES = 2_000_000
+DEEPSEEK_MODELS = frozenset(
+    {
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
+        "deepseek-flash",
+    }
+)
+PRICE_FIELDS = frozenset(
+    {
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "cache_read_input_token_cost",
+        "cache_creation_input_token_cost",
+    }
+)
+
+
+def validate_https_url(value: str) -> str:
+    """Require HTTPS without embedded credentials or fragments."""
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise ValueError("Expected an HTTPS URL without credentials or fragment")
+    return value
+
+
+class DeepSeekBand(BaseModel):
+    """One bounded USD-per-million rate band."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    input_per_1m: float
+    output_per_1m: float
+    cached_input_per_1m: float
+
+    @field_validator("input_per_1m", "output_per_1m", "cached_input_per_1m")
+    @classmethod
+    def valid_rate(cls, value: float) -> float:
+        """Reject invalid or impractically large published rate numbers."""
+        if not math.isfinite(value) or not 0 <= value <= 1_000_000:
+            raise ValueError("Rates must be finite nonnegative USD values")
+        return value
+
+
+class DeepSeekPolicy(BaseModel):
+    """Only the already-supported native DeepSeek UTC rate-band structure."""
+
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["deepseek_utc_bands"]
+    effective_from: datetime
+    peak: DeepSeekBand
+    off_peak: DeepSeekBand
+    peak_hours_utc: list[tuple[int, int]]
+    peak_weekdays: list[int]
+    public_holidays: Literal["unspecified"]
+
+    @field_validator("effective_from")
+    @classmethod
+    def valid_effective_date(cls, value: datetime) -> datetime:
+        """Normalize instant identity and reject schedules predating support."""
+        if value.tzinfo is None:
+            raise ValueError("DeepSeek effective date needs a timezone")
+        value = value.astimezone(timezone.utc)
+        if value < datetime(2026, 9, 10, 4, tzinfo=timezone.utc):
+            raise ValueError("DeepSeek weekday policy predates supported schedule")
+        return value
+
+    @field_validator("peak_hours_utc")
+    @classmethod
+    def valid_hours(cls, value: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        """Accept bounded, non-overlapping UTC hour intervals."""
+        if not value or any(not 0 <= start < end <= 24 for start, end in value):
+            raise ValueError("Invalid UTC hour interval")
+        if value != [(1, 4), (6, 10)]:
+            raise ValueError("Unsupported DeepSeek UTC peak schedule")
+        return value
+
+    @field_validator("peak_weekdays")
+    @classmethod
+    def valid_weekdays(cls, value: list[int]) -> list[int]:
+        """Weekday zero is Monday, six is Sunday."""
+        if value != [0, 1, 2, 3, 4]:
+            raise ValueError("Unsupported DeepSeek weekday schedule")
+        return value
+
+
+class HistoricalPolicy(BaseModel):
+    """A previously reviewed revision carried with a newer feed."""
+
+    model_config = ConfigDict(extra="forbid")
+    policy: DeepSeekPolicy
+    provenance: dict[str, Any]
+
+
+class ReviewedPrice(BaseModel):
+    """An explicitly reviewed USD price with first-party evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+    policy: Literal["flat_per_token", "deepseek_utc_bands"]
+    source_url: str
+    verified_at: datetime
+    effective_from: datetime
+    prices: dict[str, float] | None = None
+    price_policy: DeepSeekPolicy | None = None
+    price_policy_history: list[HistoricalPolicy] = Field(
+        default_factory=list, max_length=100
+    )
+
+    _source_url = field_validator("source_url")(validate_https_url)
+
+    @field_validator("prices", mode="before")
+    @classmethod
+    def valid_prices(cls, value: Any) -> Any:
+        """Reject incomplete, non-finite, negative, and unsupported prices."""
+        if value is None:
+            return value
+        if not isinstance(value, dict) or not {
+            "input_cost_per_token",
+            "output_cost_per_token",
+        }.issubset(value):
+            raise ValueError("Input and output prices are required")
+        if set(value) - PRICE_FIELDS:
+            raise ValueError("Unsupported price policy or field")
+        for price in value.values():
+            if (
+                isinstance(price, bool)
+                or not isinstance(price, (float, int))
+                or price < 0
+                or price > 1e6
+                or not math.isfinite(price)
+            ):
+                raise ValueError("Prices must be finite nonnegative numbers")
+        return value
+
+
+class ReviewedPriceFeed(BaseModel):
+    """The published artifact accepted by the runtime and build command."""
+
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal[1]
+    currency: Literal["USD"]
+    revision: str
+    published_at: datetime
+    expires_at: datetime
+    models: dict[str, ReviewedPrice]
+
+
+def validate_feed(payload: Any, *, now: datetime | None = None) -> ReviewedPriceFeed:
+    """Validate provenance and dates without mutating any runtime prices."""
+    feed = ReviewedPriceFeed.model_validate(payload)
+    clock = now or datetime.now(timezone.utc)
+    if not feed.revision.strip() or not feed.models:
+        raise ValueError("A revision and at least one model are required")
+    stamps = [feed.published_at, feed.expires_at]
+    for entry in feed.models.values():
+        stamps.extend([entry.verified_at, entry.effective_from])
+    if any(stamp.tzinfo is None for stamp in stamps):
+        raise ValueError("All timestamps must include a timezone")
+    if not feed.published_at <= clock < feed.expires_at:
+        raise ValueError("Feed is expired or not yet published")
+    if (feed.expires_at - feed.published_at).total_seconds() > 31 * 86400:
+        raise ValueError("Feed validity must not exceed 31 days")
+    for entry in feed.models.values():
+        if entry.verified_at > feed.published_at:
+            raise ValueError("Evidence cannot postdate publication")
+        if entry.policy == "flat_per_token":
+            if entry.effective_from > entry.verified_at:
+                raise ValueError("Flat prices must already be effective when verified")
+            if (
+                entry.prices is None
+                or entry.price_policy is not None
+                or entry.price_policy_history
+            ):
+                raise ValueError("Flat policy requires prices only")
+        elif (
+            entry.prices is not None
+            or entry.price_policy is None
+            or entry.price_policy.effective_from != entry.effective_from
+        ):
+            raise ValueError("DeepSeek policy requires matching dated policy data only")
+        if (feed.published_at - entry.verified_at).total_seconds() > 14 * 86400:
+            raise ValueError("Provider evidence is more than 14 days old")
+        for historical in entry.price_policy_history:
+            provenance = historical.provenance
+            validate_https_url(provenance.get("source_url", ""))
+            if not provenance.get("revision"):
+                raise ValueError("Historical policy revision is required")
+            verified = datetime.fromisoformat(provenance.get("verified_at", ""))
+            effective = datetime.fromisoformat(provenance.get("effective_from", ""))
+            if (
+                verified.tzinfo is None
+                or effective.tzinfo is None
+                or verified > feed.published_at
+                or effective != historical.policy.effective_from
+                or effective >= entry.effective_from
+            ):
+                raise ValueError("Invalid historical policy provenance or dates")
+    return feed
+
+
+def _policy_history(
+    existing: dict[str, Any], entry: ReviewedPrice
+) -> list[dict[str, Any]]:
+    """Preserve dated revisions and reject silent changes to a prior tariff."""
+    assert entry.price_policy is not None
+    current = entry.price_policy.model_dump(mode="json")
+    current_date = entry.price_policy.effective_from.isoformat()
+    history = list(existing.get("preloop_price_policy_history", []))
+    if existing.get("preloop_price_policy") and isinstance(
+        existing.get("preloop_price_provenance"), dict
+    ):
+        history.append(
+            {
+                "policy": existing["preloop_price_policy"],
+                "provenance": existing["preloop_price_provenance"],
+            }
+        )
+    history.extend(item.model_dump(mode="json") for item in entry.price_policy_history)
+    policies = {current_date: current}
+    retained: dict[str, dict[str, Any]] = {}
+    for item in history:
+        policy = DeepSeekPolicy.model_validate(item["policy"])
+        normalized = policy.model_dump(mode="json")
+        date = policy.effective_from.isoformat()
+        if date in policies and policies[date] != normalized:
+            raise ValueError("Cannot mutate a previously reviewed tariff")
+        policies[date] = normalized
+        if date != current_date:
+            retained[date] = {**item, "policy": normalized}
+    if len(retained) > 100:
+        raise ValueError("Historical policy limit exceeded")
+    return [retained[key] for key in sorted(retained)]
+
+
+class ReviewedPriceRefresher:
+    """One lifecycle-owned polling task for a process's LiteLLM price map."""
+
+    def __init__(
+        self, *, url: str, allowed_models: list[str], interval_seconds: int
+    ) -> None:
+        self.url = validate_https_url(url)
+        self.allowed_models = frozenset(allowed_models)
+        if not self.allowed_models:
+            raise ValueError("Reviewed price refresh needs an explicit model allowlist")
+        self.interval_seconds = max(60, interval_seconds)
+        self.task: asyncio.Task[None] | None = None
+        self.applied_at: datetime | None = None
+        self.digest: str | None = None
+
+    def apply(self, payload: Any) -> int:
+        """Atomically replace supported existing prices after full validation."""
+        import hashlib
+
+        import litellm
+
+        feed = validate_feed(payload)
+        digest = hashlib.sha256(feed.model_dump_json().encode("utf-8")).hexdigest()
+        if (
+            self.applied_at is not None
+            and feed.published_at <= self.applied_at
+            and self.digest != digest
+        ):
+            raise ValueError("Refusing older or mutated published price revision")
+        if set(feed.models) - self.allowed_models:
+            raise ValueError("Feed contains models outside the operator allowlist")
+        from litellm.utils import _invalidate_model_cost_lowercase_map
+
+        from preloop.services.model_price_catalog import _lock as catalog_lock
+
+        with catalog_lock:
+            changed = 0
+            updated = dict(litellm.model_cost)
+            for model, entry in feed.models.items():
+                existing = updated.get(model)
+                if not isinstance(existing, dict):
+                    raise ValueError("Feed may only refresh existing catalog models")
+                native_key = (
+                    existing.get("litellm_provider") == "deepseek"
+                    and model.removeprefix("deepseek/") in DEEPSEEK_MODELS
+                )
+                if entry.policy == "flat_per_token" and any(
+                    "cost" in key and key not in PRICE_FIELDS for key in existing
+                ):
+                    raise ValueError(
+                        "Existing model has a policy requiring dedicated support"
+                    )
+                if entry.policy == "flat_per_token":
+                    if native_key or existing.get("preloop_price_policy"):
+                        raise ValueError(
+                            "Cannot replace a native policy with flat rates"
+                        )
+                    replacement = {
+                        key: value
+                        for key, value in existing.items()
+                        if key not in PRICE_FIELDS
+                    }
+                    replacement.update(entry.prices or {})
+                else:
+                    if not native_key:
+                        raise ValueError(
+                            "Native DeepSeek policy requires a direct model"
+                        )
+                    replacement = dict(existing)
+                    assert entry.price_policy is not None
+                    replacement["preloop_price_policy"] = entry.price_policy.model_dump(
+                        mode="json"
+                    )
+                    replacement["preloop_price_policy_history"] = _policy_history(
+                        existing, entry
+                    )
+                replacement["preloop_price_provenance"] = {
+                    "revision": feed.revision,
+                    "published_at": feed.published_at.isoformat(),
+                    "expires_at": feed.expires_at.isoformat(),
+                    "source_url": entry.source_url,
+                    "verified_at": entry.verified_at.isoformat(),
+                    "effective_from": entry.effective_from.isoformat(),
+                }
+                changed += replacement != existing
+                updated[model] = replacement
+            if not changed:
+                return 0
+            litellm.model_cost = updated
+            _invalidate_model_cost_lowercase_map()
+        self.applied_at = feed.published_at
+        self.digest = digest
+        logger.info("Applied reviewed model price feed: %d models", len(feed.models))
+        return changed
+
+    async def refresh(self, client: httpx.AsyncClient) -> int:
+        """Download a bounded feed; redirects and invalid payloads fail closed."""
+        chunks = bytearray()
+        async with client.stream("GET", self.url) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                chunks.extend(chunk)
+                if len(chunks) > MAX_FEED_BYTES:
+                    raise ValueError("Reviewed price feed exceeds size limit")
+        return self.apply(json.loads(chunks))
+
+    async def run(self) -> None:
+        """Poll until shutdown, retaining the last good prices on failures."""
+        async with httpx.AsyncClient(timeout=30, follow_redirects=False) as client:
+            while True:
+                try:
+                    await self.refresh(client)
+                except (httpx.HTTPError, ValueError, TypeError):
+                    # Do not log the configured URL or fetched body: operator
+                    # endpoints may carry access tokens in query parameters.
+                    logger.warning(
+                        "Reviewed price refresh failed; retaining last good prices"
+                    )
+                await asyncio.sleep(self.interval_seconds)
+
+    def start(self) -> None:
+        """Start at most one task for this lifecycle owner."""
+        if self.task is None or self.task.done():
+            self.task = asyncio.create_task(self.run(), name="reviewed-model-prices")
+
+    async def stop(self) -> None:
+        """Cancel polling and close its HTTP client before lifecycle exit."""
+        if self.task is not None:
+            self.task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self.task
+            self.task = None
+
+
+def start_reviewed_price_refresh() -> ReviewedPriceRefresher | None:
+    """Start only when the deployment explicitly configures a reviewed feed."""
+    from preloop.config import settings
+
+    if not settings.model_price_refresh_url:
+        return None
+    refresher = ReviewedPriceRefresher(
+        url=settings.model_price_refresh_url,
+        allowed_models=settings.model_price_refresh_allowed_models,
+        interval_seconds=settings.model_price_refresh_interval_seconds,
+    )
+    refresher.start()
+    return refresher

--- a/backend/preloop/services/reviewed_model_price_refresh.py
+++ b/backend/preloop/services/reviewed_model_price_refresh.py
@@ -41,6 +41,10 @@ PRICE_FIELDS = frozenset(
 )
 
 
+class PriceRefreshCompatibilityError(RuntimeError):
+    """LiteLLM cannot safely invalidate estimates after a price-map change."""
+
+
 def validate_https_url(value: str) -> str:
     """Require HTTPS without embedded credentials or fragments."""
     parsed = urlsplit(value)
@@ -293,7 +297,32 @@ class ReviewedPriceRefresher:
             raise ValueError("Refusing older or mutated published price revision")
         if set(feed.models) - self.allowed_models:
             raise ValueError("Feed contains models outside the operator allowlist")
-        from litellm.utils import _invalidate_model_cost_lowercase_map
+        from litellm import utils as litellm_utils
+
+        # This private helper clears LiteLLM's derived model-info caches. A
+        # map-only or register_model fallback could leave warmed prices stale.
+        invalidate = getattr(
+            litellm_utils, "_invalidate_model_cost_lowercase_map", None
+        )
+        if not callable(invalidate):
+            raise PriceRefreshCompatibilityError(
+                "LiteLLM price caches are incompatible"
+            )
+        # Capture supported LRU clearers for rollback if a callable helper
+        # fails after the map swap. Names differ between LiteLLM versions.
+        rollback_clearers = [
+            clear
+            for name in (
+                "get_model_info",
+                "_cached_get_model_info",
+                "_cached_get_model_info_helper",
+            )
+            if callable(
+                clear := getattr(
+                    getattr(litellm_utils, name, None), "cache_clear", None
+                )
+            )
+        ]
 
         from preloop.services.model_price_catalog import _lock as catalog_lock
 
@@ -350,8 +379,30 @@ class ReviewedPriceRefresher:
                 updated[model] = replacement
             if not changed:
                 return 0
+            # Probe before publishing: signature/internal API incompatibility
+            # normally fails here while all prices still use the old map.
+            try:
+                invalidate()
+            except Exception:  # noqa: BLE001 - dependency callback compatibility
+                raise PriceRefreshCompatibilityError(
+                    "LiteLLM price caches are incompatible"
+                ) from None
+            previous = litellm.model_cost
             litellm.model_cost = updated
-            _invalidate_model_cost_lowercase_map()
+            try:
+                invalidate()
+            except Exception:  # noqa: BLE001 - roll back before reporting failure
+                litellm.model_cost = previous
+                for clear in rollback_clearers:
+                    try:
+                        clear()
+                    except Exception:  # noqa: BLE001 - try remaining compatible caches
+                        logger.warning(
+                            "Reviewed price rollback could not clear a LiteLLM cache"
+                        )
+                raise PriceRefreshCompatibilityError(
+                    "LiteLLM price caches are incompatible"
+                ) from None
         self.applied_at = feed.published_at
         self.digest = digest
         logger.info("Applied reviewed model price feed: %d models", len(feed.models))
@@ -374,6 +425,11 @@ class ReviewedPriceRefresher:
             while True:
                 try:
                     await self.refresh(client)
+                except PriceRefreshCompatibilityError:
+                    logger.warning(
+                        "Reviewed price refresh unavailable: incompatible LiteLLM "
+                        "cache API; retaining last good prices"
+                    )
                 except (httpx.HTTPError, ValueError, TypeError):
                     # Do not log the configured URL or fetched body: operator
                     # endpoints may carry access tokens in query parameters.
@@ -402,10 +458,16 @@ def start_reviewed_price_refresh() -> ReviewedPriceRefresher | None:
 
     if not settings.model_price_refresh_url:
         return None
-    refresher = ReviewedPriceRefresher(
-        url=settings.model_price_refresh_url,
-        allowed_models=settings.model_price_refresh_allowed_models,
-        interval_seconds=settings.model_price_refresh_interval_seconds,
-    )
+    try:
+        refresher = ReviewedPriceRefresher(
+            url=settings.model_price_refresh_url,
+            allowed_models=settings.model_price_refresh_allowed_models,
+            interval_seconds=settings.model_price_refresh_interval_seconds,
+        )
+    except (ValueError, TypeError):
+        # Never include the URL or exception text: configuration can contain
+        # query-string tokens, embedded credentials, or private hostnames.
+        logger.warning("Reviewed price refresh disabled: invalid configuration")
+        return None
     refresher.start()
     return refresher

--- a/backend/preloop/services/usage_repricing.py
+++ b/backend/preloop/services/usage_repricing.py
@@ -70,6 +70,8 @@ def _pricing_observed_at(meta_data: Any, fallback: datetime) -> datetime:
             if parsed.tzinfo is not None:
                 return parsed.astimezone(timezone.utc)
         except ValueError:
+            # Malformed legacy snapshots must not block repricing; use the
+            # usage row's timestamp below, as for missing or naive snapshots.
             pass
     return fallback
 

--- a/backend/preloop/services/usage_repricing.py
+++ b/backend/preloop/services/usage_repricing.py
@@ -24,7 +24,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 from sqlalchemy.orm import Session
 
@@ -56,6 +56,22 @@ class RepriceResult:
     cost_before: float = 0.0
     cost_after: float = 0.0
     dry_run: bool = False
+
+
+def _pricing_observed_at(meta_data: Any, fallback: datetime) -> datetime:
+    """Reuse the original pricing instant when a stream crossed a time band."""
+    snapshot = (
+        meta_data.get("pricing_snapshot") if isinstance(meta_data, dict) else None
+    )
+    value = snapshot.get("observed_at") if isinstance(snapshot, dict) else None
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+            if parsed.tzinfo is not None:
+                return parsed.astimezone(timezone.utc)
+        except ValueError:
+            pass
+    return fallback
 
 
 def reprice_single_row(
@@ -101,6 +117,7 @@ def reprice_single_row(
         total_tokens=int(row.total_tokens or 0),
         usage_details=usage_details if isinstance(usage_details, dict) else None,
         pricing_override=pricing_override,
+        observed_at=_pricing_observed_at(meta, row.timestamp),
     )
     if estimate.cost == row.estimated_cost and estimate.source == row.cost_source:
         return False
@@ -115,6 +132,7 @@ def reprice_single_row(
             "previous_estimated_cost": row.estimated_cost,
             "previous_cost_source": row.cost_source,
             "repriced_by": "live_price_lookup",
+            "pricing_snapshot": estimate.pricing_snapshot,
         },
     )
     if row.flow_execution_id is not None:
@@ -251,6 +269,7 @@ def reprice_gateway_usage(
             "total_tokens": int(row.total_tokens or 0),
             "usage_details": usage_details,
             "pricing_override": pricing_override,
+            "observed_at": _pricing_observed_at(meta, row.timestamp),
         }
         estimate = estimate_ai_model_usage_cost_detailed(ai_model, **estimate_kwargs)
 
@@ -299,6 +318,7 @@ def reprice_gateway_usage(
                 "repriced_at": repriced_at,
                 "previous_estimated_cost": row.estimated_cost,
                 "previous_cost_source": row.cost_source,
+                "pricing_snapshot": estimate.pricing_snapshot,
             },
             commit=False,
         )

--- a/backend/preloop/sync/services/nats_worker.py
+++ b/backend/preloop/sync/services/nats_worker.py
@@ -214,6 +214,13 @@ class PreloopSyncNatsWorker:
             logger.error("Cannot start listening, NATS client not connected.")
             return
 
+        from preloop.services.reviewed_model_price_refresh import (
+            start_reviewed_price_refresh,
+        )
+
+        if getattr(self, "_price_refresher", None) is None:
+            self._price_refresher = start_reviewed_price_refresh()
+
         subjects_to_subscribe = self._subjects_to_subscribe()
 
         logger.info(
@@ -535,6 +542,9 @@ class PreloopSyncNatsWorker:
 
     async def stop(self):
         logger.info("Worker stop signal received.")
+        if getattr(self, "_price_refresher", None) is not None:
+            await self._price_refresher.stop()
+            self._price_refresher = None
         await self.begin_drain()
         for subject, sub in self.subs:
             try:

--- a/backend/tests/services/test_deepseek_pricing.py
+++ b/backend/tests/services/test_deepseek_pricing.py
@@ -1,0 +1,370 @@
+"""Native DeepSeek effective dates, time bands and billing-source precedence."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from preloop.models import models
+from preloop.services import ai_model_pricing, deepseek_pricing
+from preloop.services.model_pricing import estimate_ai_model_usage_cost_detailed
+
+
+def model(
+    identifier: str = "deepseek/deepseek-v4-pro",
+    provider: str = "deepseek",
+    endpoint: str | None = None,
+) -> models.AIModel:
+    return models.AIModel(
+        id="00000000-0000-0000-0000-000000000001",
+        provider_name=provider,
+        model_identifier=identifier,
+        api_endpoint=endpoint,
+    )
+
+
+def moment(value: str) -> datetime:
+    return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("instant", "band", "input_price"),
+    [
+        ("2026-09-11T00:59:59", "off_peak", 0.66),
+        ("2026-09-11T01:00:00", "peak", 1.32),
+        ("2026-09-11T03:59:59", "peak", 1.32),
+        ("2026-09-11T04:00:00", "off_peak", 0.66),
+        ("2026-09-11T05:59:59", "off_peak", 0.66),
+        ("2026-09-11T06:00:00", "peak", 1.32),
+        ("2026-09-11T09:59:59", "peak", 1.32),
+        ("2026-09-11T10:00:00", "off_peak", 0.66),
+        ("2026-09-12T02:00:00", "off_peak", 0.66),
+        ("2026-09-13T07:00:00", "off_peak", 0.66),
+        # The later weekday restriction is not backdated into August.
+        ("2026-08-22T02:00:00", "peak", 1.32),
+        # Pro continues at its own prices after the rescinded retirement.
+        ("2026-09-14T06:00:00", "peak", 1.32),
+    ],
+)
+def test_native_pro_time_bands(instant: str, band: str, input_price: float) -> None:
+    tariff = deepseek_pricing.native_tariff(model(), observed_at=moment(instant))
+    assert tariff is not None
+    assert tariff.band == band
+    assert tariff.input_per_1m == input_price
+
+
+@pytest.mark.parametrize(
+    ("instant", "price", "canonical"),
+    [
+        ("2026-08-16T15:59:59", None, None),
+        ("2026-08-16T16:00:00", 0.22, "deepseek-v4-flash"),
+        ("2026-09-10T03:59:59", 0.44, "deepseek-v4-flash"),
+        ("2026-09-10T04:00:00", 0.15, "deepseek-flash"),
+    ],
+)
+def test_flash_effective_instants(
+    instant: str, price: float | None, canonical: str | None
+) -> None:
+    tariff = deepseek_pricing.native_tariff(
+        model("deepseek-v4-flash"), observed_at=moment(instant)
+    )
+    if price is None:
+        assert tariff is None
+    else:
+        assert tariff is not None
+        assert tariff.input_per_1m == price
+        assert tariff.model == canonical
+
+
+@pytest.mark.parametrize(
+    ("provider", "endpoint", "identifier", "native"),
+    [
+        ("deepseek", None, "deepseek/deepseek-v4-pro", True),
+        ("openai-compatible", "https://api.deepseek.com/v1", "deepseek-v4-pro", True),
+        ("deepseek", "https://openrouter.ai/api/v1", "deepseek-v4-pro", False),
+        ("openrouter", None, "deepseek/deepseek-v4-pro", False),
+        ("deepseek", "https://api.deepseek.com.example.com", "deepseek-v4-pro", False),
+        ("deepseek", "https://example.com/api.deepseek.com", "deepseek-v4-pro", False),
+        ("bedrock", None, "deepseek-v4-pro", False),
+        ("deepseek", None, "deepseek-v4-flash-0731", False),
+        ("deepseek", None, "deepseek-flash", True),
+        ("deepseek", None, "deepseek-v4-flash-vision-exp", True),
+    ],
+)
+def test_serving_endpoint_and_exact_alias(
+    provider: str, endpoint: str | None, identifier: str, native: bool
+) -> None:
+    tariff = deepseek_pricing.native_tariff(
+        model(identifier, provider, endpoint),
+        observed_at=moment("2026-09-12T06:00:00"),
+    )
+    assert (tariff is not None) == native
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        {"prompt_cache_hit_tokens": 900_000},
+        {"prompt_tokens_details": {"cached_tokens": 900_000}},
+        {"cache_read_input_tokens": 900_000},
+    ],
+)
+def test_estimator_uses_cache_split_and_persists_tariff(usage: dict) -> None:
+    estimate = estimate_ai_model_usage_cost_detailed(
+        model(),
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+        total_tokens=2_000_000,
+        usage_details=usage,
+        observed_at=moment("2026-09-12T06:00:00"),
+    )
+    assert estimate.cost == pytest.approx(0.9 * 0.022 + 0.1 * 0.66 + 1.98)
+    assert estimate.source == "catalog"
+    assert estimate.pricing_snapshot["rate_band"] == "off_peak"
+    assert estimate.pricing_snapshot["estimate_limitations"]
+
+
+def test_explicit_zero_cached_count_wins_over_fallback() -> None:
+    tariff = deepseek_pricing.native_tariff(
+        model(), observed_at=moment("2026-09-12T06:00:00")
+    )
+    assert (
+        tariff.estimate(
+            prompt_tokens=1_000_000,
+            completion_tokens=0,
+            usage_details={
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "prompt_cache_hit_tokens": 1_000_000,
+            },
+        )
+        == 0.66
+    )
+
+
+@pytest.mark.parametrize("kind", ["override", "model_config", "provider"])
+def test_explicit_prices_and_actual_cost_precede_tariff(kind: str) -> None:
+    ai_model = model()
+    configured = {"input_price_per_1k": 0.001}
+    if kind == "model_config":
+        ai_model.meta_data = {"pricing": configured}
+    estimate = estimate_ai_model_usage_cost_detailed(
+        ai_model,
+        prompt_tokens=1_000_000,
+        completion_tokens=0,
+        total_tokens=1_000_000,
+        usage_details={"cost": 5.0},
+        pricing_override=configured if kind == "override" else None,
+        observed_at=moment("2026-09-12T06:00:00"),
+    )
+    assert estimate.cost == (5.0 if kind == "provider" else 1.0)
+    assert estimate.source == kind
+    assert estimate.pricing_snapshot is None
+
+
+def test_price_readback_matches_selected_tariff_and_exposes_provenance() -> None:
+    ai_model = model()
+    tariff = deepseek_pricing.native_tariff(
+        ai_model, observed_at=moment("2026-09-12T06:00:00")
+    )
+    with patch.object(deepseek_pricing, "native_tariff", return_value=tariff):
+        response = ai_model_pricing._pricing_response(ai_model, None)
+    assert response.price.input_per_1m == 0.66
+    assert response.price.output_per_1m == 1.98
+    assert response.price.cached_input_per_1m == 0.022
+    assert response.catalog_provenance["rate_band"] == "off_peak"
+    assert response.catalog_provenance["estimate_limitations"]
+    assert response.effective_from == deepseek_pricing.SEPTEMBER_START
+
+
+def test_reviewed_policy_activates_at_effective_instant_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm
+
+    entry = {
+        "preloop_price_policy": {
+            "kind": "deepseek_utc_bands",
+            "effective_from": "2026-09-14T06:00:00+00:00",
+            "peak": {
+                "input_per_1m": 2.0,
+                "output_per_1m": 6.0,
+                "cached_input_per_1m": 0.06,
+            },
+            "off_peak": {
+                "input_per_1m": 1.0,
+                "output_per_1m": 3.0,
+                "cached_input_per_1m": 0.03,
+            },
+            "peak_hours_utc": [[1, 4], [6, 10]],
+            "peak_weekdays": [0, 1, 2, 3, 4],
+            "public_holidays": "unspecified",
+        },
+        "preloop_price_provenance": {
+            "revision": "reviewed-example",
+            "verified_at": "2026-09-12T00:00:00+00:00",
+            "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
+        },
+    }
+    monkeypatch.setitem(litellm.model_cost, "deepseek/deepseek-v4-pro", entry)
+    before = deepseek_pricing.native_tariff(
+        model(), observed_at=moment("2026-09-14T05:59:59")
+    )
+    after = deepseek_pricing.native_tariff(
+        model(), observed_at=moment("2026-09-14T06:00:00")
+    )
+    assert before.input_per_1m == 0.66
+    assert after.input_per_1m == 2.0
+    assert after.metadata()["policy_version"] == "reviewed-example"
+    assert (
+        deepseek_pricing.native_tariff(
+            model(endpoint="https://openrouter.ai/api/v1"),
+            observed_at=moment("2026-09-14T06:00:00"),
+        )
+        is None
+    )
+
+
+def test_gateway_records_request_start_tariff_across_stream_boundary(
+    db_session, test_user
+) -> None:
+    from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+    from preloop.models.crud import crud_ai_model
+    from preloop.services.openai_gateway import OpenAIGatewayService
+
+    ai_model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Native tariff test",
+            "provider_name": "deepseek",
+            "model_identifier": "deepseek-v4-pro",
+            "api_key": "test-provider-key",
+        },
+        account_id=test_user.account_id,
+    )
+    service = OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="test", user=test_user)
+    )
+    usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+    with patch("preloop.services.openai_gateway.datetime") as clock:
+        clock.now.return_value = moment("2026-09-11T04:00:01")
+        service._record_gateway_request_inner(
+            endpoint="/openai/v1/chat/completions",
+            method="POST",
+            status_code=200,
+            duration=2.0,
+            ai_model=ai_model,
+            requested_model="deepseek-v4-pro",
+            response_payload={"usage": usage},
+            upstream_response={"usage": usage},
+            endpoint_kind="chat.completions",
+        )
+    row = db_session.query(models.ApiUsage).filter_by(ai_model_id=ai_model.id).one()
+    assert row.estimated_cost == 1.32
+    snapshot = row.meta_data["pricing_snapshot"]
+    assert snapshot["rate_band"] == "peak"
+    assert snapshot["observed_at"] == "2026-09-11T03:59:59+00:00"
+    assert snapshot["timestamp_basis"] == "request_start_estimated_from_duration"
+
+
+@pytest.mark.parametrize("feed_alias", ["deepseek-flash", "deepseek-v4-flash"])
+def test_reviewed_future_version_preserves_inflight_previous_tariff(
+    monkeypatch: pytest.MonkeyPatch,
+    feed_alias: str,
+) -> None:
+    import litellm
+
+    def policy(effective_from: str, price: float) -> dict:
+        return {
+            "kind": "deepseek_utc_bands",
+            "effective_from": effective_from,
+            "peak": {
+                "input_per_1m": price,
+                "output_per_1m": price,
+                "cached_input_per_1m": price,
+            },
+            "off_peak": {
+                "input_per_1m": price / 2,
+                "output_per_1m": price / 2,
+                "cached_input_per_1m": price / 2,
+            },
+            "peak_hours_utc": [[1, 4], [6, 10]],
+            "peak_weekdays": [0, 1, 2, 3, 4],
+            "public_holidays": "unspecified",
+        }
+
+    monkeypatch.setitem(
+        litellm.model_cost,
+        f"deepseek/{feed_alias}",
+        {
+            "preloop_price_policy": policy("2026-09-14T06:00:00+00:00", 4),
+            "preloop_price_provenance": {"revision": "v2"},
+            "preloop_price_policy_history": [
+                {
+                    "policy": policy("2026-09-11T00:00:00+00:00", 2),
+                    "provenance": {"revision": "v1"},
+                }
+            ],
+        },
+    )
+    # A current canonical feed policy also prices retired native aliases.
+    earlier = deepseek_pricing.native_tariff(
+        model("deepseek-v4-flash"), observed_at=moment("2026-09-11T06:00:00")
+    )
+    newer = deepseek_pricing.native_tariff(
+        model("deepseek-flash"), observed_at=moment("2026-09-14T06:00:00")
+    )
+    assert earlier.input_per_1m == 2
+    assert earlier.metadata()["policy_version"] == "v1"
+    assert newer.input_per_1m == 4
+    assert newer.metadata()["policy_version"] == "v2"
+
+
+@pytest.mark.parametrize(
+    ("recorded_at", "snapshot"),
+    [
+        ("2026-09-11T03:59:59", None),
+        ("2026-09-11T04:00:01", {"observed_at": "2026-09-11T03:59:59+00:00"}),
+        ("2026-09-11T03:59:59", {"observed_at": "invalid"}),
+        ("2026-09-11T03:59:59", {"observed_at": "2026-09-11T04:00:01"}),
+    ],
+)
+def test_manual_reprice_uses_usage_timestamp_and_records_tariff(
+    db_session, test_user, recorded_at: str, snapshot: dict | None
+) -> None:
+    from preloop.models.crud import crud_ai_model, crud_api_usage
+    from preloop.services.usage_repricing import reprice_single_row
+
+    ai_model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Historical tariff test",
+            "provider_name": "deepseek",
+            "model_identifier": "deepseek-v4-pro",
+            "api_key": "test-provider-key",
+        },
+        account_id=test_user.account_id,
+    )
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=1.0,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        provider_name="deepseek",
+        model_alias="deepseek-v4-pro",
+        prompt_tokens=1_000_000,
+        completion_tokens=0,
+        total_tokens=1_000_000,
+        estimated_cost=None,
+        cost_source="unpriced",
+        meta_data={"pricing_snapshot": snapshot},
+    )
+    row.timestamp = moment(recorded_at)
+    db_session.flush()
+    assert reprice_single_row(db_session, api_usage_id=row.id)
+    db_session.refresh(row)
+    assert row.estimated_cost == 1.32
+    assert row.meta_data["pricing_snapshot"]["rate_band"] == "peak"

--- a/backend/tests/services/test_gateway_flow_totals.py
+++ b/backend/tests/services/test_gateway_flow_totals.py
@@ -1,0 +1,77 @@
+"""Flow totals must not inherit the limits of recent-activity lists."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import UUID
+
+from sqlalchemy.orm import Query, Session
+
+from preloop.models import models
+from preloop.models.crud import crud_api_usage
+from preloop.services.model_gateway_usage import ModelGatewayUsageService
+from preloop.services.tool_usage_stats import ToolUsageStatsService
+
+
+def test_account_flow_totals_include_groups_beyond_top_twenty() -> None:
+    """The account summary retains quiet flows, with the same account/window scope."""
+    account = models.Account(id=UUID(int=1), meta_data={})
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    end = datetime(2026, 2, 1, tzinfo=UTC)
+    # Synthetic grouped database results: a quiet, expensive flow sorts last.
+    rows = [
+        SimpleNamespace(
+            flow_id=UUID(int=index + 2),
+            flow_name=f"Flow {index}",
+            request_count=21 - index,
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            estimated_cost=40.0 if index == 20 else 1.0,
+        )
+        for index in range(21)
+    ]
+    totals = {
+        "request_count": 231,
+        "success_count": 231,
+        "error_count": 0,
+        "prompt_tokens": 210,
+        "completion_tokens": 105,
+        "total_tokens": 315,
+        "estimated_cost": 60.0,
+    }
+    queries: list[Query] = []
+
+    def grouped_results(query: Query) -> list[SimpleNamespace]:
+        queries.append(query)
+        # Respect the actual SQL query's LIMIT without opening a connection.
+        limit = query._limit_clause
+        return rows if limit is None else rows[: limit.value]
+
+    with (
+        Session() as db,
+        patch.object(Query, "all", grouped_results),
+        patch.object(crud_api_usage, "get_gateway_usage_summary", return_value=totals),
+        patch.object(crud_api_usage, "get_gateway_usage_by_model", return_value=[]),
+        patch.object(crud_api_usage, "get_gateway_usage_by_session", return_value=[]),
+        patch.object(crud_api_usage, "get_gateway_usage_timeseries", return_value=[]),
+        patch.object(
+            ToolUsageStatsService, "get_account_usage_by_tool", return_value=[]
+        ),
+    ):
+        summary = ModelGatewayUsageService(db).get_account_summary(
+            account=account,
+            start_date=start,
+            end_date=end,
+            runtime_principal_id="principal-example",
+        )
+
+    assert len(summary.usage_by_flow) == 21
+    assert summary.usage_by_flow[-1].estimated_cost == 40.0
+    assert sum(row.estimated_cost for row in summary.usage_by_flow) == 60.0
+    assert len(queries) == 1
+    parameters = queries[0].statement.compile().params.values()
+    assert str(account.id) in parameters
+    assert start in parameters
+    assert end in parameters
+    assert "principal-example" in parameters

--- a/backend/tests/services/test_reviewed_model_price_refresh.py
+++ b/backend/tests/services/test_reviewed_model_price_refresh.py
@@ -1,0 +1,445 @@
+"""Reviewed feeds must fail without partially changing current estimates."""
+
+import asyncio
+import copy
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import litellm
+import pytest
+
+from preloop.services.reviewed_model_price_refresh import (
+    ReviewedPriceRefresher,
+    start_reviewed_price_refresh,
+    validate_feed,
+)
+
+
+@pytest.fixture
+def payload() -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "schema_version": 1,
+        "currency": "USD",
+        "revision": "review-1",
+        "published_at": (now - timedelta(minutes=1)).isoformat(),
+        "expires_at": (now + timedelta(days=7)).isoformat(),
+        "models": {
+            "example/model": {
+                "policy": "flat_per_token",
+                "source_url": "https://example.com/pricing",
+                "verified_at": (now - timedelta(minutes=2)).isoformat(),
+                "effective_from": (now - timedelta(days=1)).isoformat(),
+                "prices": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000002,
+                },
+            }
+        },
+    }
+
+
+@pytest.fixture
+def refresher(monkeypatch: pytest.MonkeyPatch) -> ReviewedPriceRefresher:
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            "example/model": {
+                "litellm_provider": "openai",
+                "input_cost_per_token": 0.000003,
+                "output_cost_per_token": 0.000004,
+                "cache_read_input_token_cost": 0.000001,
+            },
+            "untouched": {"input_cost_per_token": 7},
+        },
+    )
+    return ReviewedPriceRefresher(
+        url="https://example.com/feed.json",
+        allowed_models=["example/model"],
+        interval_seconds=60,
+    )
+
+
+def test_applies_complete_snapshot_without_mutating_previous_map(
+    refresher: ReviewedPriceRefresher, payload: dict
+) -> None:
+    previous = litellm.model_cost
+    assert refresher.apply(payload) == 1
+    assert previous["example/model"]["input_cost_per_token"] == 0.000003
+    assert litellm.model_cost["example/model"]["input_cost_per_token"] == 0.000001
+    assert "cache_read_input_token_cost" not in litellm.model_cost["example/model"]
+    assert litellm.model_cost["untouched"] == previous["untouched"]
+    assert (
+        litellm.model_cost["example/model"]["preloop_price_provenance"]["revision"]
+        == "review-1"
+    )
+    assert refresher.apply(payload) == 0
+
+
+@pytest.mark.parametrize(
+    "price", [-1, -(10**400), 10**400, float("nan"), float("inf"), True, "0.2"]
+)
+def test_bad_price_rejected_before_any_mutation(
+    refresher: ReviewedPriceRefresher, payload: dict, price: object
+) -> None:
+    previous = litellm.model_cost
+    payload["models"]["example/model"]["prices"]["input_cost_per_token"] = price
+    with pytest.raises(ValueError):
+        refresher.apply(payload)
+    assert litellm.model_cost is previous
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("policy", "time_of_day"),
+        ("source_url", "http://example.com/pricing"),
+        ("verified_at", "2000-01-01T00:00:00Z"),
+        ("effective_from", "2099-01-01T00:00:00Z"),
+        ("verified_at", "2026-01-01T00:00:00"),
+    ],
+)
+def test_invalid_evidence_rejected(payload: dict, field: str, value: str) -> None:
+    payload["models"]["example/model"][field] = value
+    with pytest.raises(ValueError):
+        validate_feed(payload)
+
+
+def test_expired_feed_rejected(payload: dict) -> None:
+    payload["expires_at"] = "2000-01-01T00:00:00Z"
+    with pytest.raises(ValueError):
+        validate_feed(payload)
+
+
+def test_model_scope_and_unsupported_existing_tiers_fail_atomically(
+    refresher: ReviewedPriceRefresher, payload: dict
+) -> None:
+    previous = litellm.model_cost
+    payload["models"]["unknown"] = copy.deepcopy(payload["models"]["example/model"])
+    with pytest.raises(ValueError, match="allowlist"):
+        refresher.apply(payload)
+    assert litellm.model_cost is previous
+    refresher.allowed_models = frozenset(payload["models"])
+    with pytest.raises(ValueError, match="existing catalog"):
+        refresher.apply(payload)
+    assert litellm.model_cost is previous
+    del payload["models"]["unknown"]
+    previous["example/model"]["input_cost_per_token_above_200k_tokens"] = 0.001
+    with pytest.raises(ValueError, match="dedicated support"):
+        refresher.apply(payload)
+    assert litellm.model_cost is previous
+
+
+def test_same_timestamp_cannot_silently_mutate_revision(
+    refresher: ReviewedPriceRefresher, payload: dict
+) -> None:
+    refresher.apply(payload)
+    previous = litellm.model_cost
+    payload["models"]["example/model"]["prices"]["input_cost_per_token"] = 0.005
+    with pytest.raises(ValueError, match="older or mutated"):
+        refresher.apply(payload)
+    assert litellm.model_cost is previous
+
+
+@pytest.mark.asyncio
+async def test_download_uses_feed_and_rejects_redirects(
+    refresher: ReviewedPriceRefresher, payload: dict
+) -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    async with httpx.AsyncClient(transport=transport) as client:
+        assert await refresher.refresh(client) == 1
+    previous = litellm.model_cost
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(302, headers={"location": "https://other.test"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await refresher.refresh(client)
+    assert litellm.model_cost is previous
+
+
+@pytest.mark.asyncio
+async def test_poll_failure_retains_prices_and_stop_cancels_task(
+    refresher: ReviewedPriceRefresher, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    previous = litellm.model_cost
+    poll = AsyncMock(side_effect=ValueError("invalid feed"))
+    monkeypatch.setattr(refresher, "refresh", poll)
+    refresher.start()
+    task = refresher.task
+    refresher.start()
+    assert refresher.task is task
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if poll.await_count:
+            break
+    await refresher.stop()
+    assert poll.await_count == 1
+    assert task is not None and task.cancelled()
+    assert refresher.task is None
+    assert litellm.model_cost is previous
+
+
+def test_disabled_setting_starts_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from preloop.config import settings
+
+    monkeypatch.setattr(settings, "model_price_refresh_url", "")
+    assert start_reviewed_price_refresh() is None
+
+
+def test_builder_exports_catalog_prices_and_requires_evidence(payload: dict) -> None:
+    script = (
+        Path(__file__).resolve().parents[3] / "scripts/build_reviewed_model_prices.py"
+    )
+    spec = importlib.util.spec_from_file_location("price_feed_builder", script)
+    assert spec is not None and spec.loader is not None
+    builder = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(builder)
+    catalog = {"example/model": payload["models"]["example/model"].pop("prices")}
+    built = builder.build_feed(catalog, payload)
+    assert built["models"]["example/model"]["prices"] == catalog["example/model"]
+    assert validate_feed(json.loads(json.dumps(built)))
+    payload["models"]["example/model"]["prices"] = catalog["example/model"]
+    with pytest.raises(ValueError, match="must come from"):
+        builder.build_feed(catalog, payload)
+
+
+def test_warmed_litellm_prices_change_and_same_feed_repairs_mutation(
+    refresher: ReviewedPriceRefresher, payload: dict
+) -> None:
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    litellm.model_cost["example/model"].update({"mode": "chat", "max_tokens": 4096})
+    _invalidate_model_cost_lowercase_map()
+    before = litellm.cost_per_token(
+        model="example/model",
+        prompt_tokens=1000,
+        completion_tokens=1000,
+        custom_llm_provider="openai",
+    )
+    refresher.apply(payload)
+    after = litellm.cost_per_token(
+        model="example/model",
+        prompt_tokens=1000,
+        completion_tokens=1000,
+        custom_llm_provider="openai",
+    )
+    assert before == pytest.approx((0.003, 0.004))
+    assert after == pytest.approx((0.001, 0.002))
+    litellm.model_cost["example/model"]["input_cost_per_token"] = 0.4
+    litellm.model_cost["newly-discovered"] = {"input_cost_per_token": 0.5}
+    assert refresher.apply(payload) == 1
+    assert litellm.model_cost["example/model"]["input_cost_per_token"] == 0.000001
+    assert "newly-discovered" in litellm.model_cost
+
+
+def test_live_lookup_cannot_overwrite_reviewed_entry(
+    refresher: ReviewedPriceRefresher, payload: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from preloop.services import model_price_catalog
+
+    refresher.apply(payload)
+    model_price_catalog.reset_lookup_state_for_tests()
+    monkeypatch.setattr(
+        model_price_catalog,
+        "_fetch_remote_price_map",
+        lambda: {"example/model": {"input_cost_per_token": 0.8}},
+    )
+    assert (
+        model_price_catalog.lookup_model_price_now(["example/model"]) == "example/model"
+    )
+    assert litellm.model_cost["example/model"]["input_cost_per_token"] == 0.000001
+
+
+@pytest.fixture
+def native_payload(refresher: ReviewedPriceRefresher, payload: dict) -> dict:
+    entry = payload["models"]["example/model"]
+    entry.pop("prices")
+    entry["policy"] = "deepseek_utc_bands"
+    entry["price_policy"] = {
+        "kind": "deepseek_utc_bands",
+        "effective_from": entry["effective_from"],
+        "peak": {
+            "input_per_1m": 0.3,
+            "output_per_1m": 1.2,
+            "cached_input_per_1m": 0.006,
+        },
+        "off_peak": {
+            "input_per_1m": 0.15,
+            "output_per_1m": 0.6,
+            "cached_input_per_1m": 0.003,
+        },
+        "peak_hours_utc": [[1, 4], [6, 10]],
+        "peak_weekdays": [0, 1, 2, 3, 4],
+        "public_holidays": "unspecified",
+    }
+    litellm.model_cost["example/model"]["litellm_provider"] = "deepseek"
+    litellm.model_cost["deepseek/deepseek-flash"] = litellm.model_cost.pop(
+        "example/model"
+    )
+    payload["models"]["deepseek/deepseek-flash"] = payload["models"].pop(
+        "example/model"
+    )
+    refresher.allowed_models = frozenset(["deepseek/deepseek-flash"])
+    return payload
+
+
+def test_native_policy_updates_without_flattening(
+    refresher: ReviewedPriceRefresher, native_payload: dict
+) -> None:
+    assert refresher.apply(native_payload) == 1
+    updated = litellm.model_cost["deepseek/deepseek-flash"]
+    assert updated["input_cost_per_token"] == 0.000003
+    assert updated["preloop_price_policy"]["peak"]["input_per_1m"] == 0.3
+
+
+def test_initial_catalog_policy_without_runtime_provenance_can_be_verified(
+    refresher: ReviewedPriceRefresher, native_payload: dict
+) -> None:
+    key = "deepseek/deepseek-flash"
+    litellm.model_cost[key]["preloop_price_policy"] = copy.deepcopy(
+        native_payload["models"][key]["price_policy"]
+    )
+    assert refresher.apply(native_payload) == 1
+    assert litellm.model_cost[key]["preloop_price_provenance"]["revision"] == "review-1"
+
+
+def test_future_revision_preserves_previous_tariff_and_restart_history(
+    refresher: ReviewedPriceRefresher, native_payload: dict
+) -> None:
+    key = "deepseek/deepseek-flash"
+    refresher.apply(native_payload)
+    previous = copy.deepcopy(litellm.model_cost[key])
+    revised = copy.deepcopy(native_payload)
+    now = datetime.now(timezone.utc)
+    revised["published_at"] = now.isoformat()
+    revised["revision"] = "review-2"
+    entry = revised["models"][key]
+    entry["effective_from"] = (now + timedelta(days=1)).isoformat()
+    entry["price_policy"]["effective_from"] = entry["effective_from"]
+    entry["price_policy"]["peak"]["input_per_1m"] = 0.5
+    entry["price_policy_history"] = [
+        {
+            "policy": previous["preloop_price_policy"],
+            "provenance": previous["preloop_price_provenance"],
+        }
+    ]
+    assert refresher.apply(revised) == 1
+    assert (
+        litellm.model_cost[key]["preloop_price_policy_history"]
+        == entry["price_policy_history"]
+    )
+    # A fresh process can reconstruct the same history from the published feed.
+    litellm.model_cost[key] = {"litellm_provider": "deepseek"}
+    restarted = ReviewedPriceRefresher(
+        url=refresher.url, allowed_models=[key], interval_seconds=60
+    )
+    assert restarted.apply(revised) == 1
+    assert (
+        litellm.model_cost[key]["preloop_price_policy_history"]
+        == entry["price_policy_history"]
+    )
+
+
+def test_equivalent_timezone_cannot_mutate_reviewed_effective_instant(
+    refresher: ReviewedPriceRefresher, native_payload: dict
+) -> None:
+    refresher.apply(native_payload)
+    revised = copy.deepcopy(native_payload)
+    revised["published_at"] = datetime.now(timezone.utc).isoformat()
+    entry = revised["models"]["deepseek/deepseek-flash"]
+    equivalent = (
+        datetime.fromisoformat(entry["effective_from"])
+        .astimezone(timezone(timedelta(hours=2)))
+        .isoformat()
+    )
+    entry["effective_from"] = equivalent
+    entry["price_policy"]["effective_from"] = equivalent
+    entry["price_policy"]["peak"]["input_per_1m"] = 9.0
+    with pytest.raises(ValueError, match="Cannot mutate"):
+        refresher.apply(revised)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("peak_hours_utc", [[2, 4], [6, 10]]),
+        ("peak_weekdays", [0, 1, 2, 3, 4, 5]),
+        ("effective_from", "2026-09-01T00:00:00Z"),
+    ],
+)
+def test_unsupported_dynamic_shapes_are_not_accepted(
+    native_payload: dict, field: str, value: object
+) -> None:
+    native_payload["models"]["deepseek/deepseek-flash"]["price_policy"][field] = value
+    with pytest.raises(ValueError):
+        validate_feed(native_payload)
+
+
+def test_native_flat_and_marketplace_dynamic_policies_rejected(
+    refresher: ReviewedPriceRefresher, native_payload: dict, payload: dict
+) -> None:
+    key = "deepseek/deepseek-flash"
+    native = copy.deepcopy(native_payload)
+    native["models"][key] = {
+        **native["models"][key],
+        "policy": "flat_per_token",
+        "prices": {"input_cost_per_token": 0.1, "output_cost_per_token": 0.2},
+    }
+    native["models"][key].pop("price_policy")
+    with pytest.raises(ValueError, match="native policy"):
+        refresher.apply(native)
+    litellm.model_cost[key]["litellm_provider"] = "openrouter"
+    with pytest.raises(ValueError, match="direct model"):
+        refresher.apply(native_payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["api", "gateway", "all"])
+async def test_actual_app_lifespan_owns_refresh_task(
+    role: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from fastapi import FastAPI
+    from preloop.api import app as app_module
+    from preloop.services import reviewed_model_price_refresh as service
+
+    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("INIT_DB", "false")
+    monkeypatch.setenv("INIT_TEST_DATA", "false")
+    monkeypatch.setenv("PRELOOP_SERVICE_ROLE", role)
+    refresher = MagicMock(stop=AsyncMock())
+    start = MagicMock(return_value=refresher)
+    monkeypatch.setattr(service, "start_reviewed_price_refresh", start)
+    async with app_module.lifespan(FastAPI()):
+        start.assert_called_once()
+        refresher.stop.assert_not_awaited()
+    refresher.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_actual_worker_starts_once_and_stops_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from preloop.services import reviewed_model_price_refresh as service
+    from preloop.sync.services.nats_worker import PreloopSyncNatsWorker
+
+    worker = PreloopSyncNatsWorker(nats_url="nats://example.com", queue_name="test")
+    worker.nc = MagicMock(is_connected=True, is_closed=True)
+    monkeypatch.setattr(worker, "_subjects_to_subscribe", lambda: [])
+    monkeypatch.setattr(worker, "_remove_conflicting_wildcard_consumer", AsyncMock())
+    monkeypatch.setattr(worker, "begin_drain", AsyncMock())
+    refresher = MagicMock(stop=AsyncMock())
+    start = MagicMock(return_value=refresher)
+    monkeypatch.setattr(service, "start_reviewed_price_refresh", start)
+    with pytest.raises(RuntimeError, match="no subjects"):
+        await worker.start_listening()
+    with pytest.raises(RuntimeError, match="no subjects"):
+        await worker.start_listening()
+    start.assert_called_once()
+    await worker.stop()
+    refresher.stop.assert_awaited_once()

--- a/backend/tests/services/test_reviewed_model_price_refresh.py
+++ b/backend/tests/services/test_reviewed_model_price_refresh.py
@@ -13,6 +13,7 @@ import litellm
 import pytest
 
 from preloop.services.reviewed_model_price_refresh import (
+    PriceRefreshCompatibilityError,
     ReviewedPriceRefresher,
     start_reviewed_price_refresh,
     validate_feed,
@@ -190,6 +191,147 @@ def test_disabled_setting_starts_nothing(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(settings, "model_price_refresh_url", "")
     assert start_reviewed_price_refresh() is None
+
+
+@pytest.mark.parametrize(
+    ("url", "allowed_models"),
+    [
+        ("http://example.com/feed?token=synthetic-secret", ["example/model"]),
+        ("https://user:synthetic-secret@example.com/feed", ["example/model"]),
+        ("https://example.com/feed?token=synthetic-secret", []),
+    ],
+)
+def test_invalid_startup_configuration_disables_refresh_without_logging_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    url: str,
+    allowed_models: list[str],
+) -> None:
+    from preloop.config import settings
+
+    monkeypatch.setattr(settings, "model_price_refresh_url", url)
+    monkeypatch.setattr(settings, "model_price_refresh_allowed_models", allowed_models)
+    start = MagicMock()
+    monkeypatch.setattr(ReviewedPriceRefresher, "start", start)
+    assert start_reviewed_price_refresh() is None
+    start.assert_not_called()
+    assert "disabled" in caplog.text
+    assert "synthetic-secret" not in caplog.text
+    assert "example.com" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "compatibility",
+    [
+        "missing",
+        "not_callable",
+        "raises",
+        "raises_after_swap",
+        "rollback_clearer_raises",
+    ],
+)
+def test_incompatible_litellm_keeps_warmed_last_good_prices_and_revision(
+    refresher: ReviewedPriceRefresher,
+    payload: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    compatibility: str,
+) -> None:
+    from litellm import utils
+
+    original_invalidate = utils._invalidate_model_cost_lowercase_map
+    litellm.model_cost["example/model"].update({"mode": "chat", "max_tokens": 4096})
+    refresher.apply(payload)
+    previous = litellm.model_cost
+    previous_digest, previous_applied = refresher.digest, refresher.applied_at
+
+    def price() -> tuple[float, float]:
+        return litellm.cost_per_token(
+            model="example/model",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+            custom_llm_provider="openai",
+        )
+
+    assert price() == pytest.approx((0.001, 0.002))
+    revised = copy.deepcopy(payload)
+    revised["published_at"] = datetime.now(timezone.utc).isoformat()
+    revised["revision"] = "next-review"
+    revised["models"]["example/model"]["prices"]["input_cost_per_token"] = 0.000005
+    calls = 0
+
+    def broken_invalidate() -> None:
+        nonlocal calls
+        calls += 1
+        after_swap = compatibility in {"raises_after_swap", "rollback_clearer_raises"}
+        if after_swap and calls == 1:
+            original_invalidate()
+            return
+        if after_swap:
+            original_invalidate()
+            price()  # Warm the candidate before its invalidation failure.
+        raise RuntimeError("synthetic-private-library-detail")
+
+    if compatibility == "rollback_clearer_raises":
+
+        def broken_clearer() -> None:
+            raise RuntimeError("synthetic-private-cache-detail")
+
+        monkeypatch.setattr(
+            utils.get_model_info, "cache_clear", broken_clearer, raising=False
+        )
+
+    if compatibility == "missing":
+        monkeypatch.delattr(utils, "_invalidate_model_cost_lowercase_map")
+    elif compatibility == "not_callable":
+        monkeypatch.setattr(utils, "_invalidate_model_cost_lowercase_map", None)
+    else:
+        monkeypatch.setattr(
+            utils, "_invalidate_model_cost_lowercase_map", broken_invalidate
+        )
+    with pytest.raises(PriceRefreshCompatibilityError, match="incompatible"):
+        refresher.apply(revised)
+    assert litellm.model_cost is previous
+    assert refresher.digest == previous_digest
+    assert refresher.applied_at == previous_applied
+    assert price() == pytest.approx((0.001, 0.002))
+    assert "synthetic-private" not in caplog.text
+    monkeypatch.setattr(
+        utils,
+        "_invalidate_model_cost_lowercase_map",
+        original_invalidate,
+        raising=False,
+    )
+    assert refresher.apply(revised) == 1
+    assert price() == pytest.approx((0.005, 0.002))
+
+
+@pytest.mark.asyncio
+async def test_poll_retries_compatibility_failure_without_logging_exception_details(
+    refresher: ReviewedPriceRefresher,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    poll = AsyncMock(
+        side_effect=[PriceRefreshCompatibilityError("synthetic-secret"), 0]
+    )
+    monkeypatch.setattr(refresher, "refresh", poll)
+    original_sleep = asyncio.sleep
+
+    async def bounded_sleep(seconds: float) -> None:
+        if poll.await_count == 2:
+            raise asyncio.CancelledError
+        await original_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", bounded_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await refresher.run()
+    assert poll.await_count == 2
+    assert "incompatible LiteLLM" in caplog.text
+    assert "retaining last good prices" in caplog.text
+    assert "synthetic-secret" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 def test_builder_exports_catalog_prices_and_requires_evidence(payload: dict) -> None:

--- a/docs/architecture/cost.md
+++ b/docs/architecture/cost.md
@@ -15,3 +15,17 @@ Cost analytics turns gateway telemetry into explainable spend and budget health.
 *   **Default AI Model Use:** Enterprise session-value analysis should call the account's default AI model through the Preloop Gateway, producing an auditable meta-usage record for the evaluation itself. The analysis should reference redacted session summaries, gateway events, tool calls, approvals, and final outcomes rather than unrestricted raw prompts.
 *   **Plugin Boundary:** Backend features beyond OSS summaries and budget-health tracking must live in Enterprise plugins under `./plugins/`, likely extending `plugins/billing/` for budget policy enforcement, pricing overrides, FinOps, credits, promotions, forecasting, exports, and value-review jobs. The shared frontend should gate those panels with feature flags.
 *   **Budget Actions:** Core enforcement should continue to block or warn before upstream dispatch. Enterprise plugins can add escalations, Slack/mobile notifications, approval requirements for expensive calls, and post-hoc anomaly workflows.
+
+## Reviewed price publication
+
+After an initial rollout and explicit configuration, each API, dedicated gateway,
+and worker polls the same trusted HTTPS price artifact. A reviewed publication
+updates supported flat token rates and native DeepSeek UTC peak/off-peak tariff
+revisions without deploying application code. Unknown policy structures require
+an estimator change, boundary tests, and a deployment. Refresh validates evidence,
+effective dates, model scope, and historical tariff continuity before replacing
+the current map; existing usage records, account overrides, and provider-reported
+costs are unchanged. On failure it retains last-known rates as potentially stale
+estimates and logs the failure. The disabled weekly factory review template
+produces an evidence-backed PR and generated feed, reporting providers it could
+not verify. See [configuration and publication](../guide/model-price-refresh.md).

--- a/docs/guide/model-price-refresh.md
+++ b/docs/guide/model-price-refresh.md
@@ -1,0 +1,150 @@
+# Model price refresh
+
+Preloop separates model discovery, price evidence, and current estimates. The
+model-discovery scheduler adds provider model identifiers; it does not refresh
+existing prices. The vendored catalog supplies default estimates. Missing models
+can trigger a live LiteLLM/OpenRouter lookup, but that path does not periodically
+update existing prices. Most providers' model-list endpoints do not return prices.
+
+## Reviewed prices without an application deployment
+
+The optional reviewed-feed service runs in each API, dedicated gateway, and worker
+process. After the initial code rollout and configuration, it fetches an
+operator-controlled HTTPS JSON artifact every six hours. Publishing a new reviewed
+artifact updates current estimates without restarting those processes.
+
+Configure the same values for all serving processes:
+
+```shell
+MODEL_PRICE_REFRESH_URL=https://example.com/reviewed_model_prices.json
+MODEL_PRICE_REFRESH_ALLOWED_MODELS='["example/model"]'
+MODEL_PRICE_REFRESH_INTERVAL_SECONDS=21600
+```
+
+An empty URL (the default) disables polling. The allowlist contains exact existing
+LiteLLM catalog keys, not provider or account IDs. Restrict write access to the
+publication branch/bucket: this URL is a pricing trust boundary. Redirects are not
+followed. An approved PR can publish the artifact through the organization's
+existing branch or static-artifact hosting; no extra application deployment is
+needed. This feature does not configure that hosting or activate a live schedule.
+
+Each feed must declare USD, a revision, publication and expiry timestamps, and
+per-model source URL, verification time, effective date, and either flat input/output rates per token (with optional cache rates) or
+a supported native DeepSeek UTC-band policy. Invalid, expired, future,
+out-of-scope, unknown-model, or unsupported-policy feeds leave the last good prices
+in place and log a refresh failure. Publication timestamps cannot move backwards
+within a process. Feed validity is at most 31 days and evidence must be verified
+within 14 days of publication. A process restart reloads the vendored baseline
+until its first successful poll; cross-process refresh is eventually consistent.
+
+The accepted batch replaces the process price-map reference once, after complete
+validation. Account overrides, provider-reported costs, and dedicated provider
+policies retain their existing precedence. The job never writes usage records or
+re-prices historical costs. Retained last-good rates remain estimates if a feed
+expires or becomes unreachable; operators should monitor the refresh failure log.
+Rollback uses a newly reviewed revision with a later publication timestamp.
+
+The supported native DeepSeek policy uses UTC peak hours 01:00-04:00 and
+06:00-10:00 Monday-Friday, separate peak/off-peak input/output/cache prices,
+and dated effective revisions. Rates within this known structure can refresh
+without deployment, including future-dated rates activated at request time.
+Unspecified public-holiday exemptions remain an explicit estimate limitation.
+Different time bands, holiday definitions, context tiers, or region rules require
+an adapter and boundary tests in a code rollout; they cannot be flattened into
+one feed price. Native DeepSeek keys reject flat-price feeds.
+
+Dynamic catalog entries store `preloop_price_policy` and
+`preloop_price_policy_history` (a list of `{policy, provenance}` records). The
+builder exports these as `price_policy` and `price_policy_history` under a manifest
+model with `policy: deepseek_utc_bands`. A policy contains `kind`, `effective_from`,
+`peak` and `off_peak` rate objects (`input_per_1m`, `output_per_1m`,
+`cached_input_per_1m`), `peak_hours_utc: [[1,4],[6,10]]`,
+`peak_weekdays: [0,1,2,3,4]`, and `public_holidays: unspecified`.
+Use an existing native key such as `deepseek/deepseek-v4-flash` in the allowlist.
+The dedicated estimator resolves the current Flash alias to that native policy.
+
+For example, this is the native policy shape in a catalog entry (illustrative
+dates and rates; verify official evidence before publication):
+
+```json
+{
+  "litellm_provider": "deepseek",
+  "preloop_price_policy": {
+    "kind": "deepseek_utc_bands",
+    "effective_from": "2026-09-12T00:00:00Z",
+    "peak": {"input_per_1m": 0.3, "output_per_1m": 1.2, "cached_input_per_1m": 0.006},
+    "off_peak": {"input_per_1m": 0.15, "output_per_1m": 0.6, "cached_input_per_1m": 0.003},
+    "peak_hours_utc": [[1, 4], [6, 10]],
+    "peak_weekdays": [0, 1, 2, 3, 4],
+    "public_holidays": "unspecified"
+  },
+  "preloop_price_policy_history": []
+}
+```
+
+Its manifest model entry uses the same `effective_from`, `source_url` pointing
+to the official provider publication, fresh `verified_at`, and
+`policy: "deepseek_utc_bands"`. The builder copies the policy and history from
+the catalog. On the next tariff change, append the previous `preloop_price_policy`
+and its `preloop_price_provenance` as a `{ "policy": ..., "provenance": ... }`
+history record before replacing the current policy. Feed provenance includes
+`revision`, `published_at`, `expires_at`, `source_url`, `verified_at`, and
+`effective_from`; preserve it unchanged for that historical record.
+
+Each new publication must carry prior reviewed policies and their provenance,
+so a restarted process can still price requests that began under an older tariff.
+Running processes also retain previous reviewed revisions (maximum 100 per key)
+and reject changing the rates at an already-reviewed effective instant. Read-back
+exposes selected tariff provenance; historical usage records remain unchanged.
+
+## Build and review the publication artifact
+
+Keep provider evidence in `docs/pricing/reviews/<date>.md`. A manifest selects only
+the catalog keys actually reviewed; it does not duplicate their rate numbers:
+
+```json
+{
+  "schema_version": 1,
+  "currency": "USD",
+  "revision": "example-review-1",
+  "published_at": "2026-09-12T12:00:00Z",
+  "expires_at": "2026-09-19T12:00:00Z",
+  "models": {
+    "example/model": {
+      "policy": "flat_per_token",
+      "source_url": "https://example.com/pricing",
+      "verified_at": "2026-09-12T11:00:00Z",
+      "effective_from": "2026-09-01T00:00:00Z"
+    }
+  }
+}
+```
+
+The example is illustrative, not a production price feed. After reviewing the
+catalog and recording actual provider evidence, generate the artifact:
+
+```shell
+PRELOOP_DISABLE_TELEMETRY=true PYTHONPATH=backend python scripts/build_reviewed_model_prices.py \
+  --catalog backend/preloop/services/data/model_prices.json \
+  --manifest docs/pricing/reviewed-price-manifest.json \
+  --output backend/preloop/services/data/reviewed_model_prices.json
+```
+
+The builder validates provenance and copies rates and supported policies directly
+from the reviewed catalog. Include catalog changes, manifest, generated artifact, source excerpts,
+and relevant tests in the PR. Renew evidence and feed expiry even when prices have
+not changed; do not relabel failed retrievals as fresh verification.
+
+The enterprise factory template `factory/loops/model-price-review.yaml` prepares a
+Monday 06:00 UTC audit and isolated PR publication. It is disabled and has explicit
+repository/model binding placeholders. Configure those bindings, inspect its
+verification profile, and review a manual run before enabling the schedule. It
+checks official provider pricing, uses public APIs where they expose prices,
+reports unsupported policies, and generates the artifact above. PR review/merge
+controls publishing; the agent has no permission to merge or deploy.
+
+The template's isolated pricing gate runs unit coverage without an account
+database. It explicitly excludes the two native gateway/repricing integration
+test functions requiring `db_session` and `test_user`; repository integration CI
+must still run those with its configured test database. This does not disable
+them in pytest or remove their coverage requirement.

--- a/docs/guide/model-price-refresh.md
+++ b/docs/guide/model-price-refresh.md
@@ -27,6 +27,9 @@ publication branch/bucket: this URL is a pricing trust boundary. Redirects are n
 followed. An approved PR can publish the artifact through the organization's
 existing branch or static-artifact hosting; no extra application deployment is
 needed. This feature does not configure that hosting or activate a live schedule.
+An invalid URL or an empty allowlist disables this optional refresh service and
+logs a sanitized warning; it does not stop API, gateway, or worker startup. The
+warning omits the configured URL and exception details, which may contain secrets.
 
 Each feed must declare USD, a revision, publication and expiry timestamps, and
 per-model source URL, verification time, effective date, and either flat input/output rates per token (with optional cache rates) or
@@ -43,6 +46,16 @@ policies retain their existing precedence. The job never writes usage records or
 re-prices historical costs. Retained last-good rates remain estimates if a feed
 expires or becomes unreachable; operators should monitor the refresh failure log.
 Rollback uses a newly reviewed revision with a later publication timestamp.
+
+Runtime replacement currently depends on LiteLLM's private
+`_invalidate_model_cost_lowercase_map` helper to clear cached model information.
+LiteLLM upgrades must pass the warmed-price refresh regression tests. If that
+helper is missing, not callable, or raises, refresh logs a compatibility warning
+and retains the previous price map and accepted revision. It does not fall back
+to changing the map without invalidating caches. A callable helper is checked
+before publication; if it fails after publication, the map is restored and the
+known model-info LRU caches are cleared. Polling continues so a compatibility
+repair can recover without losing the last accepted feed.
 
 The supported native DeepSeek policy uses UTC peak hours 01:00-04:00 and
 06:00-10:00 Monday-Friday, separate peak/off-peak input/output/cache prices,

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -293,6 +293,9 @@ export class InventoryCard extends LitElement {
    * answer, not a slow one.
    */
   @property({ type: Boolean }) usageLoading = false;
+  /** Whether the usage belongs to the range in the header. */
+  @property({ type: Boolean }) usageAvailable = true;
+  @property({ type: Boolean }) modelUsageAvailable = true;
   /**
    * Per-tab overrides for {@link usageLoading}. The tabs do not share one
    * usage request: Agents / Users / Tools read the account breakdown, Flows
@@ -985,14 +988,22 @@ export class InventoryCard extends LitElement {
    * of a number rather than the width of the column, so the cell does not
    * shimmer across half the table while it waits.
    */
-  private renderUsageCell(value: unknown, pending = this.usageLoading) {
+  private renderUsageCell(
+    value: unknown,
+    pending = this.usageLoading,
+    available = this.activeTab === 'models'
+      ? this.modelUsageAvailable
+      : this.usageAvailable
+  ) {
     if (pending) {
       return html`<sl-skeleton
         class="usage-skeleton"
         effect="none"
       ></sl-skeleton>`;
     }
-    return value;
+    return available
+      ? value
+      : html`<span title="Usage unavailable for this range">—</span>`;
   }
 
   private renderEmpty() {
@@ -1211,7 +1222,8 @@ export class InventoryCard extends LitElement {
                         >
                           ${this.renderUsageCell(
                             this.formatCompactNumber(row.failed),
-                            this.isUsageLoading('flows')
+                            this.isUsageLoading('flows'),
+                            true
                           )}
                         </td>
                         <!-- Tokens before cost, split in and out: the

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -170,6 +170,111 @@ describe('CostView', () => {
     expect(agentTable?.querySelector('th[scope="col"]')).to.exist;
   });
 
+  it('uses complete flow totals when the recent session breakdown is capped', async () => {
+    const flow = {
+      flow_id: 'flow-review',
+      flow_name: 'Review Flow',
+      request_count: 1000,
+      token_usage: {
+        prompt_tokens: 4000,
+        completion_tokens: 1000,
+        total_tokens: 5000,
+      },
+      estimated_cost: 42,
+    };
+    summaryPayload = {
+      ...summary,
+      usage_by_flow: [
+        flow,
+        {
+          ...flow,
+          flow_id: 'flow-older',
+          flow_name: 'Older Flow',
+          estimated_cost: 6,
+        },
+        { ...flow, flow_id: null, flow_name: null, estimated_cost: 8.5 },
+      ],
+      // The backend returns only the newest 250 session/model slices. The
+      // flow aggregate includes older requests and flows outside that page.
+      usage_by_session: [
+        ...Array.from({ length: 249 }, (_, index) => ({
+          ...summary.usage_by_session[0],
+          runtime_session_id: `flow-session-${index}`,
+          agent_id: null,
+          agent_name: null,
+          flow_id: flow.flow_id,
+          flow_name: flow.flow_name,
+          request_count: 1,
+          estimated_cost: 0.02,
+        })),
+        summary.usage_by_session[0],
+      ],
+    };
+    const element = await fixture<CostView>(html`<cost-view></cost-view>`);
+    await waitUntil(() => !element['loading']);
+    await element.updateComplete;
+    const groups = element['buildAgentGroups']();
+    const review = groups.find((row) => row.flowId === flow.flow_id)!;
+    expect(review.cost).to.equal(42);
+    expect(review.requests).to.equal(1000);
+    expect(review.totalTokens).to.equal(5000);
+    expect(review.tokenUsage).to.deep.equal(flow.token_usage);
+    expect(groups.find((row) => row.flowId === 'flow-older')?.cost).to.equal(6);
+    expect(groups.find((row) => row.agentId === 'agent-1')?.cost).to.equal(8.5);
+    expect(groups).to.have.length(3);
+    const flowLink = element.shadowRoot!.querySelector(
+      'a[href="/console/flows/flow-review"]'
+    )!;
+    expect(flowLink.closest('tr')!.textContent).to.contain('$42.00');
+  });
+
+  it('counts a flow request only once when its session also names an agent', async () => {
+    summaryPayload = {
+      ...summary,
+      usage_by_flow: [
+        {
+          flow_id: 'flow-review',
+          flow_name: 'Review Flow',
+          request_count: 5,
+          token_usage: summary.token_usage,
+          estimated_cost: 8.5,
+        },
+      ],
+      usage_by_session: [
+        {
+          ...summary.usage_by_session[0],
+          flow_id: 'flow-review',
+          flow_name: 'Review Flow',
+        },
+      ],
+    };
+    const element = await fixture<CostView>(html`<cost-view></cost-view>`);
+    await waitUntil(() => !element['loading']);
+    const groups = element['buildAgentGroups']();
+    expect(groups).to.have.length(1);
+    expect(groups[0].flowId).to.equal('flow-review');
+    expect(groups[0].cost).to.equal(8.5);
+  });
+
+  it('does not replace an empty flow aggregate with a partial session total', async () => {
+    summaryPayload = {
+      ...summary,
+      usage_by_flow: [],
+      usage_by_session: [
+        {
+          ...summary.usage_by_session[0],
+          agent_id: null,
+          agent_name: null,
+          flow_id: 'flow-review',
+          flow_name: 'Review Flow',
+        },
+      ],
+    };
+    const element = await fixture<CostView>(html`<cost-view></cost-view>`);
+    await waitUntil(() => !element['loading']);
+    expect(element['buildAgentGroups']()).to.have.length(0);
+  });
+
   it('puts the token split ahead of the money in the agent table', async () => {
     summaryPayload = {
       ...summary,

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -90,7 +90,7 @@ type SortColumn<T> = {
   value: (row: T) => number | string;
 };
 
-// Aggregated row for the Agents tab (grouped sessions by agent or flow).
+// Aggregated row for the Agents tab (agent sessions or full flow totals).
 type AgentGroupRow = {
   key: string;
   name: string;
@@ -1506,13 +1506,31 @@ export class CostView extends AuthedElement {
     );
   }
 
-  // Group sessions for the Agents tab. Agent-backed sessions collapse into an
-  // agent row (linked when agent_id is present), flow-backed sessions into a
-  // flow row, and everything else into a single "Other" row.
+  // Flow rows use complete period aggregates, not the bounded recent-session
+  // list. Flow-scoped requests belong to the flow in this mixed table, even
+  // when their session also names an agent, so their cost is counted once.
+  // Non-flow sessions retain their agent/Other grouping.
   private buildAgentGroups(): AgentGroupRow[] {
     const sessions = this.summary?.usage_by_session || [];
     const groups = new Map<string, AgentGroupRow>();
+    for (const flow of this.summary?.usage_by_flow || []) {
+      // The null-flow aggregate includes non-flow agents: it is not a flow
+      // row and must not be added again beside their session-based groups.
+      if (!flow.flow_id) continue;
+      const key = `flow:${flow.flow_id}`;
+      groups.set(key, {
+        key,
+        name: flow.flow_name || flow.flow_id,
+        agentId: null,
+        flowId: flow.flow_id,
+        requests: flow.request_count || 0,
+        totalTokens: flow.token_usage?.total_tokens || 0,
+        tokenUsage: flow.token_usage || null,
+        cost: flow.estimated_cost || 0,
+      });
+    }
     for (const session of sessions) {
+      if (session.flow_id) continue;
       let key: string;
       let name: string;
       let agentId: string | null = null;

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -78,10 +78,7 @@ import { parseUTCDate } from '../../utils/date';
 import { formatRelativeTime } from '../../components/relative-time-label';
 import { sumTokenUsage } from '../../components/token-figures';
 import { executionSubjectCss } from '../../utils/execution-subject';
-import {
-  hasUsageBreakdown,
-  mergeGatewaySummaryPreservingBreakdown,
-} from '../../utils/gateway-summary';
+import { mergeGatewaySummaryPreservingBreakdown } from '../../utils/gateway-summary';
 import {
   pickDefaultModel,
   selectableModels,
@@ -321,6 +318,10 @@ export class DashboardView extends AuthedElement {
   @state() private error: string | null = null;
   @state() private gatewaySummary: AccountGatewayUsageSummaryResponse | null =
     null;
+  // Provenance belongs to the detailed reads, not the lightweight summary
+  // whose period metadata advances independently on realtime refreshes.
+  @state() private gatewayUsageRange: string | null = null;
+  @state() private modelUsageRange: string | null = null;
   /** The window before `gatewayTimeRange`, for the Usage card's delta. */
   @state()
   private priorGatewaySummary: AccountGatewayUsageSummaryResponse | null = null;
@@ -1542,7 +1543,10 @@ export class DashboardView extends AuthedElement {
       if (!raw) return;
 
       const data = JSON.parse(raw);
-      if (data.gatewaySummary) this.gatewaySummary = data.gatewaySummary;
+      if (data.gatewayUsageRange === this.gatewayTimeRange) {
+        this.gatewaySummary = data.gatewaySummary || null;
+        this.gatewayUsageRange = data.gatewayUsageRange;
+      }
       this.runtimeSessions = data.runtimeSessions || [];
       this.managedAgents = data.managedAgents || [];
       this.gatewayInteractions = data.gatewayInteractions || [];
@@ -1555,7 +1559,10 @@ export class DashboardView extends AuthedElement {
       // the Inventory Models tab would otherwise sit on "No models yet · Add
       // a model" for the length of that pass on every reload.
       this.aiModels = data.aiModels || [];
-      this.aiModelOverview = data.aiModelOverview || [];
+      if (data.modelUsageRange === this.gatewayTimeRange) {
+        this.aiModelOverview = data.aiModelOverview || [];
+        this.modelUsageRange = data.modelUsageRange;
+      }
       this.flowExecutions = data.flowExecutions || [];
       this.flows = data.flows || [];
       this.flowExecutionsCount = data.flowExecutionsCount || 0;
@@ -1623,6 +1630,8 @@ export class DashboardView extends AuthedElement {
       const key = `preloop:dashboard:${sub}`;
       const cacheObj = {
         gatewaySummary: this.gatewaySummary,
+        gatewayUsageRange: this.gatewayUsageRange,
+        modelUsageRange: this.modelUsageRange,
         // Only what the cards actually show is worth keeping: the full lists
         // pushed this object past the sessionStorage quota on busy accounts,
         // and a quota failure threw away the whole cache.
@@ -1933,6 +1942,7 @@ export class DashboardView extends AuthedElement {
 
   /** What a gateway call can change: the totals, the deltas, the failures. */
   private async refreshGatewayFold(): Promise<void> {
+    const range = this.gatewayTimeRange;
     const startDateStr = this.getGatewayStartDate();
     const priorWindow = this.getPriorGatewayWindow(startDateStr);
     const [summary, priorSummary, rateLimitReport, interactions] =
@@ -1966,12 +1976,14 @@ export class DashboardView extends AuthedElement {
           >
         ),
       ]);
+    if (range !== this.gatewayTimeRange) return;
     // Merge, never replace: the breakdown on screen came from a heavier
     // request that this one does not make.
     this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
-      this.gatewaySummary,
+      this.gatewayUsageRange === range ? this.gatewaySummary : null,
       summary
     );
+    if (this.gatewayUsageRange !== range) this.gatewayUsageRange = null;
     this.priorGatewaySummary = priorSummary;
     this.rateLimitReport = rateLimitReport;
     this.gatewayInteractions = interactions.items || [];
@@ -2225,6 +2237,7 @@ export class DashboardView extends AuthedElement {
     }
     this.error = null;
 
+    const range = this.gatewayTimeRange;
     const startDateStr = this.getGatewayStartDate();
     const priorWindow = this.getPriorGatewayWindow(startDateStr);
 
@@ -2297,10 +2310,13 @@ export class DashboardView extends AuthedElement {
       // One batch of assignments with no await between them, so Lit renders
       // the finished fold once instead of eight times.
       this.rateLimitReport = rateLimitReport;
-      this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
-        this.gatewaySummary,
-        gatewaySummary
-      );
+      if (range === this.gatewayTimeRange) {
+        this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
+          this.gatewayUsageRange === range ? this.gatewaySummary : null,
+          gatewaySummary
+        );
+        if (this.gatewayUsageRange !== range) this.gatewayUsageRange = null;
+      }
       this.priorGatewaySummary = priorGatewaySummary;
       this.fetchingGatewaySummary = false;
       this.updatingUsage = false;
@@ -2332,6 +2348,7 @@ export class DashboardView extends AuthedElement {
         // A range change reloads what the range changes; the flows, the
         // people and the tool catalogue are the same at any range.
         rangeChangeOnly: options.preserveLoadingState === true,
+        range,
       });
     } catch (error) {
       console.error(
@@ -2366,12 +2383,12 @@ export class DashboardView extends AuthedElement {
    */
   private async fetchDeferredData(
     startDateStr: string,
-    options: { rangeChangeOnly?: boolean } = {}
+    options: { rangeChangeOnly?: boolean; range?: string } = {}
   ): Promise<void> {
     if (options.rangeChangeOnly) {
       await Promise.all([
         this.refreshGatewayInteractions(startDateStr),
-        this.refreshUsageBreakdown(startDateStr),
+        this.refreshUsageBreakdown(startDateStr, options.range),
         // The Audit trail line is per range, and the approvals it counts are
         // filtered from the page already in hand.
         this.refreshAuditEventCount(startDateStr),
@@ -2381,7 +2398,10 @@ export class DashboardView extends AuthedElement {
       return;
     }
     const inventoryPromise = this.fetchInventoryData(startDateStr);
-    const breakdownPromise = this.refreshUsageBreakdown(startDateStr);
+    const breakdownPromise = this.refreshUsageBreakdown(
+      startDateStr,
+      options.range
+    );
     const secondaryPromise = this.fetchSecondaryDashboardData();
 
     await Promise.all([inventoryPromise, breakdownPromise]);
@@ -2708,20 +2728,22 @@ export class DashboardView extends AuthedElement {
    * handed it instead of asking for a second one.
    */
   private async refreshUsageBreakdown(
-    gatewayStartDate: string
+    gatewayStartDate: string,
+    range: string = this.gatewayTimeRange
   ): Promise<AccountGatewayUsageSummaryResponse | null> {
     // Two requests, two flags: Models usage can land from the overview
     // without waiting for the heavier account breakdown, and the other way
     // around (D32).
     const [detailed] = await Promise.all([
-      this.fetchGatewayBreakdown(gatewayStartDate),
-      this.fetchModelUsage(gatewayStartDate),
+      this.fetchGatewayBreakdown(gatewayStartDate, range),
+      this.fetchModelUsage(gatewayStartDate, range),
     ]);
     return detailed;
   }
 
   private async fetchGatewayBreakdown(
-    gatewayStartDate: string
+    gatewayStartDate: string,
+    range: string = this.gatewayTimeRange
   ): Promise<AccountGatewayUsageSummaryResponse | null> {
     this.fetchingUsageBreakdown = true;
     try {
@@ -2732,30 +2754,35 @@ export class DashboardView extends AuthedElement {
         }),
         null
       );
-      if (!detailed) {
+      if (!detailed || range !== this.gatewayTimeRange) {
         return null;
       }
       this.gatewaySummary = detailed;
+      this.gatewayUsageRange = range;
       return detailed;
     } catch (error) {
       console.error('Failed to load gateway breakdown for top models', error);
       return null;
     } finally {
-      // Off whatever happened: a 403 on this endpoint means the columns will
-      // never fill, and a skeleton that never resolves is worse than a zero.
+      // Failed reads stop loading; unavailable range data renders as a dash.
+      // A same-range refresh failure can keep the previous usable values.
       this.fetchingUsageBreakdown = false;
     }
   }
 
-  private async fetchModelUsage(gatewayStartDate: string): Promise<void> {
+  private async fetchModelUsage(
+    gatewayStartDate: string,
+    range: string = this.gatewayTimeRange
+  ): Promise<void> {
     this.fetchingModelUsage = true;
     try {
       const overview = await this.catchWith403Handling(
         getAIModelsOverview({ startDate: gatewayStartDate }),
         null
       );
-      if (overview?.models) {
+      if (overview?.models && range === this.gatewayTimeRange) {
         this.aiModelOverview = overview.models;
+        this.modelUsageRange = range;
       }
     } catch (error) {
       console.error('Failed to load model usage for the Inventory', error);
@@ -3957,6 +3984,10 @@ export class DashboardView extends AuthedElement {
       };
     });
 
+    // Alias-only rows need a breakdown from this range too: the model
+    // overview can finish first while the summary still holds old usage.
+    if (this.gatewayUsageRange !== this.gatewayTimeRange) return rows;
+
     // Aliases the gateway served that are no longer in the models list.
     const seenAliases = new Set<string>();
     for (const model of this.gatewaySummary?.usage_by_model || []) {
@@ -4070,15 +4101,13 @@ export class DashboardView extends AuthedElement {
       });
   }
 
-  /**
-   * True while the usage columns of the Agents and Users tabs have nothing
-   * true to show. A breakdown already in hand (from the cache, or from the
-   * range before this one) is shown rather than hidden: stale numbers that
-   * are about to be replaced beat skeletons over data the page already has.
-   */
+  /** Keep same-range values during refresh; never relabel another range. */
   private get usageColumnsPending(): boolean {
     return (
-      this.fetchingUsageBreakdown && !hasUsageBreakdown(this.gatewaySummary)
+      this.gatewayUsageRange !== this.gatewayTimeRange &&
+      (this.fetchingUsageBreakdown ||
+        this.fetchingGatewaySummary ||
+        this.updatingUsage)
     );
   }
 
@@ -4091,7 +4120,12 @@ export class DashboardView extends AuthedElement {
   }
 
   private get modelUsagePending(): boolean {
-    return this.fetchingModelUsage && this.aiModelOverview.length === 0;
+    return (
+      this.modelUsageRange !== this.gatewayTimeRange &&
+      (this.fetchingModelUsage ||
+        this.fetchingGatewaySummary ||
+        this.updatingUsage)
+    );
   }
 
   /**
@@ -4120,6 +4154,8 @@ export class DashboardView extends AuthedElement {
         .loadingModels=${this.fetchingModels}
         .loadingTools=${this.fetchingTools}
         .loadingUsers=${this.fetchingUsers}
+        .usageAvailable=${this.gatewayUsageRange === this.gatewayTimeRange}
+        .modelUsageAvailable=${this.modelUsageRange === this.gatewayTimeRange}
         ?usageLoading=${this.usageColumnsPending}
         .usageLoadingFlows=${this.flowUsagePending}
         .usageLoadingFlowCost=${this.usageColumnsPending}

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -1781,6 +1781,195 @@ describe('DashboardView', () => {
       ]);
     });
 
+    it('does not label cached usage from another range as 30d', async () => {
+      const payload = btoa(JSON.stringify({ sub: 'range-cache-tester' }));
+      localStorage.setItem('accessToken', `header.${payload}.signature`);
+      const first = await mountLoaded();
+      first['gatewayTimeRange'] = 'day';
+      await first['refreshUsageBreakdown'](first['getGatewayStartDate']());
+      first['saveDashboardCache']();
+      const restored = document.createElement(
+        'dashboard-view'
+      ) as DashboardView;
+      restored['loadCachedDashboardData']();
+      expect(restored['aiModels']).to.have.length(1);
+      expect(restored['gatewaySummary']).to.equal(null);
+      expect(restored['aiModelOverview']).to.have.length(0);
+    });
+
+    it('hides old-range spend while loading and after a failed range refresh', async () => {
+      const element = await mountLoaded();
+      let release!: () => void;
+      const failureGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      fetchStub
+        .withArgs(
+          sinon.match(
+            (url: string) =>
+              url.includes('include_breakdown=true') ||
+              url.startsWith('/api/v1/ai-models/overview')
+          )
+        )
+        .callsFake(async () => {
+          await failureGate;
+          return new Response('', { status: 500 });
+        });
+      const inventory = element.shadowRoot!.querySelector(
+        'inventory-card'
+      ) as any;
+      element
+        .shadowRoot!.querySelector('usage-card')!
+        .dispatchEvent(
+          new CustomEvent('range-change', { detail: { value: 'day' } })
+        );
+      await waitUntil(() => element['fetchingUsageBreakdown']);
+      await element.updateComplete;
+      await inventory.updateComplete;
+      expect(inventory.rangeLabel).to.equal('24h');
+      expect(
+        inventory.shadowRoot.querySelector('[data-label="Spend"]').textContent
+      ).not.to.contain('$4.20');
+      expect(inventory.usageLoading).to.equal(true);
+      release();
+      await waitUntil(() => !element['refreshInFlight']);
+      await element.updateComplete;
+      await inventory.updateComplete;
+      expect(inventory.usageLoading).to.equal(false);
+      expect(
+        inventory.shadowRoot
+          .querySelector('[data-label="Spend"]')
+          .textContent.trim()
+      ).to.equal('—');
+      inventory.tab = 'models';
+      await inventory.updateComplete;
+      expect(
+        inventory.shadowRoot
+          .querySelector('[data-label="Spend"]')
+          .textContent.trim()
+      ).to.equal('—');
+    });
+
+    it('ignores a breakdown and model overview completed after the range changes', async () => {
+      const element = await mountLoaded();
+      let release!: () => void;
+      breakdownGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      overviewGate = breakdownGate;
+      const originalSummary = element['gatewaySummary'];
+      const originalModels = element['aiModelOverview'];
+      const pending = element['refreshUsageBreakdown'](
+        element['getGatewayStartDate']()
+      );
+      element['gatewayTimeRange'] = 'day';
+      release();
+      await pending;
+      expect(element['gatewaySummary']).to.equal(originalSummary);
+      expect(element['aiModelOverview']).to.equal(originalModels);
+    });
+
+    it('carries the original range into deferred requests after a slow first wave', async () => {
+      const element = await mountLoaded();
+      let release!: () => void;
+      summaryGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const pending = element['fetchDashboardData']({
+        preserveLoadingState: true,
+      });
+      element['gatewayTimeRange'] = 'day';
+      release();
+      await pending;
+      expect(element['gatewayUsageRange']).to.equal('month');
+      expect(element['modelUsageRange']).to.equal('month');
+      await element.updateComplete;
+      const inventory = element.shadowRoot!.querySelector(
+        'inventory-card'
+      ) as any;
+      expect(inventory.usageAvailable).to.equal(false);
+      expect(inventory.modelUsageAvailable).to.equal(false);
+    });
+
+    it('does not reuse provenance after a lightweight summary replaces another range', async () => {
+      const element = await mountLoaded();
+      element['gatewayTimeRange'] = 'day';
+      gatewaySummaryResponse = {
+        ...gatewaySummaryResponse,
+        usage_by_session: [],
+        usage_by_model: [],
+        usage_by_flow: [],
+        usage_by_tool: [],
+      };
+      await element['refreshGatewayFold']();
+      expect(element['gatewayUsageRange']).to.equal(null);
+      element['gatewayTimeRange'] = 'month';
+      await element.updateComplete;
+      const inventory = element.shadowRoot!.querySelector(
+        'inventory-card'
+      ) as any;
+      await inventory.updateComplete;
+      expect(inventory.usageAvailable).to.equal(false);
+      expect(
+        inventory.shadowRoot
+          .querySelector('[data-label="Spend"]')
+          .textContent.trim()
+      ).to.equal('—');
+    });
+
+    it('does not expose old alias costs when model usage arrives before the new breakdown', async () => {
+      const element = await mountLoaded();
+      element['gatewaySummary'] = {
+        ...element['gatewaySummary']!,
+        usage_by_model: [
+          {
+            ...gatewaySummaryResponse.usage_by_model[0],
+            ai_model_id: null,
+            model_alias: 'retired-model',
+          },
+        ],
+      };
+      element['gatewayTimeRange'] = 'day';
+      await element['fetchModelUsage'](element['getGatewayStartDate']());
+      expect(
+        element['inventoryModelRows'].map((row) => row.alias)
+      ).not.to.contain('retired-model');
+    });
+
+    it('keeps same-range usage during refresh but clears it on a successful empty breakdown', async () => {
+      const element = await mountLoaded();
+      let release!: () => void;
+      breakdownGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const pending = element['refreshUsageBreakdown'](
+        element['getGatewayStartDate']()
+      );
+      await element.updateComplete;
+      const inventory = element.shadowRoot!.querySelector(
+        'inventory-card'
+      ) as any;
+      await inventory.updateComplete;
+      expect(inventory.usageLoading).to.equal(false);
+      expect(
+        inventory.shadowRoot.querySelector('[data-label="Spend"]').textContent
+      ).to.contain('$4.20');
+      gatewaySummaryResponse = {
+        ...gatewaySummaryResponse,
+        usage_by_session: [],
+        usage_by_model: [],
+        usage_by_flow: [],
+        usage_by_tool: [],
+      };
+      release();
+      await pending;
+      await element.updateComplete;
+      await inventory.updateComplete;
+      expect(
+        inventory.shadowRoot.querySelector('[data-label="Spend"]').textContent
+      ).to.contain('$0.00');
+    });
+
     it('counts flow runs in the range the $ est. column already covers', async () => {
       // Two runs of the same flow: one this morning, one last quarter. The
       // spend column is range-scoped, so the run counts beside it must be.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12012,6 +12012,13 @@ components:
             format: date-time
           - type: 'null'
           title: Effective Until
+        catalog_provenance:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Catalog Provenance
+          description: Published-price provenance and schedule estimation assumptions.
         catalog_key:
           anyOf:
           - type: string

--- a/scripts/build_reviewed_model_prices.py
+++ b/scripts/build_reviewed_model_prices.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Build a runtime price feed from a reviewed catalog and evidence manifest.
+
+Run from the repository root with PYTHONPATH=backend. The manifest has the
+ReviewedPriceFeed shape except that each model's rates and native policy
+are omitted: those are copied from the catalog, avoiding duplicate rate tables.
+Only the explicitly reviewed model keys are exported. This does not fetch,
+publish, or activate prices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from preloop.services.reviewed_model_price_refresh import PRICE_FIELDS, validate_feed
+
+
+def build_feed(catalog: dict[str, Any], manifest: dict[str, Any]) -> dict[str, Any]:
+    """Copy reviewed rates/policies, requiring per-model provider evidence."""
+    payload = {**manifest, "models": {}}
+    for model, evidence in manifest["models"].items():
+        entry = catalog[model]
+        if "prices" in evidence or "price_policy" in evidence:
+            raise ValueError(
+                "Manifest prices/policy must come from the reviewed catalog"
+            )
+        if evidence["policy"] == "deepseek_utc_bands":
+            payload["models"][model] = {
+                **evidence,
+                "price_policy": entry["preloop_price_policy"],
+                "price_policy_history": entry.get("preloop_price_policy_history", []),
+            }
+            continue
+        if any("cost" in field and field not in PRICE_FIELDS for field in entry):
+            raise ValueError(f"Model {model} has an unsupported price policy")
+        payload["models"][model] = {
+            **evidence,
+            "prices": {key: entry[key] for key in PRICE_FIELDS if key in entry},
+        }
+    return validate_feed(payload).model_dump(mode="json", exclude_none=True)
+
+
+def main() -> int:
+    """Validate a reviewed artifact before writing it to the requested path."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_feed(
+        json.loads(args.catalog.read_text()), json.loads(args.manifest.read_text())
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(f"Validated reviewed feed: {len(payload['models'])} model(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Overview and Cost could show different totals because Cost rebuilt flow totals from a capped session list, while Overview could retain estimates from a previous date range. Use complete flow aggregates in Cost and retain Overview estimates only for the range that produced them. Flow sessions are excluded from agent regrouping to avoid double counting.

Correct native DeepSeek estimates with dated UTC peak/off-peak and cache rates, consistent aliases, and request price snapshots. Streams use an estimated request-start timestamp; manual repricing uses the saved timestamp when available. Provider-reported costs and explicit account overrides retain precedence.

Add optional reviewed-price feed refresh for API/gateway and worker processes, plus a feed builder and operating guide. Validated feeds update existing supported prices, invalidate estimator caches, preserve reviewed policy history, and expose provenance. Polling is disabled by default; failures retain the last accepted prices. This PR does not activate feed hosting, scheduled reviews, deployment, or historical repricing. Native schedule and timestamp assumptions are documented.

Validation: 239 focused backend tests passed against current main, including pricing, refresh, flow aggregation, and gateway integration regressions. The unchanged frontend base and reviewed patch passed 145 browser tests and TypeScript checks. Two independent runtime tests verified actual generic/native estimates after refresh. Scoped pre-commit, OpenAPI generation, targeted Prettier, and diff checks passed in the publication clone.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Changes core cost/pricing logic (flow totals, native DeepSeek tariff, optional price-feed refresh) with strong test coverage and a new network service; the startup-time config-failure path flagged in the prior review is now handled gracefully.
>
> **Overview**
> Aligns Cost and Overview totals using complete flow aggregates, adds a dated native DeepSeek tariff estimator with provenance, and introduces an optional operator-reviewed price feed for API/gateway/worker processes (disabled by default). All previously raised issues are addressed: startup config errors degrade to a sanitized disable, and the LiteLLM private-cache coupling is guarded with rollback. No security issues found.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 47c8a8e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->