### PR TITLE
Complete agent-control connection fencing and persistence safeguards

### DIFF
--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -6,16 +6,14 @@ import asyncio
 import json
 import logging
 import uuid
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from functools import partial
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 import nats.errors
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
 from pydantic_core import PydanticSerializationError
-from sqlalchemy import inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
@@ -37,6 +35,8 @@ from preloop.models.crud import (
     crud_runtime_session,
     crud_runtime_session_activity,
 )
+from preloop.models.crud import agent_control_connection as control_connection
+from preloop.models.crud.agent_control_connection import AgentControlConnectionContext
 from preloop.models.db.session import get_db_session
 from preloop.schemas.agent_control import (
     AgentControlCommandResponse,
@@ -63,6 +63,9 @@ router = APIRouter()
 # already defines the same value as ``EVICTION_CLOSE_CODE`` in
 # ``integrations/agent_control/core.py``; keep them in sync.
 EVICTION_CLOSE_CODE: int = 4000
+# Registration is serialized through the claim/registry handoff. A stalled
+# evicted socket must not hold that lock while unrelated agents try to connect.
+EVICTION_CLOSE_TIMEOUT_SECONDS: float = 1.0
 
 # How long the control WebSocket waits for an inbound frame before it pings the
 # agent, and how many of those windows may pass in silence before the socket is
@@ -110,24 +113,17 @@ HEARTBEAT_TOUCH_INTERVAL = timedelta(seconds=15)
 SUPPORTED_CONTROL_AGENT_KINDS = {"hermes", "openclaw", "claude_code", "opencode"}
 
 
-@dataclass(frozen=True)
-class AgentControlConnectionContext:
-    """Stable connection identifiers that survive managed-agent deletion."""
-
-    account_id: str
-    managed_agent_id: str
-    runtime_session_id: str
-    session_source_type: str
-    session_source_id: str
-    managed_agent_session_source_type: str
-    managed_agent_session_source_id: str
-
-
 def _connection_context_from_auth(
     context: RuntimeBearerAuthContext,
 ) -> AgentControlConnectionContext:
     """Capture connection identifiers before ORM rows can be deleted."""
     return AgentControlConnectionContext(
+        api_key_id=str(context.api_key.id),
+        user_id=str(context.user.id),
+        agent_kind=context.managed_agent.agent_kind,
+        session_reference=context.runtime_session.session_reference,
+        runtime_principal_id=context.runtime_session.runtime_principal_id,
+        connection_id=str(uuid.uuid4()),
         account_id=str(context.runtime_session.account_id),
         managed_agent_id=str(context.managed_agent.id),
         runtime_session_id=str(context.runtime_session.id),
@@ -158,6 +154,7 @@ class _ControlDatabase:
             with Session(
                 bind=self._bind, join_transaction_mode="create_savepoint"
             ) as db:
+                control_connection.configure_transaction(db)
                 return operation(db)
 
         async with self._lock:
@@ -165,25 +162,12 @@ class _ControlDatabase:
             return await run_db_off_loop(execute)
 
 
-def _load_control_identity(db: Session, token: str) -> RuntimeBearerAuthContext:
-    """Authenticate and detach scalar identity before any socket/NATS await."""
+def _load_control_identity(db: Session, token: str) -> AgentControlConnectionContext:
+    """Authenticate in the worker and return scalar identity only."""
     context = authenticate_runtime_bearer_token(
         db, token, enforce_current_binding=False
     )
-    # Detached entities must only be read by column attribute (no
-    # relationships, lazy loads, db.merge, or db.add). api_key is unused after
-    # auth, so do not hydrate its columns for socket use.
-    for entity in (
-        context.user,
-        context.runtime_session,
-        context.managed_agent,
-    ):
-        # Auth can commit and expire these rows. Hydrate on the worker, then
-        # detach so later phase commits/rollbacks cannot trigger lazy reloads.
-        for attribute in inspect(entity).mapper.column_attrs:
-            getattr(entity, attribute.key)
-        db.expunge(entity)
-    return context
+    return _connection_context_from_auth(context)
 
 
 def _agent_has_control_config(db: Session, *, account_id: str, agent: Any) -> bool:
@@ -241,9 +225,17 @@ class AgentControlConnectionManager:
         self._agent_connections: dict[str, str] = {}
         self._connection_agents: dict[str, str] = {}
         self._presence: dict[str, dict[str, Any]] = {}
+        self._senders: dict[str, Callable[[dict[str, Any]], Awaitable[bool]]] = {}
         self._lock = asyncio.Lock()
+        self.registration_lock = asyncio.Lock()
 
-    async def connect(self, *, managed_agent_id: str, websocket: WebSocket) -> str:
+    async def connect(
+        self,
+        *,
+        managed_agent_id: str,
+        websocket: WebSocket,
+        sender: Callable[[dict[str, Any]], Awaitable[bool]] | None = None,
+    ) -> str:
         """Register one accepted managed-agent WebSocket.
 
         If another connection is already registered for the same agent,
@@ -260,7 +252,10 @@ class AgentControlConnectionManager:
                 evicted_ws = self._connections.pop(previous_connection_id, None)
                 evicted_id = previous_connection_id
                 self._connection_agents.pop(previous_connection_id, None)
+                self._senders.pop(previous_connection_id, None)
             self._connections[connection_id] = websocket
+            if sender is not None:
+                self._senders[connection_id] = sender
             self._agent_connections[managed_agent_id] = connection_id
             self._connection_agents[connection_id] = managed_agent_id
         if evicted_ws is not None:
@@ -272,9 +267,12 @@ class AgentControlConnectionManager:
                 connection_id,
             )
             try:
-                await evicted_ws.close(
-                    code=EVICTION_CLOSE_CODE,
-                    reason="Superseded by a newer connection for this agent",
+                await asyncio.wait_for(
+                    evicted_ws.close(
+                        code=EVICTION_CLOSE_CODE,
+                        reason="Superseded by a newer connection for this agent",
+                    ),
+                    timeout=EVICTION_CLOSE_TIMEOUT_SECONDS,
                 )
             except Exception:
                 logger.debug(
@@ -289,6 +287,7 @@ class AgentControlConnectionManager:
         async with self._lock:
             managed_agent_id = self._connection_agents.pop(connection_id, None)
             self._connections.pop(connection_id, None)
+            self._senders.pop(connection_id, None)
             if managed_agent_id is None:
                 return False
             if self._agent_connections.get(managed_agent_id) == connection_id:
@@ -325,9 +324,18 @@ class AgentControlConnectionManager:
         }
 
     def record_presence(
-        self, managed_agent_id: str, payload: dict[str, Any] | None
+        self,
+        managed_agent_id: str,
+        payload: dict[str, Any] | None,
+        *,
+        connection_id: str | None = None,
     ) -> None:
         """Remember the last capabilities/session_mode envelope from the plugin."""
+        if (
+            connection_id is not None
+            and self._agent_connections.get(managed_agent_id) != connection_id
+        ):
+            return
         self._presence[managed_agent_id] = payload or {}
 
     async def send_to_agent(
@@ -337,6 +345,7 @@ class AgentControlConnectionManager:
         async with self._lock:
             connection_id = self._agent_connections.get(managed_agent_id)
             websocket = self._connections.get(connection_id or "")
+            sender = self._senders.get(connection_id or "")
         if websocket is None:
             return False
         try:
@@ -355,6 +364,8 @@ class AgentControlConnectionManager:
                 "payload": {"error": "envelope_serialization_failed"},
             }
         try:
+            if sender is not None:
+                return bool(await sender(payload))
             await websocket.send_json(payload)
         except _WS_DELIVERY_ERRORS:
             logger.exception(
@@ -453,7 +464,7 @@ def _operator_command_envelope(
 
 def _touch_presence(
     db: Session,
-    context: RuntimeBearerAuthContext,
+    context: AgentControlConnectionContext,
     *,
     observed_at: datetime,
     session_mode: Optional[str] = None,
@@ -463,10 +474,9 @@ def _touch_presence(
     # Reversing this order lets heartbeat and decommission wait on each other.
     crud_managed_agent.touch_last_seen_for_principal(
         db,
-        account_id=context.runtime_session.account_id,
-        session_source_type=context.managed_agent.session_source_type,
-        session_source_id=context.managed_agent.session_source_id,
-        runtime_session_id=context.runtime_session.id,
+        account_id=context.account_id,
+        session_source_type=context.managed_agent_session_source_type,
+        session_source_id=context.managed_agent_session_source_id,
         observed_at=observed_at,
         control_session_mode=session_mode,
         # This function is only reachable from the Agent Control WebSocket, so
@@ -477,29 +487,31 @@ def _touch_presence(
     )
     crud_runtime_session.touch_activity(
         db,
-        account_id=context.runtime_session.account_id,
-        runtime_session_id=context.runtime_session.id,
+        account_id=context.account_id,
+        runtime_session_id=context.runtime_session_id,
         observed_at=observed_at,
         min_update_interval=HEARTBEAT_TOUCH_INTERVAL,
         commit=False,
     )
     if commit:
-        db.commit()
+        control_connection.commit(db)
 
 
 def _mark_control_verified_from_capabilities(
     db: Session,
-    context: RuntimeBearerAuthContext,
+    context: AgentControlConnectionContext,
     inbound: AgentControlInboundEnvelope,
+    *,
+    commit: bool = True,
 ) -> None:
     """Treat a live capabilities envelope as runtime-plugin verification."""
     if inbound.type != "presence" or inbound.name != "capabilities":
         return
 
     agent_kind = str(
-        context.managed_agent.agent_kind
-        or context.managed_agent.session_source_type
-        or context.runtime_session.session_source_type
+        context.agent_kind
+        or context.managed_agent_session_source_type
+        or context.session_source_type
         or ""
     ).lower()
     if agent_kind not in SUPPORTED_CONTROL_AGENT_KINDS:
@@ -507,13 +519,13 @@ def _mark_control_verified_from_capabilities(
 
     latest_enrollment = crud_managed_agent_enrollment.get_latest_for_agent_by_type(
         db,
-        account_id=str(context.runtime_session.account_id),
-        agent_id=str(context.managed_agent.id),
+        account_id=str(context.account_id),
+        agent_id=str(context.managed_agent_id),
         enrollment_type="cli_managed_config",
     ) or crud_managed_agent_enrollment.get_latest_for_agent_by_type(
         db,
-        account_id=str(context.runtime_session.account_id),
-        agent_id=str(context.managed_agent.id),
+        account_id=str(context.account_id),
+        agent_id=str(context.managed_agent_id),
         enrollment_type="runtime_plugin_control",
     )
     validation_result = {
@@ -533,26 +545,29 @@ def _mark_control_verified_from_capabilities(
         "control_runtime_session_id_present": True,
     }
     if latest_enrollment is not None:
-        latest_enrollment.status = "validated"
-        latest_enrollment.validation_result = validation_result
-        latest_enrollment.last_validated_at = datetime.now(UTC)
-        db.add(latest_enrollment)
-        db.commit()
+        crud_managed_agent_enrollment.mark_validated(
+            db,
+            account_id=context.account_id,
+            agent_id=context.managed_agent_id,
+            enrollment_id=str(latest_enrollment.id),
+            validation_result=validation_result,
+            commit=commit,
+        )
         return
 
     crud_managed_agent_enrollment.create_for_agent(
         db,
-        account_id=context.runtime_session.account_id,
-        agent_id=context.managed_agent.id,
-        created_by_user_id=context.user.id,
+        account_id=context.account_id,
+        agent_id=context.managed_agent_id,
+        created_by_user_id=context.user_id,
         enrollment_type="runtime_plugin_control",
         adapter_key=agent_kind,
         status="validated",
-        target_config_path=context.runtime_session.session_reference,
+        target_config_path=context.session_reference,
         discovered_config={
-            "session_source_type": context.runtime_session.session_source_type,
-            "session_source_id": context.runtime_session.session_source_id,
-            "runtime_principal_id": context.runtime_session.runtime_principal_id,
+            "session_source_type": context.session_source_type,
+            "session_source_id": context.session_source_id,
+            "runtime_principal_id": context.runtime_principal_id,
         },
         managed_config={
             "preloop": {
@@ -560,9 +575,9 @@ def _mark_control_verified_from_capabilities(
                     "enabled": True,
                     "runtime": agent_kind,
                     "control_ws_url": "/api/v1/agents/control/ws",
-                    "managed_agent_id": str(context.managed_agent.id),
-                    "runtime_session_id": str(context.runtime_session.id),
-                    "runtime_principal_id": context.runtime_session.runtime_principal_id,
+                    "managed_agent_id": str(context.managed_agent_id),
+                    "runtime_session_id": str(context.runtime_session_id),
+                    "runtime_principal_id": context.runtime_principal_id,
                 }
             }
         },
@@ -570,7 +585,7 @@ def _mark_control_verified_from_capabilities(
         restore_available=False,
         last_applied_at=datetime.now(UTC),
         last_validated_at=datetime.now(UTC),
-        commit=True,
+        commit=commit,
     )
 
 
@@ -623,12 +638,71 @@ def _safe_mark_command_delivered(
         )
 
 
+async def _send_control_command(
+    database: _ControlDatabase,
+    connection: AgentControlConnectionContext,
+    websocket: WebSocket,
+    payload: dict[str, Any],
+) -> bool:
+    """Fence database effects around at-least-once socket delivery.
+
+    Use the persisted account/agent-scoped envelope, never broker-supplied
+    command content. Replacement can happen after the read and before the
+    send; that old socket can no longer acknowledge or mark delivery.
+    """
+    command_id = payload.get("message_id")
+    if payload.get("type") != "command" or not isinstance(command_id, str):
+        return False
+
+    def load(db: Session) -> dict[str, Any] | None:
+        if control_connection.authorize(db, connection) is None:
+            return None
+        record = crud_agent_control_command.get_by_command_id(
+            db,
+            account_id=connection.account_id,
+            managed_agent_id=connection.managed_agent_id,
+            command_id=command_id,
+        )
+        if (
+            record is None
+            or record.kind != "command"
+            or record.status not in {"pending", "delivered"}
+        ):
+            return None
+        if record.expires_at is not None and record.expires_at.replace(
+            tzinfo=UTC
+        ) <= datetime.now(UTC):
+            return None
+        return dict(record.envelope)
+
+    def mark(db: Session) -> None:
+        if control_connection.authorize(db, connection) is not None:
+            _safe_mark_command_delivered(
+                db,
+                account_id=connection.account_id,
+                managed_agent_id=connection.managed_agent_id,
+                command_id=command_id,
+            )
+
+    try:
+        envelope = await database.run(load)
+        if envelope is None:
+            return False
+        await websocket.send_json(envelope)
+        await database.run(mark)
+        return True
+    except _DB_DELIVERY_ERRORS + _WS_DELIVERY_ERRORS:
+        logger.warning("Control command delivery unavailable", exc_info=True)
+        return False
+
+
 async def _subscribe_to_commands(
     *,
     managed_agent_id: str,
     websocket: WebSocket,
     database: Optional[_ControlDatabase] = None,
     account_id: Optional[str] = None,
+    connection: AgentControlConnectionContext | None = None,
 ) -> Any:
     subject = f"agent-control.commands.{managed_agent_id}"
     try:
@@ -639,34 +713,12 @@ async def _subscribe_to_commands(
         async def forward_command(msg: Any) -> None:
             try:
                 payload = json.loads(msg.data.decode())
-                await websocket.send_json(payload)
             except _WS_DELIVERY_ERRORS:
-                logger.exception("Failed to forward managed-agent command")
-                # Do not mark delivered — NATS/WS may retry; continue to the
-                # next message without treating this payload as sent.
+                logger.exception("Invalid managed-agent command notification")
                 return
-            # The publishing pod leaves the command pending; the pod that
-            # holds the WebSocket marks it delivered once actually sent.
-            command_id = payload.get("message_id")
-            envelope_agent_id = payload.get("managed_agent_id")
-            if (
-                database is not None
-                and account_id is not None
-                and payload.get("type") == "command"
-                and isinstance(command_id, str)
-                and (
-                    envelope_agent_id is None
-                    or str(envelope_agent_id) == str(managed_agent_id)
-                )
-            ):
-                await database.run(
-                    lambda db: _safe_mark_command_delivered(
-                        db,
-                        account_id=account_id,
-                        command_id=command_id,
-                        managed_agent_id=managed_agent_id,
-                    )
-                )
+            if not isinstance(payload, dict) or database is None or connection is None:
+                return
+            await _send_control_command(database, connection, websocket, payload)
 
         return await nats_client.subscribe(subject, cb=forward_command)
     except _NATS_DELIVERY_ERRORS:
@@ -683,10 +735,21 @@ async def _redeliver_pending_commands(
     now = datetime.now(UTC)
 
     def load(db: Session) -> list[tuple[str, dict[str, Any]]]:
+        if control_connection.authorize(db, connection) is None:
+            return []
         with db.begin_nested():
-            crud_agent_control_command.expire_stale(db, now=now, commit=False)
+            crud_agent_control_command.expire_stale(
+                db,
+                now=now,
+                account_id=connection.account_id,
+                managed_agent_id=connection.managed_agent_id,
+                commit=False,
+            )
             pending = crud_agent_control_command.get_undelivered_for_agent(
-                db, managed_agent_id=connection.managed_agent_id, now=now
+                db,
+                managed_agent_id=connection.managed_agent_id,
+                account_id=connection.account_id,
+                now=now,
             )
             snapshots = [
                 (record.command_id, dict(record.envelope)) for record in pending
@@ -703,35 +766,9 @@ async def _redeliver_pending_commands(
         )
         return
 
-    delivered_ids: list[str] = []
-    for command_id, envelope in pending:
-        try:
-            await websocket.send_json(envelope)
-        except _WS_DELIVERY_ERRORS:
-            logger.exception("Failed to redeliver Agent Control command %s", command_id)
+    for _, envelope in pending:
+        if not await _send_control_command(database, connection, websocket, envelope):
             break
-        delivered_ids.append(command_id)
-
-    def mark_delivered(db: Session) -> None:
-        with db.begin_nested():
-            crud_agent_control_command.mark_delivered_many(
-                db,
-                account_id=connection.account_id,
-                managed_agent_id=connection.managed_agent_id,
-                command_ids=delivered_ids,
-                delivered_at=datetime.now(UTC),
-                commit=False,
-            )
-        db.commit()
-
-    if delivered_ids:
-        try:
-            await database.run(mark_delivered)
-        except _DB_DELIVERY_ERRORS:
-            logger.exception(
-                "Failed to batch-mark %s Agent Control commands delivered",
-                len(delivered_ids),
-            )
 
 
 _COMMAND_ACK_NAMES = {"ack", "command_ack", "command_result", "command_error"}
@@ -741,6 +778,8 @@ def _handle_command_ack(
     db: Session,
     connection: AgentControlConnectionContext,
     inbound: AgentControlInboundEnvelope,
+    *,
+    commit: bool = True,
 ) -> None:
     """Record an end-to-end command acknowledgement from the agent.
 
@@ -766,13 +805,16 @@ def _handle_command_ack(
                 acked_at=datetime.now(UTC),
                 commit=False,
             )
-        db.commit()
+        if commit:
+            control_connection.commit(db)
         if record is None:
             logger.info(
                 "Received ack for unknown or cross-agent Agent Control command %s",
                 command_id,
             )
     except _DB_DELIVERY_ERRORS:
+        if not commit:
+            raise
         logger.exception("Failed to mark Agent Control command %s acked", command_id)
 
 
@@ -813,8 +855,10 @@ def _sanitize_agent_control_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _persist_agent_control_result(
     db: Session,
-    context: RuntimeBearerAuthContext,
+    context: AgentControlConnectionContext,
     inbound: AgentControlInboundEnvelope,
+    *,
+    commit: bool = True,
 ) -> None:
     if inbound.type != "status" or inbound.name not in {
         "command_result",
@@ -824,6 +868,15 @@ def _persist_agent_control_result(
 
     command_id = inbound.payload.get("command_id")
     if not isinstance(command_id, str) or not command_id.strip():
+        return
+
+    command = crud_agent_control_command.get_by_command_id(
+        db,
+        account_id=context.account_id,
+        managed_agent_id=context.managed_agent_id,
+        command_id=command_id.strip(),
+    )
+    if command is None or command.kind != "command" or command.status != "acked":
         return
 
     default_status = "failed" if inbound.name == "command_error" else "completed"
@@ -838,12 +891,13 @@ def _persist_agent_control_result(
 
     crud_runtime_session_activity.log_agent_control_result(
         db,
-        account_id=context.runtime_session.account_id,
+        account_id=context.account_id,
         command_id=command_id.strip(),
-        fallback_runtime_session_id=context.runtime_session.id,
+        fallback_runtime_session_id=context.runtime_session_id,
         status=result_status,
         message=message,
         metadata=_sanitize_agent_control_payload(inbound.payload),
+        commit=commit,
     )
 
 
@@ -874,24 +928,23 @@ async def _emit_agent_message(
 
 def _process_control_message(
     db: Session,
-    context: RuntimeBearerAuthContext,
     connection: AgentControlConnectionContext,
     inbound: AgentControlInboundEnvelope,
     observed_at: datetime,
 ) -> bool:
     """Persist one inbound frame using one isolated worker session."""
-    agent = crud_managed_agent.get_for_account(
-        db, account_id=connection.account_id, agent_id=connection.managed_agent_id
-    )
-    if agent is None or agent.lifecycle_state in {"suspended", "decommissioned"}:
+    if control_connection.authorize(db, connection) is None:
         return False
     inbound_mode = inbound.payload.get("session_mode")
     if inbound_mode not in {"local", "remote", "queued"}:
         inbound_mode = None
-    _touch_presence(db, context, observed_at=observed_at, session_mode=inbound_mode)
-    _mark_control_verified_from_capabilities(db, context, inbound)
-    _handle_command_ack(db, connection, inbound)
-    _persist_agent_control_result(db, context, inbound)
+    _touch_presence(
+        db, connection, observed_at=observed_at, session_mode=inbound_mode, commit=False
+    )
+    _mark_control_verified_from_capabilities(db, connection, inbound, commit=False)
+    _handle_command_ack(db, connection, inbound, commit=False)
+    _persist_agent_control_result(db, connection, inbound, commit=False)
+    control_connection.commit(db)
     return True
 
 
@@ -899,24 +952,18 @@ def _retire_control_presence(
     db: Session,
     connection: AgentControlConnectionContext,
     last_presence_at: datetime,
-) -> None:
-    """Retire only this connection's heartbeat and runtime binding."""
-    crud_managed_agent.clear_control_heartbeat(
-        db,
-        account_id=connection.account_id,
-        session_source_type=connection.managed_agent_session_source_type,
-        session_source_id=connection.managed_agent_session_source_id,
-        not_newer_than=last_presence_at,
-        commit=True,
-    )
-    crud_managed_agent.clear_runtime_session_binding(
-        db,
-        account_id=connection.account_id,
-        session_source_type=connection.managed_agent_session_source_type,
-        session_source_id=connection.managed_agent_session_source_id,
-        runtime_session_id=connection.runtime_session_id,
-        commit=True,
-    )
+) -> bool:
+    """Retire presence atomically using the persisted generation."""
+    return control_connection.retire(db, connection)
+
+
+def _claim_control_connection(
+    db: Session, connection: AgentControlConnectionContext, observed_at: datetime
+) -> bool:
+    if control_connection.authorize(db, connection, claim=True) is None:
+        return False
+    _touch_presence(db, connection, observed_at=observed_at)
+    return True
 
 
 @router.websocket("/agents/control/ws")
@@ -925,6 +972,7 @@ async def managed_agent_control_websocket(
     db: Session = Depends(get_db_session),
 ) -> None:
     """Keep one managed agent online for low-latency operator commands."""
+    manager = agent_control_manager
     token = _extract_bearer_token(websocket)
     if token is None:
         await websocket.close(code=1008, reason="Runtime bearer token required")
@@ -932,7 +980,7 @@ async def managed_agent_control_websocket(
 
     database = _ControlDatabase(db)
     try:
-        context = await database.run(
+        connection = await database.run(
             lambda session: _load_control_identity(session, token)
         )
     except HTTPException as exc:
@@ -949,24 +997,30 @@ async def managed_agent_control_websocket(
         return
 
     await websocket.accept()
-    connection = _connection_context_from_auth(context)
-    connection_id = await agent_control_manager.connect(
-        managed_agent_id=connection.managed_agent_id,
-        websocket=websocket,
-    )
+    connection_id = ""
     command_subscription = None
     now = datetime.now(UTC)
     last_presence_at = now
     try:
+        async with manager.registration_lock:
+            if not await database.run(
+                lambda session: _claim_control_connection(session, connection, now)
+            ):
+                await websocket.close(
+                    code=1008, reason="Control credential is no longer active"
+                )
+                return
+            connection_id = await manager.connect(
+                managed_agent_id=connection.managed_agent_id,
+                websocket=websocket,
+                sender=partial(_send_control_command, database, connection, websocket),
+            )
         command_subscription = await _subscribe_to_commands(
             managed_agent_id=connection.managed_agent_id,
             websocket=websocket,
             database=database,
             account_id=connection.account_id,
-        )
-
-        await database.run(
-            lambda session: _touch_presence(session, context, observed_at=now)
+            connection=connection,
         )
         # The last heartbeat this connection wrote, so a clean close can retire
         # its own presence without stealing a newer connection's.
@@ -1040,7 +1094,6 @@ async def managed_agent_control_websocket(
                 active = await database.run(
                     partial(
                         _process_control_message,
-                        context=context,
                         connection=connection,
                         inbound=inbound,
                         observed_at=last_presence_at,
@@ -1051,10 +1104,16 @@ async def managed_agent_control_websocket(
                         "Managed agent %s deleted or inactive during control websocket; closing",
                         connection.managed_agent_id,
                     )
+                    await websocket.close(
+                        code=EVICTION_CLOSE_CODE,
+                        reason="Control ownership or credential changed",
+                    )
                     break
                 if inbound.type in {"presence", "heartbeat", "status"}:
-                    agent_control_manager.record_presence(
-                        connection.managed_agent_id, inbound.payload
+                    manager.record_presence(
+                        connection.managed_agent_id,
+                        inbound.payload,
+                        connection_id=connection_id,
                     )
             except _AGENT_GONE_ERRORS:
                 logger.info(
@@ -1068,6 +1127,7 @@ async def managed_agent_control_websocket(
                     connection.managed_agent_id,
                     exc_info=True,
                 )
+                await websocket.close(code=1013, reason="Database busy; reconnect")
                 break
             await _emit_agent_message(connection, inbound)
             if inbound.type == "heartbeat":
@@ -1079,8 +1139,11 @@ async def managed_agent_control_websocket(
                     payload={"status": "ok"},
                 )
                 await websocket.send_json(ack.model_dump(mode="json"))
-    except WebSocketDisconnect:
+    except _WS_DELIVERY_ERRORS:
         logger.info("Managed-agent control WebSocket disconnected")
+    except _DB_DELIVERY_ERRORS:
+        logger.warning("Control database phase failed", exc_info=True)
+        await websocket.close(code=1013, reason="Database busy; reconnect")
     finally:
         if command_subscription is not None:
             try:
@@ -1090,14 +1153,15 @@ async def managed_agent_control_websocket(
                     "Failed to unsubscribe agent command subscription",
                     exc_info=True,
                 )
-        removed_active = await agent_control_manager.disconnect(connection_id)
-        if removed_active:
+        removed_active = await manager.disconnect(connection_id)
+        if removed_active or not connection_id:
             # A clean close is presence information every replica can read, so
             # retire the heartbeat instead of waiting out the window. This runs
             # in a finally block: a session that already failed must not stop
             # the disconnect bookkeeping below.
+            retired = False
             try:
-                await database.run(
+                retired = await database.run(
                     lambda session: _retire_control_presence(
                         session, connection, last_presence_at
                     )
@@ -1108,19 +1172,20 @@ async def managed_agent_control_websocket(
                     connection.managed_agent_id,
                     exc_info=True,
                 )
-            emit_account_event(
-                build_account_event(
-                    account_id=connection.account_id,
-                    topic=ACCOUNT_TOPIC_AGENT_CONTROL,
-                    event_type="managed_agent_offline",
-                    payload={
-                        "managed_agent_id": connection.managed_agent_id,
-                        "runtime_session_id": connection.runtime_session_id,
-                    },
-                    managed_agent_id=connection.managed_agent_id,
-                    runtime_session_id=connection.runtime_session_id,
+            if retired:
+                emit_account_event(
+                    build_account_event(
+                        account_id=connection.account_id,
+                        topic=ACCOUNT_TOPIC_AGENT_CONTROL,
+                        event_type="managed_agent_offline",
+                        payload={
+                            "managed_agent_id": connection.managed_agent_id,
+                            "runtime_session_id": connection.runtime_session_id,
+                        },
+                        managed_agent_id=connection.managed_agent_id,
+                        runtime_session_id=connection.runtime_session_id,
+                    )
                 )
-            )
 
 
 def _resolve_session_mode(
@@ -1287,18 +1352,17 @@ async def _route_managed_agent_prompt(
         expires_at=expires_at,
     )
 
+    # create_command refreshes its row after committing. End that read
+    # transaction before the guarded sender checks out its own connection.
+    # Snapshot before rollback; reading an expired agent here would reacquire it.
+    delivery_agent_id = str(agent.id)
+    await run_db_off_loop(partial(control_connection.release_read_transaction, db))
     command_status = "pending"
     local_delivery = await agent_control_manager.send_to_agent(
-        managed_agent_id=str(agent.id),
+        managed_agent_id=delivery_agent_id,
         envelope=envelope,
     )
     if local_delivery:
-        _safe_mark_command_delivered(
-            db,
-            account_id=str(agent.account_id),
-            command_id=envelope.message_id,
-            managed_agent_id=str(agent.id),
-        )
         command_status = "delivered"
     subject = None
     if not local_delivery:
@@ -1535,18 +1599,17 @@ async def _route_session_action(
         created_by_user_id=current_user.id,
         expires_at=expires_at,
     )
+    # create_command refreshes its row after committing. End that read
+    # transaction before the guarded sender checks out its own connection.
+    # Snapshot before rollback; reading an expired agent here would reacquire it.
+    delivery_agent_id = str(agent.id)
+    await run_db_off_loop(partial(control_connection.release_read_transaction, db))
     command_status = "pending"
     local_delivery = await agent_control_manager.send_to_agent(
-        managed_agent_id=str(agent.id),
+        managed_agent_id=delivery_agent_id,
         envelope=envelope,
     )
     if local_delivery:
-        _safe_mark_command_delivered(
-            db,
-            account_id=str(agent.account_id),
-            command_id=envelope.message_id,
-            managed_agent_id=str(agent.id),
-        )
         command_status = "delivered"
     subject = None
     if not local_delivery:

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -951,7 +951,6 @@ def _process_control_message(
 def _retire_control_presence(
     db: Session,
     connection: AgentControlConnectionContext,
-    last_presence_at: datetime,
 ) -> bool:
     """Retire presence atomically using the persisted generation."""
     return control_connection.retire(db, connection)
@@ -1162,9 +1161,7 @@ async def managed_agent_control_websocket(
             retired = False
             try:
                 retired = await database.run(
-                    lambda session: _retire_control_presence(
-                        session, connection, last_presence_at
-                    )
+                    lambda session: _retire_control_presence(session, connection)
                 )
             except _DB_DELIVERY_ERRORS:
                 logger.warning(

--- a/backend/preloop/models/alembic/versions/20260912_control_connection.py
+++ b/backend/preloop/models/alembic/versions/20260912_control_connection.py
@@ -1,0 +1,21 @@
+"""Persist control WebSocket ownership independently of runtime identity."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260912_control_connection"
+down_revision = "20260910_operator_notes"
+branch_labels = None
+depends_on = None
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_agent", sa.Column("control_connection_id", sa.UUID(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("managed_agent", "control_connection_id")

--- a/backend/preloop/models/crud/agent_control_command.py
+++ b/backend/preloop/models/crud/agent_control_command.py
@@ -6,11 +6,14 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
-from ..models.agent_control_command import AgentControlCommand
+from preloop.models import models
+
 from .base import CRUDBase
+
+AgentControlCommand = models.AgentControlCommand
 
 
 class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
@@ -81,7 +84,7 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
             query = query.filter(
                 AgentControlCommand.managed_agent_id == managed_agent_id
             )
-        return query.first()
+        return query.populate_existing().first()
 
     def mark_delivered(
         self,
@@ -94,20 +97,28 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         commit: bool = True,
     ) -> Optional[AgentControlCommand]:
         """Transition a pending command to delivered (idempotent)."""
-        record = self.get_by_command_id(
+        query = db.query(AgentControlCommand).filter(
+            AgentControlCommand.account_id == account_id,
+            AgentControlCommand.command_id == command_id,
+            AgentControlCommand.status == "pending",
+            AgentControlCommand.kind == "command",
+        )
+        if managed_agent_id is not None:
+            query = query.filter(
+                AgentControlCommand.managed_agent_id == managed_agent_id
+            )
+        query.update(
+            {"status": "delivered", "delivered_at": delivered_at},
+            synchronize_session="fetch",
+        )
+        if commit:
+            db.commit()
+        return self.get_by_command_id(
             db,
             account_id=account_id,
             command_id=command_id,
             managed_agent_id=managed_agent_id,
         )
-        if record is None:
-            return None
-        if record.status == "pending":
-            record.status = "delivered"
-            record.delivered_at = delivered_at
-            if commit:
-                db.commit()
-        return record
 
     def mark_acked(
         self,
@@ -125,23 +136,34 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         different agent when ``managed_agent_id`` is set) so callers can
         log and continue — acks are tolerant, never errors.
         """
-        record = self.get_by_command_id(
+        query = db.query(AgentControlCommand).filter(
+            AgentControlCommand.account_id == account_id,
+            AgentControlCommand.command_id == command_id,
+            AgentControlCommand.status.in_(["pending", "delivered"]),
+            AgentControlCommand.kind == "command",
+        )
+        if managed_agent_id is not None:
+            query = query.filter(
+                AgentControlCommand.managed_agent_id == managed_agent_id
+            )
+        query.update(
+            {
+                "status": "acked",
+                "acked_at": acked_at,
+                "delivered_at": func.coalesce(
+                    AgentControlCommand.delivered_at, acked_at
+                ),
+            },
+            synchronize_session="fetch",
+        )
+        if commit:
+            db.commit()
+        return self.get_by_command_id(
             db,
             account_id=account_id,
             command_id=command_id,
             managed_agent_id=managed_agent_id,
         )
-        if record is None:
-            return None
-        if record.status in {"pending", "delivered"}:
-            record.status = "acked"
-            record.acked_at = acked_at
-            if record.delivered_at is None:
-                # An ack implies delivery even if the delivery mark was lost.
-                record.delivered_at = acked_at
-            if commit:
-                db.commit()
-        return record
 
     def mark_failed(
         self,
@@ -154,26 +176,32 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         commit: bool = True,
     ) -> Optional[AgentControlCommand]:
         """Mark a command as failed when no delivery channel was available."""
-        record = self.get_by_command_id(
+        query = db.query(AgentControlCommand).filter(
+            AgentControlCommand.account_id == account_id,
+            AgentControlCommand.command_id == command_id,
+            AgentControlCommand.kind == "command",
+        )
+        if managed_agent_id is not None:
+            query = query.filter(
+                AgentControlCommand.managed_agent_id == managed_agent_id
+            )
+        query.filter(AgentControlCommand.status == "pending").update(
+            {"status": "failed", "last_error": error}, synchronize_session="fetch"
+        )
+        query.filter(
+            or_(
+                AgentControlCommand.last_error.is_(None),
+                AgentControlCommand.last_error != error,
+            )
+        ).update({"last_error": error}, synchronize_session="fetch")
+        if commit:
+            db.commit()
+        return self.get_by_command_id(
             db,
             account_id=account_id,
             command_id=command_id,
             managed_agent_id=managed_agent_id,
         )
-        if record is None:
-            return None
-        if record.status == "pending":
-            record.status = "failed"
-            record.last_error = error
-            if commit:
-                db.commit()
-        elif record.last_error != error:
-            # Preserve terminal status; only refresh the diagnostic when it
-            # changed so repeated failure marks stay cheap.
-            record.last_error = error
-            if commit:
-                db.commit()
-        return record
 
     def get_undelivered_for_agent(
         self,
@@ -181,6 +209,7 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         *,
         managed_agent_id: Union[uuid.UUID, str],
         now: datetime,
+        account_id: Optional[Union[uuid.UUID, str]] = None,
         limit: int = 100,
     ) -> List[AgentControlCommand]:
         """List pending, unexpired commands for redelivery in send order.
@@ -188,9 +217,11 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         ``limit`` caps how many envelopes are loaded per reconnect so a
         long offline period cannot flood the WebSocket or RAM.
         """
+        query = db.query(AgentControlCommand)
+        if account_id is not None:
+            query = query.filter(AgentControlCommand.account_id == account_id)
         return (
-            db.query(AgentControlCommand)
-            .filter(
+            query.filter(
                 AgentControlCommand.managed_agent_id == managed_agent_id,
                 AgentControlCommand.kind == "command",
                 AgentControlCommand.status == "pending",
@@ -241,18 +272,23 @@ class CRUDAgentControlCommand(CRUDBase[AgentControlCommand]):
         db: Session,
         *,
         now: datetime,
+        account_id: Optional[Union[uuid.UUID, str]] = None,
+        managed_agent_id: Optional[Union[uuid.UUID, str]] = None,
         commit: bool = True,
     ) -> int:
         """Mark pending commands past their expires_at as expired."""
-        expired = (
-            db.query(AgentControlCommand)
-            .filter(
-                AgentControlCommand.status == "pending",
-                AgentControlCommand.expires_at.isnot(None),
-                AgentControlCommand.expires_at <= now,
+        query = db.query(AgentControlCommand)
+        if account_id is not None:
+            query = query.filter(AgentControlCommand.account_id == account_id)
+        if managed_agent_id is not None:
+            query = query.filter(
+                AgentControlCommand.managed_agent_id == managed_agent_id
             )
-            .update({"status": "expired"}, synchronize_session="fetch")
-        )
+        expired = query.filter(
+            AgentControlCommand.status == "pending",
+            AgentControlCommand.expires_at.isnot(None),
+            AgentControlCommand.expires_at <= now,
+        ).update({"status": "expired"}, synchronize_session="fetch")
         if commit:
             db.commit()
         return int(expired)

--- a/backend/preloop/models/crud/agent_control_connection.py
+++ b/backend/preloop/models/crud/agent_control_connection.py
@@ -1,0 +1,156 @@
+"""Short, ownership-guarded control transactions.
+
+Lock order is managed agent, credential, user, then runtime/command rows.
+Callers finish the transaction before socket or broker I/O. A generation is a
+fence for database effects; network delivery remains at least once.
+"""
+
+from dataclasses import dataclass
+import uuid
+
+from sqlalchemy import Connection, event, text
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+
+
+@dataclass(frozen=True)
+class AgentControlConnectionContext:
+    """Immutable scalar identity; no ORM entity crosses a worker boundary."""
+
+    account_id: str
+    managed_agent_id: str
+    runtime_session_id: str
+    session_source_type: str
+    session_source_id: str
+    managed_agent_session_source_type: str
+    managed_agent_session_source_id: str
+    api_key_id: str = ""
+    user_id: str = ""
+    agent_kind: str = ""
+    session_reference: str | None = None
+    runtime_principal_id: str | None = None
+    connection_id: str = ""
+
+
+def configure_transaction(db: Session) -> None:
+    """Bound database waits locally; pool checkout retains its engine timeout."""
+
+    def set_limits(
+        session: Session, transaction: object, connection: Connection
+    ) -> None:
+        if connection.dialect.name == "postgresql":
+            connection.execute(text("SET LOCAL lock_timeout = '1500ms'"))
+            connection.execute(text("SET LOCAL statement_timeout = '5000ms'"))
+
+    event.listen(db, "after_begin", set_limits)
+
+
+def authorize(
+    db: Session, connection: AgentControlConnectionContext, *, claim: bool = False
+) -> models.ManagedAgent | None:
+    """Lock and revalidate the current owner until the caller commits."""
+    agent = (
+        db.query(models.ManagedAgent)
+        .filter(
+            models.ManagedAgent.id == connection.managed_agent_id,
+            models.ManagedAgent.account_id == connection.account_id,
+        )
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+    if agent is None or agent.lifecycle_state != "active":
+        return None
+    if not claim and str(agent.control_connection_id) != connection.connection_id:
+        return None
+    key = (
+        db.query(models.ApiKey)
+        .filter(
+            models.ApiKey.id == connection.api_key_id,
+            models.ApiKey.account_id == connection.account_id,
+            models.ApiKey.user_id == connection.user_id,
+        )
+        .populate_existing()
+        .with_for_update(read=True)
+        .first()
+    )
+    if key is None or not key.is_active or key.is_expired:
+        return None
+    context = key.context_data if isinstance(key.context_data, dict) else {}
+    if str(context.get("managed_agent_id")) != connection.managed_agent_id:
+        return None
+    # Account suspension was historically not checked by runtime auth. Read
+    # it here without a row lock: account lifecycle writers do not share this
+    # lock order. A concurrent suspension may finish after this read, but the
+    # next control unit rejects it (as with the post-authorization I/O window).
+    active_account = (
+        db.query(models.Account.id)
+        .filter(
+            models.Account.id == connection.account_id,
+            models.Account.is_active.is_(True),
+        )
+        .first()
+    )
+    if active_account is None:
+        return None
+    user = (
+        db.query(models.User)
+        .filter(
+            models.User.id == connection.user_id,
+            models.User.account_id == connection.account_id,
+        )
+        .populate_existing()
+        .with_for_update(read=True)
+        .first()
+    )
+    if user is None or not user.is_active:
+        return None
+    if claim:
+        agent.control_connection_id = uuid.UUID(connection.connection_id)
+        agent.runtime_session_id = uuid.UUID(connection.runtime_session_id)
+        db.flush()
+    return agent
+
+
+def retire(db: Session, connection: AgentControlConnectionContext) -> bool:
+    """Clear presence and binding atomically, only for the persisted owner.
+
+    Cleanup is allowed after revocation so the revoked socket can retire its
+    own presence; it can never retire a replacement's generation.
+    """
+    agent = (
+        db.query(models.ManagedAgent)
+        .filter(
+            models.ManagedAgent.id == connection.managed_agent_id,
+            models.ManagedAgent.account_id == connection.account_id,
+        )
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+    if agent is None or str(agent.control_connection_id) != connection.connection_id:
+        return False
+    agent.control_connection_id = None
+    agent.control_last_heartbeat_at = None
+    agent.control_session_mode = None
+    if str(agent.runtime_session_id) == connection.runtime_session_id:
+        agent.runtime_session_id = None
+    db.commit()
+    return True
+
+
+def commit(db: Session) -> None:
+    """Finish an authorized unit without leaking its locks to network I/O."""
+    db.commit()
+
+
+def release_read_transaction(db: Session) -> None:
+    """Release a producer's post-commit reads before a sender needs the pool.
+
+    Do not commit unrelated caller edits. Durable command creation already
+    committed its write; the remaining transaction must only contain reads.
+    """
+    if len(db.new) or len(db.dirty) or len(db.deleted):
+        raise RuntimeError("Cannot release a control producer with pending writes")
+    db.rollback()

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -11,16 +11,18 @@ from sqlalchemy.orm import Session
 
 from preloop.utils.agent_kind import normalize_agent_kind
 
-from ..models.api_usage import ApiUsage
-from ..models.managed_agent import ManagedAgent
-from ..models.runtime_session import RuntimeSession
-from ..models.user import User
+from preloop.models import models
 from .api_usage import (
     EMPTY_CACHE_SPLIT,
     cache_split_columns,
     cache_split_from_row,
 )
 from .base import CRUDBase
+
+ApiUsage = models.ApiUsage
+ManagedAgent = models.ManagedAgent
+RuntimeSession = models.RuntimeSession
+User = models.User
 
 MANAGED_AGENT_ACTIVE_WINDOW = timedelta(minutes=10)
 MANAGED_AGENT_RECENT_WINDOW = timedelta(hours=24)
@@ -576,6 +578,10 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             # reversible and every auth path rejects non-active agents on each
             # request, so dropping the binding here would just make resume
             # unable to restore the agent to its previous state.
+            if lifecycle_state != "active":
+                db_obj.control_connection_id = None
+                db_obj.control_last_heartbeat_at = None
+                db_obj.control_session_mode = None
             if lifecycle_state == "decommissioned":
                 db_obj.runtime_session_id = None
         db.add(db_obj)

--- a/backend/preloop/models/crud/runtime_session_activity.py
+++ b/backend/preloop/models/crud/runtime_session_activity.py
@@ -8,11 +8,13 @@ from typing import Any, Optional
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
-from ..models.managed_agent import ManagedAgent
-from ..models.runtime_session import RuntimeSession
-from ..models.runtime_session_activity import RuntimeSessionActivity
+from preloop.models import models
 from ...utils.jsonb_sanitize import sanitize_for_jsonb
 from .base import CRUDBase
+
+ManagedAgent = models.ManagedAgent
+RuntimeSession = models.RuntimeSession
+RuntimeSessionActivity = models.RuntimeSessionActivity
 
 MAX_AGENT_CONTROL_MESSAGE_SUMMARY_LEN = 2000
 
@@ -204,6 +206,19 @@ class CRUDRuntimeSessionActivity(CRUDBase[RuntimeSessionActivity]):
             .order_by(self.model.timestamp.desc())
             .first()
         )
+        if original is not None and "result_status" in (original.metadata_ or {}):
+            return original
+        previous_result = (
+            db.query(self.model)
+            .filter(
+                self.model.account_id == account_id,
+                self.model.metadata_["command_id"].astext == command_id,
+                self.model.metadata_["source"].astext == "agent_control_result",
+            )
+            .first()
+        )
+        if previous_result is not None:
+            return previous_result
         runtime_session_id = (
             original.runtime_session_id
             if original is not None
@@ -231,11 +246,13 @@ class CRUDRuntimeSessionActivity(CRUDBase[RuntimeSessionActivity]):
             return original
 
         result_metadata = {
+            **(metadata or {}),
+            # Identity and deduplication markers belong to the server. Runtime
+            # metadata must not disguise a result as another activity/command.
             "command_id": command_id,
             "role": "assistant",
             "direction": "agent_to_operator",
             "source": "agent_control_result",
-            **(metadata or {}),
         }
         return self.log_agent_control_message(
             db,

--- a/backend/preloop/models/models/managed_agent.py
+++ b/backend/preloop/models/models/managed_agent.py
@@ -80,6 +80,9 @@ class ManagedAgent(Base):
     # Written only by the Agent Control WebSocket. last_seen_at is stamped by
     # enrollment and by gateway traffic too, so it cannot answer "is the
     # plugin connected" for a process that does not hold the socket.
+    control_connection_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
     control_last_heartbeat_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
 
     account: Mapped["Account"] = relationship(

--- a/backend/preloop/services/ask_user_inband.py
+++ b/backend/preloop/services/ask_user_inband.py
@@ -35,8 +35,11 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from typing import Any, List, Mapping, Optional
 
+from preloop.api.loop_safety import run_db_off_loop
+from preloop.models.crud import agent_control_connection as control_connection
 from preloop.models.crud import (
     crud_agent_control_command,
     crud_managed_agent,
@@ -314,21 +317,23 @@ async def _deliver(
             expires_at=command_expiry,
         )
 
+        # Snapshot all history/delivery identity before ending the producer's
+        # read transaction. The guarded socket sender needs its own connection.
+        delivery_agent_id = str(agent.id)
+        delivery_account_id = str(agent.account_id)
+        history_session_id = runtime_session_id or (
+            str(agent.runtime_session_id) if agent.runtime_session_id else None
+        )
+        await run_db_off_loop(partial(control_connection.release_read_transaction, db))
         subject: Optional[str] = None
         # send_to_agent returns False when this pod does not hold the
         # agent's WebSocket; NATS fan-out below covers peer pods.
         delivered = await manager.send_to_agent(
-            managed_agent_id=str(agent.id), envelope=envelope
+            managed_agent_id=delivery_agent_id, envelope=envelope
         )
-        if delivered:
-            crud_agent_control_command.mark_delivered(
-                db,
-                account_id=str(agent.account_id),
-                command_id=envelope.message_id,
-                managed_agent_id=str(agent.id),
-                delivered_at=datetime.now(UTC),
-            )
-        else:
+        # The accepting socket's sender owns the generation-guarded mark.
+        # A producer must not mark after a replacement wins during delivery.
+        if not delivered:
             # The agent's WebSocket may be held by a peer pod: fan out via
             # NATS and leave the row pending; the holding pod marks delivery.
             subject = await _publish_command_to_peers(envelope)
@@ -336,13 +341,10 @@ async def _deliver(
         reached = delivered or subject is not None
         # Record the audited turn on the ASKING session (not the agent's
         # current binding) so the question shows up in that session's history.
-        history_session_id = runtime_session_id or (
-            str(agent.runtime_session_id) if agent.runtime_session_id else None
-        )
         if history_session_id is not None:
             crud_runtime_session_activity.log_agent_control_message(
                 db,
-                account_id=agent.account_id,
+                account_id=delivery_account_id,
                 runtime_session_id=history_session_id,
                 message=text,
                 status="delivered"
@@ -350,7 +352,7 @@ async def _deliver(
                 else ("queued" if reached else "failed"),
                 metadata={
                     "command_id": envelope.message_id,
-                    "managed_agent_id": str(agent.id),
+                    "managed_agent_id": delivery_agent_id,
                     "kind": QUESTION_NOTICE_KIND,
                     "approval_request_id": str(approval_request_id),
                     "local_delivery": delivered,

--- a/backend/tests/api/test_control_pool_isolation.py
+++ b/backend/tests/api/test_control_pool_isolation.py
@@ -119,7 +119,13 @@ async def test_redelivery_releases_connection_before_socket_send(
         managed_agent_session_source_type="test",
         managed_agent_session_source_id="source",
     )
-    record = MagicMock(command_id="command", envelope={"message_id": "command"})
+    record = MagicMock(
+        command_id="command",
+        envelope={"type": "command", "message_id": "command"},
+        kind="command",
+        status="pending",
+        expires_at=None,
+    )
 
     def load(db: Session, **kwargs: Any) -> list[Any]:
         db.connection()
@@ -132,13 +138,21 @@ async def test_redelivery_releases_connection_before_socket_send(
     monkeypatch.setattr(
         agent_control.crud_agent_control_command, "get_undelivered_for_agent", load
     )
+    monkeypatch.setattr(
+        agent_control.control_connection, "authorize", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        agent_control.crud_agent_control_command,
+        "get_by_command_id",
+        lambda db, **kwargs: load(db)[0],
+    )
     marked = MagicMock()
     monkeypatch.setattr(
-        agent_control.crud_agent_control_command, "mark_delivered_many", marked
+        agent_control.crud_agent_control_command, "mark_delivered", marked
     )
 
     async def send(envelope: dict[str, Any]) -> None:
-        assert envelope == {"message_id": "command"}
+        assert envelope == {"type": "command", "message_id": "command"}
         assert engine.pool.checkedout() == 0
 
     with Session(engine) as dependency:
@@ -187,3 +201,41 @@ async def test_cancelled_control_phase_drains_worker_before_next_phase() -> None
     assert sessions[0] is not sessions[1]
     assert engine.pool.checkedout() == 0
     engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stalled_eviction_close_cannot_pin_global_registration(
+    monkeypatch: Any,
+) -> None:
+    """A dead socket must not prevent unrelated agents from registering."""
+    from preloop.api.endpoints import agent_control as control
+
+    monkeypatch.setattr(control, "EVICTION_CLOSE_TIMEOUT_SECONDS", 0.02)
+    manager = control.AgentControlConnectionManager()
+    close_started = asyncio.Event()
+
+    async def stalled_close(**kwargs: Any) -> None:
+        close_started.set()
+        await asyncio.Event().wait()
+
+    old_socket = AsyncMock()
+    old_socket.close.side_effect = stalled_close
+    await manager.connect(managed_agent_id="synthetic-agent", websocket=old_socket)
+
+    async def register(agent_id: str) -> str:
+        async with manager.registration_lock:
+            return await manager.connect(
+                managed_agent_id=agent_id, websocket=AsyncMock()
+            )
+
+    replacement = asyncio.create_task(register("synthetic-agent"))
+    await asyncio.wait_for(close_started.wait(), 1)
+    unrelated = asyncio.create_task(register("unrelated-agent"))
+    try:
+        await asyncio.wait_for(asyncio.gather(replacement, unrelated), 0.5)
+        assert manager.snapshot("unrelated-agent")["online"]
+        assert manager.snapshot("synthetic-agent")["online"]
+    finally:
+        for task in (replacement, unrelated):
+            task.cancel()
+        await asyncio.gather(replacement, unrelated, return_exceptions=True)

--- a/backend/tests/api/test_control_postgres_acceptance.py
+++ b/backend/tests/api/test_control_postgres_acceptance.py
@@ -503,7 +503,7 @@ async def test_cancelled_persistence_drains_and_replacement_survives_retirement(
                 await task
             assert await next_phase
             assert not await database.run(
-                lambda db: control._retire_control_presence(db, old, datetime.now(UTC))
+                lambda db: control._retire_control_presence(db, old)
             )
         assert engine.pool.checkedout() == 0
     finally:

--- a/backend/tests/api/test_control_postgres_acceptance.py
+++ b/backend/tests/api/test_control_postgres_acceptance.py
@@ -1,0 +1,994 @@
+"""Real PostgreSQL / real WebSocket acceptance for worker-owned control phases.
+
+Run against a migrated disposable database using DATABASE_URL. No external
+broker, notification, agent, or paid model is contacted.
+"""
+
+import asyncio
+from contextlib import AsyncExitStack
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime, timedelta
+import json
+import socket
+import threading
+import time
+from typing import Any, Iterator
+from uuid import uuid4
+
+import httpx
+import pytest
+import uvicorn
+import websockets
+from fastapi import FastAPI
+from sqlalchemy import Engine, create_engine, event, text
+from sqlalchemy.orm import Session
+from unittest.mock import AsyncMock
+
+from preloop.api.auth.jwt import create_refresh_token
+from preloop.api.auth.router import router as auth_router
+from preloop.api.endpoints import agent_control as control, health
+from preloop.models import models
+from preloop.models.crud import crud_agent_control_command, crud_managed_agent
+from preloop.models.crud import agent_control_connection as ownership
+from preloop.models.db.session import get_db_session
+from preloop.schemas.agent_control import AgentControlInboundEnvelope
+
+
+@dataclass(frozen=True)
+class Principal:
+    token: str
+    connection: ownership.AgentControlConnectionContext
+
+
+@pytest.fixture
+def principal(db_engine: Engine) -> Iterator[list[Principal]]:
+    assert db_engine.dialect.name == "postgresql", "Acceptance requires PostgreSQL"
+    principals = []
+    account_id = uuid4()
+    with Session(db_engine) as db:
+        account = models.Account(id=account_id, organization_name="Control acceptance")
+        user = models.User(
+            id=uuid4(),
+            account_id=account_id,
+            email=f"{uuid4()}@example.com",
+            username=str(uuid4()),
+            hashed_password="synthetic",
+            is_active=True,
+        )
+        db.add_all([account, user])
+        db.flush()
+        for _ in range(4):
+            source = str(uuid4())
+            runtime = models.RuntimeSession(
+                id=uuid4(),
+                account_id=account_id,
+                session_source_type="openclaw",
+                session_source_id=source,
+                started_at=datetime.now(UTC),
+                last_activity_at=datetime.now(UTC),
+            )
+            db.add(runtime)
+            db.flush()
+            agent = models.ManagedAgent(
+                id=uuid4(),
+                account_id=account_id,
+                runtime_session_id=runtime.id,
+                agent_kind="openclaw",
+                session_source_type="openclaw",
+                session_source_id=source,
+                display_name="Synthetic control agent",
+                lifecycle_state="active",
+                lifecycle_updated_at=datetime.now(UTC),
+                last_seen_at=datetime.now(UTC),
+            )
+            db.add(agent)
+            db.flush()
+            token = f"synthetic-{uuid4()}"
+            key = models.ApiKey(
+                id=uuid4(),
+                account_id=account_id,
+                user_id=user.id,
+                name=str(uuid4()),
+                key=token,
+                is_active=True,
+                scopes=[],
+                context_data={
+                    "managed_agent_id": str(agent.id),
+                    "runtime_session_id": str(runtime.id),
+                },
+            )
+            db.add(key)
+            principals.append(
+                Principal(
+                    token,
+                    ownership.AgentControlConnectionContext(
+                        account_id=str(account_id),
+                        user_id=str(user.id),
+                        api_key_id=str(key.id),
+                        managed_agent_id=str(agent.id),
+                        runtime_session_id=str(runtime.id),
+                        agent_kind="openclaw",
+                        session_source_type="openclaw",
+                        session_source_id=source,
+                        managed_agent_session_source_type="openclaw",
+                        managed_agent_session_source_id=source,
+                        connection_id=str(uuid4()),
+                    ),
+                )
+            )
+        db.commit()
+    try:
+        yield principals
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.Account).filter_by(id=account_id).delete()
+            db.commit()
+
+
+@dataclass
+class Server:
+    url: str
+    engine: Engine
+
+
+@pytest.fixture
+def control_server(db_engine: Engine, monkeypatch: Any) -> Iterator[Server]:
+    engine = create_engine(db_engine.url, pool_size=2, max_overflow=0, pool_timeout=2)
+    monkeypatch.setattr(
+        control, "agent_control_manager", control.AgentControlConnectionManager()
+    )
+    monkeypatch.setattr(control, "get_nats_client", AsyncMock(return_value=None))
+    monkeypatch.setattr(control, "emit_account_event", lambda *args, **kwargs: None)
+    app = FastAPI()
+    app.include_router(control.router)
+    app.include_router(health.router)
+    app.include_router(auth_router)
+
+    def dependency() -> Iterator[Session]:
+        with Session(engine) as db:
+            yield db
+
+    app.dependency_overrides[get_db_session] = dependency
+
+    @app.get("/auth")
+    async def auth(token: str) -> dict[str, str]:
+        with Session(engine) as dependency:
+            identity = await control._ControlDatabase(dependency).run(
+                lambda db: control._load_control_identity(db, token)
+            )
+        assert all(
+            value is None or isinstance(value, str)
+            for value in asdict(identity).values()
+        )
+        return {"account_id": identity.account_id}
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off"))
+    thread = threading.Thread(
+        target=server.run, kwargs={"sockets": [listener]}, daemon=True
+    )
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert server.started
+    try:
+        yield Server(f"127.0.0.1:{listener.getsockname()[1]}", engine)
+    finally:
+        server.should_exit = True
+        thread.join(5)
+        assert not thread.is_alive()
+        engine.dispose()
+
+
+async def connect(server: Server, principal: Principal) -> Any:
+    ws = await websockets.connect(
+        f"ws://{server.url}/agents/control/ws",
+        additional_headers={"Authorization": f"Bearer {principal.token}"},
+    )
+    assert json.loads(await asyncio.wait_for(ws.recv(), 3))["name"] == "connected"
+    return ws
+
+
+async def heartbeat(ws: Any) -> None:
+    message_id = str(uuid4())
+    await ws.send(
+        json.dumps({"type": "heartbeat", "message_id": message_id, "payload": {}})
+    )
+    result = json.loads(await asyncio.wait_for(ws.recv(), 3))
+    assert result["type"] == "ack" and result["message_id"] == message_id
+
+
+async def pool_idle(engine: Engine) -> None:
+    deadline = asyncio.get_running_loop().time() + 3
+    while engine.pool.checkedout() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    assert engine.pool.checkedout() == 0
+
+
+def persist_command(db_engine: Engine, principal: Principal) -> str:
+    command_id = str(uuid4())
+    with Session(db_engine) as db:
+        crud_agent_control_command.create_command(
+            db,
+            account_id=principal.connection.account_id,
+            managed_agent_id=principal.connection.managed_agent_id,
+            runtime_session_id=principal.connection.runtime_session_id,
+            command_id=command_id,
+            envelope={
+                "type": "command",
+                "name": "send_message",
+                "message_id": command_id,
+                "payload": {"text": "Synthetic instruction"},
+            },
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+    return command_id
+
+
+@pytest.mark.asyncio
+async def test_pool_two_serves_four_idle_authenticated_sockets_and_auth(
+    control_server: Server, principal: list[Principal]
+) -> None:
+    async with AsyncExitStack() as stack:
+        sockets = [
+            await stack.enter_async_context(await connect(control_server, p))
+            for p in principal
+        ]
+        await pool_idle(control_server.engine)
+        assert control_server.engine.pool.size() == 2
+        async with httpx.AsyncClient(base_url=f"http://{control_server.url}") as client:
+            assert (await client.get("/ping")).status_code == 200
+            assert (
+                await client.get("/auth", params={"token": principal[0].token})
+            ).status_code == 200
+            assert (
+                await client.post(
+                    "/refresh",
+                    json={
+                        "refresh_token": create_refresh_token(
+                            sub=principal[0].connection.user_id, scopes=[]
+                        )
+                    },
+                )
+            ).status_code == 200
+        for ws in sockets:
+            await heartbeat(ws)
+            await pool_idle(control_server.engine)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message_kind", ["heartbeat", "ack"])
+async def test_independent_row_lock_is_bounded_and_other_socket_http_progress(
+    control_server: Server,
+    principal: list[Principal],
+    db_engine: Engine,
+    message_kind: str,
+) -> None:
+    ws = await connect(control_server, principal[0])
+    other = await connect(control_server, principal[1])
+    command_id = persist_command(db_engine, principal[0])
+    requested_lock = threading.Event()
+
+    def before_execute(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if (
+            message_kind == "heartbeat"
+            and "FROM managed_agent" in statement
+            and "FOR UPDATE" in statement
+        ):
+            requested_lock.set()
+        if message_kind == "ack" and statement.lower().startswith(
+            "update agent_control_command"
+        ):
+            requested_lock.set()
+
+    event.listen(control_server.engine, "before_cursor_execute", before_execute)
+    try:
+        with Session(db_engine) as blocker:
+            if message_kind == "heartbeat":
+                blocker.query(models.ManagedAgent).filter_by(
+                    id=principal[0].connection.managed_agent_id
+                ).with_for_update().one()
+            else:
+                blocker.query(models.AgentControlCommand).filter_by(
+                    command_id=command_id
+                ).with_for_update().one()
+            start = time.monotonic()
+            await ws.send(
+                json.dumps(
+                    {"type": "heartbeat"}
+                    if message_kind == "heartbeat"
+                    else {
+                        "type": "status",
+                        "name": "command_ack",
+                        "payload": {"command_id": command_id},
+                    }
+                )
+            )
+            assert await asyncio.to_thread(requested_lock.wait, 2)
+            async with httpx.AsyncClient(
+                base_url=f"http://{control_server.url}"
+            ) as client:
+                assert (
+                    await asyncio.wait_for(client.get("/ping"), 0.8)
+                ).status_code == 200
+                assert (
+                    await asyncio.wait_for(
+                        client.get("/auth", params={"token": principal[1].token}), 0.8
+                    )
+                ).status_code == 200
+                assert (
+                    await asyncio.wait_for(
+                        client.post(
+                            "/refresh",
+                            json={
+                                "refresh_token": create_refresh_token(
+                                    sub=principal[1].connection.user_id, scopes=[]
+                                )
+                            },
+                        ),
+                        0.8,
+                    )
+                ).status_code == 200
+            await asyncio.wait_for(heartbeat(other), 0.8)
+            with pytest.raises(websockets.exceptions.ConnectionClosed) as closed:
+                await asyncio.wait_for(ws.recv(), 4)
+            assert closed.value.rcvd.code == 1013
+            assert time.monotonic() - start < 3
+        await pool_idle(control_server.engine)
+        with control_server.engine.connect() as conn:
+            assert conn.execute(text("SHOW lock_timeout")).scalar() == "0"
+        replacement = await connect(control_server, principal[0])
+        # Pending command is replayed after the handshake.
+        assert json.loads(await replacement.recv())["message_id"] == command_id
+        await heartbeat(replacement)
+        await replacement.close()
+    finally:
+        event.remove(control_server.engine, "before_cursor_execute", before_execute)
+        await ws.close()
+        await other.close()
+
+
+@pytest.mark.asyncio
+async def test_distinct_managers_replacement_fences_stale_ack_and_disconnect(
+    control_server: Server,
+    principal: list[Principal],
+    db_engine: Engine,
+    monkeypatch: Any,
+) -> None:
+    old = await connect(control_server, principal[0])
+    monkeypatch.setattr(
+        control, "agent_control_manager", control.AgentControlConnectionManager()
+    )
+    new = await connect(control_server, principal[0])
+    await heartbeat(new)
+    command_id = persist_command(db_engine, principal[0])
+    await old.send(
+        json.dumps(
+            {
+                "type": "status",
+                "name": "command_ack",
+                "payload": {"command_id": command_id},
+            }
+        )
+    )
+    with pytest.raises(websockets.exceptions.ConnectionClosed) as closed:
+        await asyncio.wait_for(old.recv(), 3)
+    assert closed.value.rcvd.code == control.EVICTION_CLOSE_CODE
+    await heartbeat(new)
+    with Session(db_engine) as db:
+        agent = db.get(models.ManagedAgent, principal[0].connection.managed_agent_id)
+        assert (
+            agent.runtime_session_id is not None
+            and agent.control_last_heartbeat_at is not None
+        )
+        assert (
+            crud_agent_control_command.get_by_command_id(
+                db, account_id=principal[0].connection.account_id, command_id=command_id
+            ).status
+            == "pending"
+        )
+    for _ in range(2):
+        await new.send(
+            json.dumps(
+                {
+                    "type": "status",
+                    "name": "command_ack",
+                    "payload": {"command_id": command_id},
+                }
+            )
+        )
+    await heartbeat(new)
+    with Session(db_engine) as db:
+        assert (
+            crud_agent_control_command.get_by_command_id(
+                db, account_id=principal[0].connection.account_id, command_id=command_id
+            ).status
+            == "acked"
+        )
+    await new.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change",
+    ["revoke", "suspended", "decommissioned", "inactive_user", "inactive_account"],
+)
+async def test_live_socket_revalidates_credential_and_lifecycle(
+    control_server: Server, principal: list[Principal], db_engine: Engine, change: str
+) -> None:
+    ws = await connect(control_server, principal[0])
+    command_id = persist_command(db_engine, principal[0])
+    identity = principal[0].connection
+    with Session(db_engine) as db:
+        if change == "revoke":
+            db.get(models.ApiKey, identity.api_key_id).is_active = False
+        elif change == "inactive_user":
+            db.get(models.User, identity.user_id).is_active = False
+        elif change == "inactive_account":
+            db.get(models.Account, identity.account_id).is_active = False
+        else:
+            crud_managed_agent.update_operator_state(
+                db,
+                account_id=identity.account_id,
+                agent_id=identity.managed_agent_id,
+                lifecycle_state=change,
+            )
+        db.commit()
+    await ws.send(
+        json.dumps(
+            {
+                "type": "status",
+                "name": "command_ack",
+                "payload": {"command_id": command_id},
+            }
+        )
+    )
+    with pytest.raises(websockets.exceptions.ConnectionClosed):
+        await asyncio.wait_for(ws.recv(), 3)
+    with Session(db_engine) as db:
+        assert (
+            crud_agent_control_command.get_by_command_id(
+                db, account_id=identity.account_id, command_id=command_id
+            ).status
+            == "pending"
+        )
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_persistence_drains_and_replacement_survives_retirement(
+    db_engine: Engine, principal: list[Principal]
+) -> None:
+    engine = create_engine(db_engine.url, pool_size=2, max_overflow=0)
+    old = principal[0].connection
+    replacement = replace(old, connection_id=str(uuid4()))
+    entered = threading.Event()
+    released = threading.Event()
+    sessions = []
+
+    def phase(db: Session) -> None:
+        sessions.append(db)
+        assert control._claim_control_connection(db, old, datetime.now(UTC))
+        assert ownership.authorize(db, old) is not None
+        entered.set()
+        assert released.wait(3)
+        control._touch_presence(db, old, observed_at=datetime.now(UTC))
+
+    try:
+        with Session(engine) as dependency:
+            database = control._ControlDatabase(dependency)
+            task = asyncio.create_task(database.run(phase))
+            assert await asyncio.to_thread(entered.wait, 2)
+            task.cancel()
+            next_phase = asyncio.create_task(
+                database.run(
+                    lambda db: control._claim_control_connection(
+                        db, replacement, datetime.now(UTC)
+                    )
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not task.done() and not next_phase.done()
+            released.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert await next_phase
+            assert not await database.run(
+                lambda db: control._retire_control_presence(db, old, datetime.now(UTC))
+            )
+        assert engine.pool.checkedout() == 0
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_broker_callback_rechecks_replacement_and_revocation(
+    db_engine: Engine, principal: list[Principal], monkeypatch: Any
+) -> None:
+    identity = principal[0].connection
+    command_id = persist_command(db_engine, principal[0])
+    callbacks = []
+
+    class Broker:
+        is_connected = True
+
+        async def subscribe(self, subject: str, cb: Any) -> object:
+            callbacks.append(cb)
+            return object()
+
+    monkeypatch.setattr(control, "get_nats_client", AsyncMock(return_value=Broker()))
+    websocket = AsyncMock()
+    with Session(db_engine) as dependency:
+        database = control._ControlDatabase(dependency)
+        assert await database.run(
+            lambda db: control._claim_control_connection(
+                db, identity, datetime.now(UTC)
+            )
+        )
+        await control._subscribe_to_commands(
+            managed_agent_id=identity.managed_agent_id,
+            websocket=websocket,
+            database=database,
+            account_id=identity.account_id,
+            connection=identity,
+        )
+        new = replace(identity, connection_id=str(uuid4()))
+        assert await database.run(
+            lambda db: control._claim_control_connection(db, new, datetime.now(UTC))
+        )
+        from types import SimpleNamespace
+
+        notification = SimpleNamespace(
+            data=json.dumps({"type": "command", "message_id": command_id}).encode()
+        )
+        await callbacks[0](notification)
+        websocket.send_json.assert_not_awaited()
+        with Session(db_engine) as db:
+            assert (
+                crud_agent_control_command.get_by_command_id(
+                    db, account_id=identity.account_id, command_id=command_id
+                ).status
+                == "pending"
+            )
+        await control._subscribe_to_commands(
+            managed_agent_id=new.managed_agent_id,
+            websocket=websocket,
+            database=database,
+            account_id=new.account_id,
+            connection=new,
+        )
+        with Session(db_engine) as db:
+            db.get(models.ApiKey, identity.api_key_id).is_active = False
+            db.commit()
+        await callbacks[1](notification)
+        websocket.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replacement_during_send_cannot_mark_delivery(
+    db_engine: Engine, principal: list[Principal]
+) -> None:
+    identity = principal[0].connection
+    replacement = replace(identity, connection_id=str(uuid4()))
+    command_id = persist_command(db_engine, principal[0])
+    engine = create_engine(db_engine.url, pool_size=2, max_overflow=0)
+    try:
+        with Session(engine) as dependency:
+            database = control._ControlDatabase(dependency)
+            assert await database.run(
+                lambda db: control._claim_control_connection(
+                    db, identity, datetime.now(UTC)
+                )
+            )
+
+            async def send(payload: dict[str, Any]) -> None:
+                assert engine.pool.checkedout() == 0
+                assert payload["payload"]["text"] == "Synthetic instruction"
+                assert await database.run(
+                    lambda db: control._claim_control_connection(
+                        db, replacement, datetime.now(UTC)
+                    )
+                )
+
+            assert await control._send_control_command(
+                database,
+                identity,
+                AsyncMock(send_json=send),
+                {
+                    "type": "command",
+                    "message_id": command_id,
+                    "payload": {"text": "Untrusted broker content"},
+                },
+            )
+        with Session(db_engine) as db:
+            assert (
+                crud_agent_control_command.get_by_command_id(
+                    db, account_id=identity.account_id, command_id=command_id
+                ).status
+                == "pending"
+            )
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_broker_failure_does_not_break_presence_or_pending_replay(
+    control_server: Server,
+    principal: list[Principal],
+    db_engine: Engine,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        control,
+        "get_nats_client",
+        AsyncMock(side_effect=OSError("Synthetic broker unavailable")),
+    )
+    command_id = persist_command(db_engine, principal[0])
+    ws = await connect(control_server, principal[0])
+    assert json.loads(await asyncio.wait_for(ws.recv(), 3))["message_id"] == command_id
+    await heartbeat(ws)
+    await ws.close()
+    await pool_idle(control_server.engine)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_write_preserves_replacement(
+    control_server: Server,
+    principal: list[Principal],
+    db_engine: Engine,
+    monkeypatch: Any,
+) -> None:
+    old = await connect(control_server, principal[0])
+    await heartbeat(old)
+    requested = threading.Event()
+
+    def before_execute(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if "FROM managed_agent" in statement and "FOR UPDATE" in statement:
+            requested.set()
+
+    event.listen(control_server.engine, "before_cursor_execute", before_execute)
+    try:
+        with Session(db_engine) as blocker:
+            blocker.query(models.ManagedAgent).filter_by(
+                id=principal[0].connection.managed_agent_id
+            ).with_for_update().one()
+            await old.send(json.dumps({"type": "heartbeat"}))
+            assert await asyncio.to_thread(requested.wait, 2)
+            closing = asyncio.create_task(old.close())
+            monkeypatch.setattr(
+                control,
+                "agent_control_manager",
+                control.AgentControlConnectionManager(),
+            )
+            replacing = asyncio.create_task(connect(control_server, principal[0]))
+            await asyncio.sleep(0.05)
+        new = await asyncio.wait_for(replacing, 3)
+        await asyncio.wait_for(closing, 3)
+        await heartbeat(new)
+        await pool_idle(control_server.engine)
+        with Session(db_engine) as db:
+            agent = db.get(
+                models.ManagedAgent, principal[0].connection.managed_agent_id
+            )
+            assert agent.control_connection_id is not None
+            assert agent.control_last_heartbeat_at is not None
+            assert (
+                str(agent.runtime_session_id)
+                == principal[0].connection.runtime_session_id
+            )
+        await new.close()
+    finally:
+        event.remove(control_server.engine, "before_cursor_execute", before_execute)
+        await old.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_identity_churn_keeps_durable_credential_valid(
+    control_server: Server, principal: list[Principal], db_engine: Engine
+) -> None:
+    ws = await connect(control_server, principal[0])
+    identity = principal[0].connection
+    with Session(db_engine) as db:
+        db.get(
+            models.RuntimeSession, identity.runtime_session_id
+        ).ended_at = datetime.now(UTC)
+        db.commit()
+    await heartbeat(ws)
+    await ws.close()
+    replacement = await connect(control_server, principal[0])
+    await heartbeat(replacement)
+    with Session(db_engine) as db:
+        assert db.get(models.ApiKey, identity.api_key_id).is_active
+        assert (
+            db.get(models.RuntimeSession, identity.runtime_session_id).ended_at is None
+        )
+    await replacement.close()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_out_of_order_results_and_peer_commands_are_isolated(
+    db_engine: Engine, principal: list[Principal]
+) -> None:
+    identity = principal[0].connection
+    command_id = persist_command(db_engine, principal[0])
+    peer_command_id = persist_command(db_engine, principal[1])
+    with Session(db_engine) as dependency:
+        database = control._ControlDatabase(dependency)
+        assert await database.run(
+            lambda db: control._claim_control_connection(
+                db, identity, datetime.now(UTC)
+            )
+        )
+        for name, command, reply in [
+            ("command_result", command_id, "First result"),
+            ("command_error", command_id, "Late error"),
+            ("command_ack", command_id, ""),
+            ("command_result", peer_command_id, "Peer injection"),
+        ]:
+            inbound = AgentControlInboundEnvelope(
+                type="status",
+                name=name,
+                payload={"command_id": command, "reply_text": reply},
+            )
+            assert await database.run(
+                lambda db, inbound=inbound: control._process_control_message(
+                    db, identity, inbound, datetime.now(UTC)
+                )
+            )
+    with Session(db_engine) as db:
+        activities = (
+            db.query(models.RuntimeSessionActivity)
+            .filter(
+                models.RuntimeSessionActivity.account_id == identity.account_id,
+                models.RuntimeSessionActivity.metadata_["source"].astext
+                == "agent_control_result",
+            )
+            .all()
+        )
+        assert len(activities) == 1
+        assert activities[0].metadata_["command_id"] == command_id
+        assert (
+            crud_agent_control_command.get_by_command_id(
+                db, account_id=identity.account_id, command_id=peer_command_id
+            ).status
+            == "pending"
+        )
+
+
+@pytest.mark.parametrize("late_mark", ["delivery", "failure", "ack"])
+def test_stale_worker_cannot_regress_terminal_command(
+    db_engine: Engine, principal: list[Principal], late_mark: str
+) -> None:
+    command_id = persist_command(db_engine, principal[0])
+    identity = principal[0].connection
+    with Session(db_engine) as stale:
+        cached = crud_agent_control_command.get_by_command_id(
+            stale, account_id=identity.account_id, command_id=command_id
+        )
+        assert cached.status == "pending"
+        with Session(db_engine) as current:
+            crud_agent_control_command.mark_acked(
+                current,
+                account_id=identity.account_id,
+                managed_agent_id=identity.managed_agent_id,
+                command_id=command_id,
+                acked_at=datetime.now(UTC),
+            )
+        if late_mark == "failure":
+            result = crud_agent_control_command.mark_failed(
+                stale,
+                account_id=identity.account_id,
+                command_id=command_id,
+                error="Delayed broker failure",
+            )
+        elif late_mark == "delivery":
+            result = crud_agent_control_command.mark_delivered(
+                stale,
+                account_id=identity.account_id,
+                command_id=command_id,
+                delivered_at=datetime.now(UTC),
+            )
+        else:
+            result = crud_agent_control_command.mark_acked(
+                stale,
+                account_id=identity.account_id,
+                command_id=command_id,
+                acked_at=datetime.now(UTC),
+            )
+        assert result.status == "acked"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("producer", ["question", "prompt", "action"])
+async def test_two_producers_release_pool_before_guarded_senders(
+    db_engine: Engine, principal: list[Principal], monkeypatch: Any, producer: str
+) -> None:
+    """Two pending sends must not consume the entire pool needed by their senders."""
+    from types import SimpleNamespace
+
+    from preloop.schemas.agent_control import (
+        AgentControlSendMessageRequest,
+        AgentControlSessionActionRequest,
+    )
+    from preloop.services import ask_user_inband
+
+    engine = create_engine(db_engine.url, pool_size=2, max_overflow=0, pool_timeout=1)
+    manager = control.AgentControlConnectionManager()
+    sockets = []
+    dependencies = []
+    for p in principal[:2]:
+        with Session(db_engine) as db:
+            assert control._claim_control_connection(
+                db, p.connection, datetime.now(UTC)
+            )
+        dependency = Session(engine)
+        dependencies.append(dependency)
+        database = control._ControlDatabase(dependency)
+        socket = AsyncMock()
+        sockets.append(socket)
+
+        async def sender(
+            payload: dict[str, Any],
+            database: control._ControlDatabase = database,
+            p: Principal = p,
+            socket: Any = socket,
+        ) -> bool:
+            return await control._send_control_command(
+                database, p.connection, socket, payload
+            )
+
+        await manager.connect(
+            managed_agent_id=p.connection.managed_agent_id,
+            websocket=socket,
+            sender=sender,
+        )
+    real_send = manager.send_to_agent
+    arrivals = 0
+    barrier = asyncio.Event()
+
+    async def synchronized_send(**kwargs: Any) -> bool:
+        nonlocal arrivals
+        arrivals += 1
+        if arrivals == 2:
+            assert engine.pool.checkedout() == 0
+            barrier.set()
+        await asyncio.wait_for(barrier.wait(), 3)
+        return await real_send(**kwargs)
+
+    monkeypatch.setattr(manager, "send_to_agent", synchronized_send)
+    monkeypatch.setattr(control, "agent_control_manager", manager)
+    monkeypatch.setattr(control, "_agent_has_control_config", lambda *a, **kw: True)
+    monkeypatch.setattr(control, "emit_account_event", lambda *a, **kw: None)
+    monkeypatch.setattr(control, "_publish_command", AsyncMock(return_value=None))
+    monkeypatch.setattr(ask_user_inband, "_agent_control_manager", lambda: manager)
+    monkeypatch.setattr(
+        ask_user_inband, "get_db_session", lambda: iter([Session(engine)])
+    )
+    monkeypatch.setattr(
+        ask_user_inband, "_publish_command_to_peers", AsyncMock(return_value=None)
+    )
+
+    async def produce(p: Principal) -> bool:
+        identity = p.connection
+        if producer == "question":
+            return await ask_user_inband._deliver(
+                account_id=identity.account_id,
+                approval_request_id=uuid4(),
+                tool_name="ask_user",
+                arguments={"question": "Synthetic question"},
+                console_url="https://example.com/approval",
+                mobile_link="preloop://approve/synthetic",
+                runtime_session_id=identity.runtime_session_id,
+                managed_agent_id=identity.managed_agent_id,
+                user_id=identity.user_id,
+                expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            )
+        with Session(engine) as db:
+            user = SimpleNamespace(id=identity.user_id, account_id=identity.account_id)
+            if producer == "prompt":
+                response = await control._route_managed_agent_prompt(
+                    agent_id=identity.managed_agent_id,
+                    request=AgentControlSendMessageRequest(message="Synthetic prompt"),
+                    current_user=user,
+                    db=db,
+                )
+            else:
+                response = await control._route_session_action(
+                    agent_id=identity.managed_agent_id,
+                    request=AgentControlSessionActionRequest(),
+                    current_user=user,
+                    db=db,
+                    name="request_takeover",
+                )
+            return response.local_delivery
+
+    try:
+        assert await asyncio.gather(*(produce(p) for p in principal[:2])) == [
+            True,
+            True,
+        ]
+        assert [socket.send_json.await_count for socket in sockets] == [1, 1]
+        assert engine.pool.checkedout() == 0
+    finally:
+        for dependency in dependencies:
+            dependency.close()
+        engine.dispose()
+
+
+def test_producer_release_does_not_commit_or_discard_pending_changes(
+    db_engine: Engine, principal: list[Principal]
+) -> None:
+    identity = principal[0].connection
+    with Session(db_engine) as db:
+        agent = db.get(models.ManagedAgent, identity.managed_agent_id)
+        agent.display_name = "Unrelated pending edit"
+        with pytest.raises(RuntimeError, match="pending writes"):
+            ownership.release_read_transaction(db)
+        assert agent in db.dirty
+        db.rollback()
+    with Session(db_engine) as db:
+        assert db.get(models.ManagedAgent, identity.managed_agent_id).display_name != (
+            "Unrelated pending edit"
+        )
+
+
+@pytest.mark.asyncio
+async def test_result_idempotency_markers_cannot_be_overridden_by_client_metadata(
+    db_engine: Engine, principal: list[Principal]
+) -> None:
+    identity = principal[0].connection
+    command_id = persist_command(db_engine, principal[0])
+    with Session(db_engine) as dependency:
+        database = control._ControlDatabase(dependency)
+        assert await database.run(
+            lambda db: control._claim_control_connection(
+                db, identity, datetime.now(UTC)
+            )
+        )
+        for _ in range(3):
+            inbound = AgentControlInboundEnvelope(
+                type="status",
+                name="command_result",
+                payload={
+                    "command_id": f" {command_id} ",
+                    "reply_text": "Synthetic result",
+                    "source": "runtime-client",
+                    "role": "user",
+                    "direction": "operator_to_agent",
+                    "client_note": "preserved",
+                },
+            )
+            assert await database.run(
+                lambda db, inbound=inbound: control._process_control_message(
+                    db, identity, inbound, datetime.now(UTC)
+                )
+            )
+    with Session(db_engine) as db:
+        activities = (
+            db.query(models.RuntimeSessionActivity)
+            .filter(models.RuntimeSessionActivity.account_id == identity.account_id)
+            .all()
+        )
+        assert len(activities) == 1
+        metadata = activities[0].metadata_
+        assert metadata["command_id"] == command_id
+        assert metadata["source"] == "agent_control_result"
+        assert metadata["direction"] == "agent_to_operator"
+        assert metadata["role"] == "assistant"
+        assert metadata["client_note"] == "preserved"

--- a/backend/tests/endpoints/test_agent_control.py
+++ b/backend/tests/endpoints/test_agent_control.py
@@ -564,6 +564,20 @@ def test_agent_control_ws_command_result_is_persisted(
     assert runtime_session is not None
     assert managed_agent is not None
 
+    crud_agent_control_command.create_command(
+        db_session,
+        account_id=test_user.account_id,
+        managed_agent_id=managed_agent.id,
+        runtime_session_id=runtime_session.id,
+        command_id="cmd-result-1",
+        envelope={"type": "command", "message_id": "cmd-result-1"},
+    )
+    crud_agent_control_command.mark_delivered(
+        db_session,
+        account_id=test_user.account_id,
+        command_id="cmd-result-1",
+        delivered_at=datetime.now(UTC),
+    )
     crud_runtime_session_activity.log_agent_control_message(
         db_session,
         account_id=test_user.account_id,

--- a/backend/tests/endpoints/test_agent_control_lock_order.py
+++ b/backend/tests/endpoints/test_agent_control_lock_order.py
@@ -12,7 +12,7 @@ from sqlalchemy import Engine, event, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
-from preloop.api.auth.jwt import RuntimeBearerAuthContext
+from preloop.models.crud.agent_control_connection import AgentControlConnectionContext
 from preloop.api.endpoints.agent_control import _touch_presence
 from preloop.models import models
 from preloop.models.crud import crud_managed_agent, crud_runtime_session
@@ -74,11 +74,14 @@ def test_heartbeat_does_not_hold_runtime_while_waiting_for_operator_agent_lock(
             runtime = db.get(models.RuntimeSession, runtime_id)
             agent = db.get(models.ManagedAgent, agent_id)
             assert runtime is not None and agent is not None
-            context = RuntimeBearerAuthContext(
-                user=models.User(),
-                api_key=None,
-                runtime_session=runtime,
-                managed_agent=agent,
+            context = AgentControlConnectionContext(
+                account_id=str(account_id),
+                runtime_session_id=str(runtime_id),
+                managed_agent_id=str(agent_id),
+                session_source_type="test",
+                session_source_id=agent.session_source_id,
+                managed_agent_session_source_type="test",
+                managed_agent_session_source_id=agent.session_source_id,
             )
 
             def before_update(

--- a/backend/tests/endpoints/test_agent_control_persistence.py
+++ b/backend/tests/endpoints/test_agent_control_persistence.py
@@ -121,6 +121,14 @@ def test_command_is_persisted_before_delivery_and_marked_delivered(
             command_id=envelope.message_id,
         )
         observed_status["at_delivery_time"] = record.status if record else None
+        # Production manager delegates delivery persistence to its guarded sender.
+        crud_agent_control_command.mark_delivered(
+            db_session,
+            account_id=test_user.account_id,
+            managed_agent_id=managed_agent_id,
+            command_id=envelope.message_id,
+            delivered_at=datetime.now(UTC),
+        )
         return True
 
     with patch(

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -178,4 +178,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert audit_chain.down_revision == "20260910_retention_hold"
     operator_notes = script.get_revision("20260910_operator_notes")
     assert operator_notes.down_revision == "20260910_audit_chain"
-    assert script.get_heads() == ["20260910_operator_notes"]
+    control_connection = script.get_revision("20260912_control_connection")
+    assert control_connection.down_revision == "20260910_operator_notes"
+    assert script.get_heads() == ["20260912_control_connection"]

--- a/backend/tests/services/test_ask_user_inband.py
+++ b/backend/tests/services/test_ask_user_inband.py
@@ -221,7 +221,7 @@ class TestDeliverQuestionToSession:
             )
         return result, mock_create, mock_delivered, mock_activity
 
-    async def test_local_delivery_marks_delivered_and_logs_turn(self):
+    async def test_local_delivery_leaves_mark_to_guarded_sender_and_logs_turn(self):
         account_id = uuid.uuid4()
         agent = self._agent(account_id)
         manager, db, patches = self._patched_env(agent, send_result=True)
@@ -236,7 +236,7 @@ class TestDeliverQuestionToSession:
         assert envelope["name"] == "send_message"
         assert envelope["payload"]["metadata"]["kind"] == QUESTION_NOTICE_KIND
         assert "Ship it?" in envelope["payload"]["text"]
-        mock_delivered.assert_called_once()
+        mock_delivered.assert_not_called()
         mock_activity.assert_called_once()
         assert mock_activity.call_args.kwargs["status"] == "delivered"
 

--- a/docs/architecture/agent-control.md
+++ b/docs/architecture/agent-control.md
@@ -3,13 +3,57 @@
 Agent Control is the audited operator channel to managed agents such as OpenClaw and Hermes. This chapter covers the control WebSocket, CLI/desktop enrollment, and mobile/watch voice contact.
 
 The control WebSocket runs authentication, heartbeat, command persistence and
-disconnect cleanup in short worker-thread database sessions. It detaches identity
-fields and copies command envelopes before socket or NATS waits, so an idle socket
-does not reserve a database connection. Delivery callbacks use separate sessions;
-DB phases for a connection are serialized and cancellation drains the active
-worker before releasing that serialization lock. Database capacity errors remain
-transient failures rather than invalid credentials. API readiness detects an
-unresponsive pod before the database-independent liveness restart window.
+disconnect cleanup in short worker-owned database sessions. Only frozen scalar
+identity and copied command envelopes leave a worker; no ORM object crosses the
+thread boundary. Idle sockets do not reserve database connections. Each socket's
+DB phases are serialized, and cancellation drains its active worker before
+another phase starts. Socket and NATS I/O happen after the session closes.
+
+A nullable `managed_agent.control_connection_id` UUID records the current socket
+generation independently of its durable runtime identity session. Every inbound
+message and every delivery read/mark locks the managed agent, then checks the
+current generation, active credential, active account/owner and agent lifecycle before
+runtime or command writes. Suspending or decommissioning invalidates the
+generation. Disconnect clears heartbeat, mode and the matching runtime binding
+atomically only if it still owns that generation, including across API replicas.
+Revoked sockets may clean up their own presence but cannot retire a replacement.
+Runtime-session churn does not revoke the durable agent credential. The account
+active check is a scoped read rather than a row lock, avoiding a new lock order
+with account lifecycle operations; a suspension racing that read is rejected by
+the next control unit.
+
+PostgreSQL control transactions set local lock and statement timeouts (1.5s and
+5s); pooled connections retain their normal settings afterwards. A failed inbound
+transaction closes with code 1013 so the runtime can reconnect; replaced or
+revoked connections close with code 4000 to avoid an eviction reconnect loop.
+The engine's pool checkout timeout remains separately configured. Database
+capacity errors during authentication remain operational failures.
+
+Local delivery, reconnect replay and NATS callbacks use persisted account/agent
+command envelopes, revalidating ownership before delivery and again before its
+mark. Producers snapshot delivery identity and release their post-commit read
+transaction before awaiting the guarded sender, so concurrent command requests
+and in-session question notices leave pool capacity for delivery. Release refuses
+pending caller writes instead of committing or discarding them. Replacement can occur between a completed read and socket I/O; that old
+socket cannot subsequently acknowledge or mark the new connection's work.
+Delivery remains at least once: adapters must deduplicate by stable command ID
+before irreversible effects. No database lock is held across the network to
+claim exactly-once execution. Unknown/peer command results are rejected and
+repeated final results do not duplicate activity history. The server owns result
+identity, source and role metadata even when the runtime supplies those keys.
+
+Apply migration `20260912_control_connection` before deploying this code. Old
+replicas do not enforce generation checks, so complete the application rollout
+and reconnect old control sockets before relying on the new fencing guarantee.
+Local registration serializes the database claim and registry handoff; eviction
+close attempts have a one-second deadline so an unresponsive old socket cannot
+hold unrelated handshakes indefinitely.
+
+The disposable PostgreSQL acceptance suite is
+`backend/tests/api/test_control_postgres_acceptance.py`. It uses real sockets and
+a pool of two, an independent lock-holding session, separate managers, and local
+synthetic credentials. Set `PRELOOP_DISABLE_TELEMETRY=true` and `DATABASE_URL` to a
+migrated disposable PostgreSQL database (UTC), then run that file with pytest.
 
 ## Agent Control
 *   **Purpose:** Agent Control gives autonomous agents such as OpenClaw and Hermes a single, audited channel for online presence, operator messages, status updates, interruption, and future voice-originated contact.


### PR DESCRIPTION
Closes #476.

A replaced or revoked control socket could retain authority over presence and
command results. Persist a connection UUID independently of runtime identity
and revalidate it with active credential, account, owner and agent lifecycle
before message writes and delivery read/mark operations. Atomic disconnect only
retires the connection it owns, and conditional command updates plus authoritative
result metadata prevent stale acknowledgements and duplicate activity history.

Control DB work uses short worker-owned sessions and frozen scalar identities;
socket/broker I/O runs after those sessions close. Producers release their
read-only post-create transaction before guarded delivery, avoiding pool
starvation. Local DB deadlines and a one-second eviction-close deadline bound
contention. Cancellation drains an active worker before cleanup.

Validation: the combined latest-main backend integration passed 276 tests using
disposable PostgreSQL, including all 24 real-PG control acceptance cases. The
control review passed 30 acceptance/isolation cases, 2 eviction regressions,
targeted CRUD mypy, and migration upgrade/downgrade/upgrade. Final full Go, focused hook race checks and all changed-file hooks/OpenAPI pass. These selections
overlap and are not a summed total.

Apply migration `20260912_control_connection` after `20260910_operator_notes`
before application deployment. Complete rollout and reconnect old sockets
before relying on fencing; old replicas do not enforce it. Delivery remains
at least once, so adapters must deduplicate command IDs before irreversible
effects. Local PostgreSQL/WebSocket tests do not certify live multi-pod broker
or phone/watch behavior.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Security-hardening of the audited Agent Control channel on a critical path, introducing a DB migration and fencing semantics; well-tested, but local PG/WS suites do not certify live multi-pod broker behavior.
>
> **Overview**
> Persists a connection UUID and revalidates credential/account/owner/agent lifecycle before control writes and delivery read/mark operations, so replaced or revoked sockets cannot retain authority over presence or command results. Adds migration `20260912_control_connection` and broad disposable-PostgreSQL acceptance coverage.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9f903179. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->